### PR TITLE
Update web2calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "test:demoswork": "rm -rf build && jest --testMatch '**/tests/**/demoswork*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose",
         "test:identities": "rm -rf build && jest --testMatch '**/tests/**/identities*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose",
         "setup:pre-push": "cp .github/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push && echo \"Pre-push hook installed\"",
-        "test:native": "rm -rf build && jest --testMatch '**/tests/native*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose"
+        "test:native": "rm -rf build && jest --testMatch '**/tests/native*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose",
+        "test:web2": "rm -rf build && jest --testMatch '**/tests/web2*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose"
     },
     "dependencies": {
         "@cosmjs/proto-signing": "^0.32.3",

--- a/src/tests/web2.spec.ts
+++ b/src/tests/web2.spec.ts
@@ -1,0 +1,28 @@
+import { EnumWeb2Methods } from "@/types"
+import { Demos } from "@/websdk"
+import { DemosWebAuth, prepareXMPayload } from "@/websdk"
+
+describe("Web2", () => {
+    test("Simple Web2 Transaction", async () => {
+        const identity = DemosWebAuth.getInstance()
+        await identity.create()
+
+        const rpc = "http://localhost:53550"
+        const demos = new Demos()
+        await demos.connect(rpc)
+        await demos.connectWallet(identity.keypair.privateKey as any)
+
+        const proxy = await demos.web2.createDahr(demos)
+        const res = await proxy.startProxy({
+            method: EnumWeb2Methods.GET,
+            url: "https://node2.demos.sh/info",
+        })
+
+        console.log(res)
+
+        const res2 = await proxy.stopProxy()
+        console.log(res2)
+
+        demos.disconnect()
+    })
+})


### PR DESCRIPTION
Take a `demos` instance in `createDahr` and pass it down when creating the `Web2Proxy`.

Sample usage following the change: `src/tests/web2.spec.ts`