### PR TITLE
Remove redundant web2 attestations code

### DIFF
--- a/src/demoswork/workstep.ts
+++ b/src/demoswork/workstep.ts
@@ -82,7 +82,6 @@ export function prepareWeb2Step({
     url = "https://icanhazip.com",
     parameters = [],
     headers = null,
-    minAttestations = 2,
 }) {
     // Generating an empty request and filling it
     const web2_payload: IWeb2Request = structuredClone(skeletons.web2_request)
@@ -91,9 +90,7 @@ export function prepareWeb2Step({
     web2_payload.raw.url = url
     web2_payload.raw.parameters = parameters
     web2_payload.raw.headers = headers
-    web2_payload.raw.minAttestations = minAttestations
     // Ensuring content is a known property
-    web2_payload.attestations = new Map()
     web2_payload.hash = ""
     web2_payload.signature = {
         type: "ed25519",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ export {
     IdentityTransaction,
     InstantMessagingTransaction,
     NativeBridgeTransaction,
-    SpecificTransaction
+    SpecificTransaction,
 } from "./blockchain/TransactionSubtypes"
 
 export { L2PSEncryptedPayload } from "@/l2ps"
@@ -71,7 +71,6 @@ export { IPeerConfig, IPeer } from "./peers/Peer"
 export {
     IParam,
     IRawWeb2Request,
-    IWeb2Attestation,
     IWeb2Request,
     IWeb2Payload,
     IWeb2Result,
@@ -80,12 +79,11 @@ export {
     IAuthorizationConfig,
     IWeb2RequestOptions,
     IStartProxyParams,
-    IAttestationWithResponse,
     IDAHRStartProxyParams,
     EnumWeb2Methods,
     EnumWeb2Actions,
     TweetSimplified,
-    Tweet
+    Tweet,
 } from "./web2"
 
 export { IOperation, ITask, XMScript } from "./xm"

--- a/src/types/web2/index.ts
+++ b/src/types/web2/index.ts
@@ -17,7 +17,6 @@ export interface IWeb2Result {
 export interface IWeb2Request {
     raw: IRawWeb2Request
     result: any
-    attestations: {}
     hash: string
     signature?: {
         type: SigningAlgorithm
@@ -54,29 +53,12 @@ export interface IRawWeb2Request {
     method: EnumWeb2Methods
     url: string
     headers?: OutgoingHttpHeaders
-    minAttestations: number
     stage: {
         origin: {
             identity: forge.pki.ed25519.BinaryBuffer
             connection_url: string
         }
-        hop_number: number
     }
-}
-
-export interface IWeb2Attestation {
-    hash: string
-    timestamp: number
-    identity: forge.pki.PublicKey
-    signature: {
-        type: SigningAlgorithm
-        data: string
-    }
-    valid: boolean
-}
-
-export interface IAttestationWithResponse extends IWeb2Attestation {
-    web2Response: IWeb2Result
 }
 
 export interface ISendHTTPRequestParams {

--- a/src/websdk/Web2Calls.ts
+++ b/src/websdk/Web2Calls.ts
@@ -1,13 +1,13 @@
 import { EnumWeb2Actions } from "@/types"
-import type {
-    IAttestationWithResponse,
-    IStartProxyParams,
-    Transaction,
-    IWeb2Payload,
-} from "@/types"
 import { web2_request } from "./utils/skeletons"
 import { DemosTransactions } from "./DemosTransactions"
 import { Demos } from "./demosclass"
+import type {
+    IStartProxyParams,
+    Transaction,
+    IWeb2Payload,
+    IWeb2Result,
+} from "@/types"
 
 const web2Request = { ...web2_request }
 
@@ -41,7 +41,7 @@ export class Web2Proxy {
             payload: {},
             authorization: "",
         },
-    }: IStartProxyParams): Promise<IAttestationWithResponse> {
+    }: IStartProxyParams): Promise<IWeb2Result> {
         web2Request.raw = {
             ...web2Request.raw,
             action: EnumWeb2Actions.START_PROXY,
@@ -123,6 +123,7 @@ export const web2Calls = {
         const signedWeb2Tx = await demos.sign(web2Tx)
         const validityData = await demos.confirm(signedWeb2Tx)
         await demos.broadcast(validityData)
+
         return new Web2Proxy(sessionId, demos)
     },
 }

--- a/src/websdk/utils/skeletons.ts
+++ b/src/websdk/utils/skeletons.ts
@@ -49,7 +49,6 @@ const web2_request: IWeb2Request = {
         method: EnumWeb2Methods.GET,
         url: "",
         headers: {},
-        minAttestations: 2,
         // Handling the various stages of an IWeb2Request
         stage: {
             // The one that will handle the response too
@@ -57,12 +56,9 @@ const web2_request: IWeb2Request = {
                 identity: "",
                 connection_url: "",
             },
-            // Starting from 0, each attestation it is increased
-            hop_number: 0,
         },
     },
     result: null,
-    attestations: {},
     hash: "",
     signature: {
         type: "ed25519",


### PR DESCRIPTION
Refactor IWeb2Request structure by removing minAttestations and attestation properties. Update related types and interfaces for consistency across the web2 module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified web2 request data structures by removing unused properties related to attestations and hop tracking.
  * Updated method signatures and interfaces to reflect these changes for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->