### PR TITLE
Refactor web2 test to streamline proxy operations

### DIFF
--- a/src/tests/web2.spec.ts
+++ b/src/tests/web2.spec.ts
@@ -16,22 +16,21 @@ describe("Web2", () => {
 
         await demos.connectWallet(identity.keypair.privateKey as Uint8Array)
 
-        for (let i = 0; i < 100; i++) {
-            // 2. Create a proxy
-            const proxy = await demos.web2.createDahr()
+        // 2. Create a proxy
+        const proxy = await demos.web2.createDahr()
 
-            // 3. Start the proxy and send a request
-            const res = await proxy.startProxy({
-                method: EnumWeb2Methods.GET,
-                url: "https://google.com",
-            })
+        // 3. Start the proxy and send a request
+        const res = await proxy.startProxy({
+            method: EnumWeb2Methods.GET,
+            url: "https://google.com",
+        })
 
-            console.log(res)
-            // 4. Cleanup
-            const res2 = await proxy.stopProxy()
-            console.log(res2)
-        }
+        console.log("Response:", res)
 
+        // 4. Cleanup
+        await proxy.stopProxy()
+
+        // 5. Disconnect from the demos instance
         demos.disconnect()
     })
 })


### PR DESCRIPTION
- Removed the loop for creating multiple proxies, simplifying the test to create and manage a single proxy instance.
- Ensured proper cleanup by stopping the proxy and disconnecting from the demos instance.