### PR TITLE
add headers to options object and make it optional

### DIFF
--- a/src/types/web2/index.ts
+++ b/src/types/web2/index.ts
@@ -41,7 +41,7 @@ export interface IRawWeb2Request {
     requestedParameters: [] | null
     method: EnumWeb2Methods
     url: string
-    headers: OutgoingHttpHeaders
+    headers?: OutgoingHttpHeaders
     minAttestations: number
     stage: {
         origin: {
@@ -84,6 +84,7 @@ export interface IAuthorizationConfig {
 }
 
 export interface IWeb2RequestOptions {
+    headers?: OutgoingHttpHeaders
     payload?: unknown
     authorization?: string
 }
@@ -91,7 +92,6 @@ export interface IWeb2RequestOptions {
 export interface IStartProxyParams {
     url: string
     method: EnumWeb2Methods
-    headers: OutgoingHttpHeaders
     options?: IWeb2RequestOptions
 }
 

--- a/src/websdk/Web2Calls.ts
+++ b/src/websdk/Web2Calls.ts
@@ -28,24 +28,25 @@ export class Web2Proxy {
     async startProxy({
         url,
         method,
-        headers,
-        options = {},
+        options = {
+            headers: {},
+            payload: {},
+            authorization: "",
+        },
     }: IStartProxyParams): Promise<IAttestationWithResponse> {
-        const { payload = {}, authorization = "" } = options
-
         web2Request.raw = {
             ...web2Request.raw,
             action: EnumWeb2Actions.START_PROXY,
             method,
             url,
-            headers,
+            headers: options.headers,
         }
 
         return await demos.call("web2ProxyRequest", {
             web2Request,
             sessionId: this._sessionId,
-            payload,
-            authorization,
+            payload: options.payload,
+            authorization: options.authorization,
         })
     }
 

--- a/src/websdk/demos.ts
+++ b/src/websdk/demos.ts
@@ -18,8 +18,7 @@ import {
 import { prepareXMPayload } from "./XMTransactions"
 
 import { Cryptography } from "@/encryption/Cryptography"
-import { EnumWeb2Methods } from "@/types"
-import type { IWeb2Result, Transaction, ValidityData, XMScript } from "@/types"
+import type { Transaction, XMScript } from "@/types"
 import {
     RPCRequest,
     RPCResponse,

--- a/src/websdk/examples/tryWeb2.ts
+++ b/src/websdk/examples/tryWeb2.ts
@@ -22,7 +22,6 @@ async function tryWeb2Proxy() {
         const response = await dahr.startProxy({
             url: "https://icanhazip.com",
             method: EnumWeb2Methods.GET,
-            headers: { Accept: "application/json" },
         })
         console.log("Response:", response)
 

--- a/src/websdk/utils/skeletons.ts
+++ b/src/websdk/utils/skeletons.ts
@@ -49,7 +49,7 @@ const web2_request: IWeb2Request = {
         requestedParameters: null, // Means all
         method: EnumWeb2Methods.GET,
         url: "",
-        headers: null,
+        headers: {},
         minAttestations: 2,
         // Handling the various stages of an IWeb2Request
         stage: {


### PR DESCRIPTION
Added the headers to the options object as it should be optional, and to simplify the `dahr.startProxy` call.