### PR TITLE
Add support for finding EVM coin/token addresses

### DIFF
--- a/src/abstraction/EvmCoinFinder.ts
+++ b/src/abstraction/EvmCoinFinder.ts
@@ -1,47 +1,202 @@
-// Import the singleton instance of the Providers class (already registered with all providers)
 import Providers from "./providers"
 import { tokenAddresses } from "./providers/CoinAddresses"
-// ! Use the Providers singleton with the methods of each chain RPC to find tokens
-/**
- * ? For each call, we should probably select a random RPC
- * ? from the Providers singleton and use that one in a for loop
- * ? that breaks when the call is successful.
- * ? This is to prevent any single RPC from being overloaded and
- * ? to be able to fail over to the next one in the list.
- */
+import * as ethers from "ethers"
+import { chainIds } from "./providers/CoinAddresses"
+export type SupportedChain = "ethereum" | "bsc" | "arbitrum" | "optimism"
 
 export default class EvmCoinFinder {
-    constructor() {}
-
-    // TODO Method to find native and wrapped eth across evms (from mainnet to other evms)
-    static async findNativeEth(targetChainIds: number[]) {
-        // TODO
-        // TODO Get the wrapped eth address for the target chain
+    private static isValidAddress(address: string): boolean {
+        return ethers.isAddress(address)
     }
 
-    // TODO Method to find native and wrapped assets across evms (e.g. opt, arb, etc.)
-    static async findNativeAssets(
-        sourceChainId: number,
+    private static async getRandomProvider(chainId: number) {
+        const rpcUrls = Providers.evm[chainId.toString()]
+
+        if (!rpcUrls || rpcUrls.length === 0) {
+            throw new Error(`No providers found for chain ${chainId}`)
+        }
+
+        // Shuffle RPC URLs to try them in random order
+        const shuffledUrls = [...rpcUrls].sort(() => Math.random() - 0.5)
+
+        // Try each RPC until one works
+        for (const rpcUrl of shuffledUrls) {
+            try {
+                // Create ethers provider
+                const provider = new ethers.JsonRpcProvider(rpcUrl)
+                // Test the connection
+                await provider.getNetwork()
+                return provider
+            } catch (error) {
+                console.warn(`Failed to connect to RPC ${rpcUrl}:`, error)
+                continue // Try next RPC
+            }
+        }
+
+        throw new Error(`All RPC providers failed for chain ${chainId}`)
+    }
+
+    static async findNativeEth(
         targetChainIds: number[],
-    ) {
-        // TODO
+    ): Promise<Record<number, { eth: string; weth: string }>> {
+        const result: Record<number, { eth: string; weth: string }> = {}
+
+        for (const chainId of targetChainIds) {
+            // First validate if chainId is supported
+            if (
+                ![
+                    chainIds.eth.mainnet,
+                    chainIds.bsc.mainnet,
+                    chainIds.arbitrum.mainnet,
+                    chainIds.optimism.mainnet,
+                ].includes(chainId)
+            ) {
+                throw new Error(`Invalid chain ID: ${chainId}`)
+            }
+
+            let weth
+            switch (chainId) {
+                case chainIds.eth.mainnet:
+                    weth = tokenAddresses.eth.wrapped.ethereum.mainnet
+                    break
+                case chainIds.bsc.mainnet:
+                    weth = tokenAddresses.eth.wrapped.bsc.mainnet
+                    break
+                case chainIds.arbitrum.mainnet:
+                    weth = tokenAddresses.eth.wrapped.arbitrum.mainnet
+                    break
+                case chainIds.optimism.mainnet:
+                    weth = tokenAddresses.eth.wrapped.optimism.mainnet
+                    break
+            }
+
+            if (weth) {
+                result[chainId] = {
+                    eth: tokenAddresses.eth.mainnet, // native ETH
+                    weth: weth!, // wrapped ETH
+                }
+            }
+        }
+        return result
     }
 
-    // TODO Method to find token pairs on evms (from an evm to other(s) evm(s))
+    static async findNativeAssets(
+        targetChainIds: number[],
+    ): Promise<Record<number, { native: string; wrapped?: string }>> {
+        const result: Record<number, { native: string; wrapped?: string }> = {}
+
+        for (const chainId of targetChainIds) {
+            let wrapped
+            switch (chainId) {
+                case chainIds.eth.mainnet:
+                    wrapped = tokenAddresses.eth.wrapped.ethereum.mainnet
+                    break
+                case chainIds.bsc.mainnet:
+                    wrapped = tokenAddresses.eth.wrapped.bsc.mainnet
+                    break
+                case chainIds.arbitrum.mainnet:
+                    wrapped = tokenAddresses.eth.wrapped.arbitrum.mainnet
+                    break
+                case chainIds.optimism.mainnet:
+                    wrapped = tokenAddresses.eth.wrapped.optimism.mainnet
+                    break
+            }
+
+            // Always include native, wrapped is optional
+            result[chainId] = {
+                native: tokenAddresses.eth.mainnet,
+                ...(wrapped && { wrapped }), // Only include wrapped if it exists
+            }
+        }
+        return result
+    }
+
     static async findTokenPairs(
         tokenAddress: string,
         sourceChainId: number,
         targetChainIds: number[],
-    ) {
-        // TODO
-        // TODO Validate the base token address for the source chain
-        // TODO Get the wrapped token address for the target chain if known or return false
+    ): Promise<Record<number, string | false>> {
+        if (!this.isValidAddress(tokenAddress)) {
+            throw new Error("Invalid token address")
+        }
+
+        const result: Record<number, string | false> = {}
+
+        // Verify token exists on source chain
+        const provider = await this.getRandomProvider(sourceChainId)
+        const code = await provider.getCode(tokenAddress)
+        if (code === "0x") {
+            throw new Error("Token contract not found on source chain")
+        }
+
+        // Find corresponding tokens on target chains
+        for (const chainId of targetChainIds) {
+            // If source and target chains are the same, return the same address
+            if (chainId === sourceChainId) {
+                result[chainId] = tokenAddress
+                continue
+            }
+
+            let mappedToken: string | false = false
+
+            // Check if it's USDC
+            if (tokenAddress === tokenAddresses.usdc.ethereum.mainnet) {
+                if (chainId === chainIds.bsc.mainnet) {
+                    mappedToken = tokenAddresses.usdc.bsc.mainnet
+                } else if (chainId === chainIds.arbitrum.mainnet) {
+                    mappedToken = tokenAddresses.usdc.arbitrum.mainnet
+                } else if (chainId === chainIds.optimism.mainnet) {
+                    mappedToken = tokenAddresses.usdc.optimism.mainnet
+                }
+            }
+            // Check if it's USDT
+            else if (tokenAddress === tokenAddresses.usdt.ethereum.mainnet) {
+                if (chainId === chainIds.bsc.mainnet) {
+                    mappedToken = tokenAddresses.usdt.bsc.mainnet
+                } else if (chainId === chainIds.arbitrum.mainnet) {
+                    mappedToken = tokenAddresses.usdt.arbitrum.mainnet
+                } else if (chainId === chainIds.optimism.mainnet) {
+                    mappedToken = tokenAddresses.usdt.optimism.mainnet
+                }
+            }
+
+            result[chainId] = mappedToken
+        }
+
+        return result
     }
 
-    static getNativeforSupportedChain(chain: string, targetChainId: number) {
-        // ! Typize this for supported chains
-        // TODO validate the chain
-        // TODO get the target chain id
-        // TODO return the native address for the target chain
+    static getNativeForSupportedChain(
+        chain: SupportedChain,
+        targetChainId: number,
+    ): string {
+        // Validate chain matches targetChainId
+        switch (chain) {
+            case "ethereum":
+                if (targetChainId !== chainIds.eth.mainnet) {
+                    throw new Error("Chain ID doesn't match ethereum")
+                }
+                break
+            case "bsc":
+                if (targetChainId !== chainIds.bsc.mainnet) {
+                    throw new Error("Chain ID doesn't match bsc")
+                }
+                break
+            case "arbitrum":
+                if (targetChainId !== chainIds.arbitrum.mainnet) {
+                    throw new Error("Chain ID doesn't match arbitrum")
+                }
+                break
+            case "optimism":
+                if (targetChainId !== chainIds.optimism.mainnet) {
+                    throw new Error("Chain ID doesn't match optimism")
+                }
+                break
+            default:
+                throw new Error(`Unsupported chain: ${chain}`)
+        }
+
+        // Return native address (0x0)
+        return tokenAddresses.eth.mainnet
     }
 }

--- a/src/abstraction/providers/AbstractionProviders.ts
+++ b/src/abstraction/providers/AbstractionProviders.ts
@@ -1,7 +1,7 @@
 /** NOTE
  *  This is the singleton class that contains the list of providers for the abstraction layer.
  *  It also contains the methods to register new providers.
- * 
+ *
  *  INFO for developers:
  *  - The providers can be registered by adding a new provider registration file in the ./index.ts file.
  *  - The provider registration files use the registerEVM and registerChainProviders methods to register the providers.
@@ -9,7 +9,7 @@
  *  - The registerChainProviders method takes a chain type, a network, and an array of RPC URLs as arguments.
  *  - For an example of how to register a new provider, see the ./ankr.ts file.
  *  - The Providers.ts file export the singleton instance of the AbstractionProviders class, already registered with all providers.
- * 
+ *
  *  NOTE: The Providers object should only used internally (e.g. in EvmCoinFinder.ts and CoinFinder.ts).
  * This is due to the fact that it is initialized with all the providers at runtime.
  */
@@ -38,7 +38,6 @@ class _AbstractionProviders {
             testnet: [],
         }
     }
-
     // Singleton
     static getInstance() {
         if (!_AbstractionProviders._instance) {

--- a/src/abstraction/providers/CoinAddresses.ts
+++ b/src/abstraction/providers/CoinAddresses.ts
@@ -1,29 +1,83 @@
-// ! This is an absolute test and could be changed anytime
+export const chainIds = {
+    eth: {
+        mainnet: 1,
+        ropsten: 3,
+        rinkeby: 4,
+        goerli: 5,
+        sepolia: 11155111,
+        holesky: 17000,
+    },
+    bsc: {
+        mainnet: 56,
+        testnet: 97,
+    },
+    arbitrum: {
+        mainnet: 42161,
+        testnet: 421614, //Sepolia
+    },
+    optimism: {
+        mainnet: 10,
+        testnet: 11155420, //Sepolia
+    },
+}
 
 export const tokenAddresses = {
-    // ANCHOR Ethereum
     eth: {
         mainnet: "0x0000000000000000000000000000000000000000",
         sepolia: "0x0000000000000000000000000000000000000000",
-        holesky: "0x0000000000000000000000000000000000000000",
-        wrapped: {
-            polygon: {
-                mainnet: "0x0000000000000000000000000000000000000000",
-            }
-        }
-    },
-    // ANCHOR Bitcoin
-    btc: {
-        mainnet: "0x0000000000000000000000000000000000000000",
         wrapped: {
             ethereum: {
-                mainnet: "0x0000000000000000000000000000000000000000",
-                sepolia: "0x0000000000000000000000000000000000000000",
-                holesky: "0x0000000000000000000000000000000000000000",
+                mainnet: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                testnet: "0xfff9976782d46cc05630d1f6ebab18b2324d6b14", // Sepolia
             },
-            polygon: {
-                mainnet: "0x0000000000000000000000000000000000000000",
-            }
-        }
+            bsc: {
+                mainnet: "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
+                testnet: "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd", // BSC Testnet
+            },
+            arbitrum: {
+                mainnet: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+                testnet: "0x980B62Da83eFf3D4576C647993b0c1D7faf17c73", // Sepolia
+            },
+            optimism: {
+                mainnet: "0x4200000000000000000000000000000000000006",
+                testnet: "0x4200000000000000000000000000000000000006", // Sepolia
+            },
+        },
+    },
+    usdc: {
+        ethereum: {
+            mainnet: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            testnet: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238", // Sepolia
+        },
+        bsc: {
+            mainnet: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+            testnet: "0x64544969ed7EBf5f083679233325356EbE738930", // BSC Testnet
+        },
+        arbitrum: {
+            mainnet: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+            testnet: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d", // Sepolia
+        },
+        optimism: {
+            mainnet: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+            testnet: "0x0000000000000000000000000000000000000000", //TODO: Cannot verify this address on Sepolia
+        },
+    },
+    usdt: {
+        ethereum: {
+            mainnet: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+            testnet: "0x7169D38820dfd117C3FA1f22a697dBA58d90BA06", // Sepolia
+        },
+        bsc: {
+            mainnet: "0x55d398326f99059fF775485246999027B3197955",
+            testnet: "0x337610d27c682E347C9cD60BD4b3b107C9d34dDd", // BSC Testnet
+        },
+        arbitrum: {
+            mainnet: "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+            testnet: "0x0000000000000000000000000000000000000000", //TODO: Cannot verify this address on Sepolia
+        },
+        optimism: {
+            mainnet: "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+            testnet: "0x0000000000000000000000000000000000000000", // TODO: Cannot verify this address on Sepolia
+        },
     },
 }

--- a/src/abstraction/providers/Providers.ts
+++ b/src/abstraction/providers/Providers.ts
@@ -1,11 +1,14 @@
 import AbstractionProvidersInstance from "./AbstractionProviders"
-import registerAnkrProviders from "./ankr"
+import registerEthereumProviders from "./ethereum"
+import registerBscProviders from "./bsc"
+import registerArbitrumProviders from "./arbitrum"
+import registerOptimismProviders from "./optimism"
 
-// Register the providers
-registerAnkrProviders()
+// Register all blockchain providers
+registerEthereumProviders()
+registerBscProviders()
+registerArbitrumProviders()
+registerOptimismProviders()
 
-// Exporting the singleton instance of the Providers class, already registered with all providers
-// Being a const, it should maintain the snapshot of the instance at the time of the import
 const Providers = AbstractionProvidersInstance()
-
 export default Providers

--- a/src/abstraction/providers/arbitrum.ts
+++ b/src/abstraction/providers/arbitrum.ts
@@ -1,0 +1,19 @@
+import AbstractionProvidersInstance from "./AbstractionProviders"
+
+export default function registerArbitrumProviders() {
+    //TODO: Change to private third-party service providers in production for better performance and reliability
+
+    // Mainnet
+    AbstractionProvidersInstance().registerEVM("arbitrum", [
+        "https://arb1.arbitrum.io/rpc",
+        "https://rpc.ankr.com/arbitrum",
+        "https://arbitrum.drpc.org",
+        "https://arbitrum.meowrpc.com",
+        "https://arb-pokt.nodies.app",
+    ])
+
+    // Testnet (Sepolia)
+    AbstractionProvidersInstance().registerEVM("arbitrum_testnet", [
+        "https://sepolia-rollup.arbitrum.io/rpc",
+    ])
+}

--- a/src/abstraction/providers/bsc.ts
+++ b/src/abstraction/providers/bsc.ts
@@ -1,0 +1,23 @@
+import AbstractionProvidersInstance from "./AbstractionProviders"
+
+export default function registerBscProviders() {
+    //TODO: Change to private third-party service providers in production for better performance and reliability
+
+    // Mainnet
+    AbstractionProvidersInstance().registerEVM("bsc", [
+        "https://bsc-dataseed.bnbchain.org",
+        "https://bsc-dataseed.nariox.org",
+        "https://bsc-dataseed.defibit.io",
+        "https://bsc-dataseed.ninicoin.io",
+        "https://bsc.nodereal.io",
+        "https://bsc-dataseed-public.bnbchain.org",
+        "https://bnb.rpc.subquery.network/public",
+    ])
+
+    // Testnet
+    AbstractionProvidersInstance().registerEVM("bsc_testnet", [
+        "https://bsc-testnet-dataseed.bnbchain.org",
+        "https://bsc-testnet.bnbchain.org",
+        "https://bsc-prebsc-dataseed.bnbchain.org",
+    ])
+}

--- a/src/abstraction/providers/ethereum.ts
+++ b/src/abstraction/providers/ethereum.ts
@@ -1,0 +1,34 @@
+import AbstractionProvidersInstance from "./AbstractionProviders"
+import { chainIds } from "./CoinAddresses"
+
+export default function registerEthereumProviders() {
+    //TODO: Change to private third-party service providers in production for better performance and reliability
+
+    // Mainnet
+    AbstractionProvidersInstance().registerEVM(
+        chainIds.eth.mainnet.toString(),
+        [
+            "https://rpc.ankr.com/eth",
+            "https://eth.drpc.org",
+            "https://eth.llamarpc.com",
+            "https://ethereum.publicnode.com",
+            "https://rpc.flashbots.net",
+            "https://rpc.payload.de",
+            "https://singapore.rpc.blxrbdn.com",
+            "https://uk.rpc.blxrbdn.com",
+            "https://virginia.rpc.blxrbdn.com",
+        ],
+    )
+
+    // Testnet (Sepolia)
+    AbstractionProvidersInstance().registerEVM(
+        chainIds.eth.sepolia.toString(),
+        [
+            "https://rpc.ankr.com/eth_sepolia",
+            "https://eth-sepolia.public.blastapi.io",
+            "https://endpoints.omniatech.io/v1/eth/sepolia/public",
+            "https://1rpc.io/sepolia",
+            "https://ethereum-sepolia.blockpi.network/v1/rpc/private",
+        ],
+    )
+}

--- a/src/abstraction/providers/optimism.ts
+++ b/src/abstraction/providers/optimism.ts
@@ -1,0 +1,23 @@
+import AbstractionProvidersInstance from "./AbstractionProviders"
+
+export default function registerOptimismProviders() {
+    //TODO: Change to private third-party service providers in production for better performance and reliability
+
+    // Mainnet
+    AbstractionProvidersInstance().registerEVM("optimism", [
+        "https://mainnet.optimism.io",
+        "https://rpc.ankr.com/optimism",
+        "https://endpoints.omniatech.io/v1/op/mainnet/public",
+        "https://optimism-rpc.publicnode.com",
+        "https://optimism.drpc.org",
+        "https://optimism.meowrpc.com",
+    ])
+
+    // Testnet (Sepolia)
+    AbstractionProvidersInstance().registerEVM("optimism-sepolia", [
+        "https://api.zan.top/opt-sepolia",
+        "https://optimism-sepolia.gateway.tenderly.co",
+        "https://endpoints.omniatech.io/v1/op/sepolia/public",
+        "https://optimism-sepolia.drpc.org",
+    ])
+}

--- a/src/tests/multichain/evmCoinFinder.spec.ts
+++ b/src/tests/multichain/evmCoinFinder.spec.ts
@@ -1,0 +1,103 @@
+import EvmCoinFinder from "../../abstraction/EvmCoinFinder"
+import { ethers } from "ethers"
+// Mock the JsonRpcProvider
+jest.mock("ethers", () => ({
+    ...jest.requireActual("ethers"),
+    JsonRpcProvider: jest.fn().mockImplementation(() => ({
+        getCode: jest.fn().mockResolvedValue("0x123"),
+        getNetwork: jest.fn().mockResolvedValue({ chainId: 1 }),
+    })),
+    isAddress: jest.requireActual("ethers").isAddress,
+}))
+
+describe("EVM COIN FINDER TESTS", () => {
+    const ETHEREUM_CHAIN_ID = 1
+    const BSC_CHAIN_ID = 56
+    const ARBITRUM_CHAIN_ID = 42161
+    const OPTIMISM_CHAIN_ID = 10
+    const USDC_ETH = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+    test("findNativeEth returns WETH addresses across chains", async () => {
+        const result = await EvmCoinFinder.findNativeEth([
+            ETHEREUM_CHAIN_ID,
+            BSC_CHAIN_ID,
+            ARBITRUM_CHAIN_ID,
+            OPTIMISM_CHAIN_ID,
+        ])
+        expect(result[ETHEREUM_CHAIN_ID]).toBeDefined()
+        expect(result[BSC_CHAIN_ID]).toBeDefined()
+        expect(result[ARBITRUM_CHAIN_ID]).toBeDefined()
+        expect(result[OPTIMISM_CHAIN_ID]).toBeDefined()
+    })
+
+    test("findNativeAssets returns native and wrapped assets across chains", async () => {
+        const result = await EvmCoinFinder.findNativeAssets([
+            BSC_CHAIN_ID,
+            ARBITRUM_CHAIN_ID,
+            OPTIMISM_CHAIN_ID,
+        ])
+
+        // Native should always exist
+        expect(result[BSC_CHAIN_ID].native).toBeDefined()
+        expect(result[ARBITRUM_CHAIN_ID].native).toBeDefined()
+        expect(result[OPTIMISM_CHAIN_ID].native).toBeDefined()
+
+        // Wrapped might exist
+        if (result[BSC_CHAIN_ID].wrapped) {
+            expect(ethers.isAddress(result[BSC_CHAIN_ID].wrapped)).toBe(true)
+        }
+        if (result[ARBITRUM_CHAIN_ID].wrapped) {
+            expect(ethers.isAddress(result[ARBITRUM_CHAIN_ID].wrapped)).toBe(
+                true,
+            )
+        }
+        if (result[OPTIMISM_CHAIN_ID].wrapped) {
+            expect(ethers.isAddress(result[OPTIMISM_CHAIN_ID].wrapped)).toBe(
+                true,
+            )
+        }
+    })
+
+    test("findTokenPairs returns corresponding tokens across chains", async () => {
+        const result = await EvmCoinFinder.findTokenPairs(
+            USDC_ETH,
+            ETHEREUM_CHAIN_ID,
+            [BSC_CHAIN_ID, ARBITRUM_CHAIN_ID, OPTIMISM_CHAIN_ID],
+        )
+        expect(result[BSC_CHAIN_ID]).toBeDefined()
+        expect(result[ARBITRUM_CHAIN_ID]).toBeDefined()
+        expect(result[OPTIMISM_CHAIN_ID]).toBeDefined()
+    })
+
+    test("findTokenPairs rejects invalid addresses", async () => {
+        await expect(
+            EvmCoinFinder.findTokenPairs("invalid-address", ETHEREUM_CHAIN_ID, [
+                BSC_CHAIN_ID,
+            ]),
+        ).rejects.toThrow("Invalid token address")
+    })
+
+    test("getNativeForSupportedChain returns native addresses for all supported chains", () => {
+        expect(
+            EvmCoinFinder.getNativeForSupportedChain(
+                "ethereum",
+                ETHEREUM_CHAIN_ID,
+            ),
+        ).toBeDefined()
+        expect(
+            EvmCoinFinder.getNativeForSupportedChain("bsc", BSC_CHAIN_ID),
+        ).toBeDefined()
+        expect(
+            EvmCoinFinder.getNativeForSupportedChain(
+                "arbitrum",
+                ARBITRUM_CHAIN_ID,
+            ),
+        ).toBeDefined()
+        expect(
+            EvmCoinFinder.getNativeForSupportedChain(
+                "optimism",
+                OPTIMISM_CHAIN_ID,
+            ),
+        ).toBeDefined()
+    })
+})


### PR DESCRIPTION
This PR adds support for finding eth(weth), usdc and usdt addresses for following chains:

- Eth mainnet and testnet (Sepolia)
- Bsc mainnet and testnet (Sepolia)
- Arbitrum mainnet and testnet (Sepolia)
- Optimism mainnet and testnet (Sepolia)
