### PR TITLE
fix: implement gas fee calculation based on GCR edits in Demos class

### DIFF
--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -334,6 +334,11 @@ export class Demos {
 
         raw_tx.content.gcr_edits = await GCRGeneration.generate(raw_tx)
 
+        // We derive the network fee from GCR edits (sum of sender balance removals minus `amount`).
+        // This is a pragmatic interim approach; ideally the node should authoritatively return fees
+        // to avoid drift between SDK and node logic.
+        raw_tx = this._calculateAndApplyGasFee(raw_tx)
+
         raw_tx.hash = Hashing.sha256(JSON.stringify(raw_tx.content))
         const signature = await this.crypto.sign(
             this.algorithm,
@@ -420,6 +425,58 @@ export class Demos {
         })
 
         return verified
+    }
+
+    /**
+     * @private
+     * Calculates and applies the gas fee for a transaction (SDK-level fallback).
+     * NOTE: We infer the fee by analyzing the generated GCR (Gas Consumption Record) edits:
+     * - Sum all "balance" edits with operation "remove" for the sender
+     * - Subtract the declared transaction `amount`
+     * The remainder is treated as the network fee. If a fee already exists on the tx, we only raise
+     * `network_fee` if the newly inferred fee is higher (prevents double-charging on re-sign).
+     * This is an interim approach; the preferred design is for the node to return fees explicitly.
+     *
+     * @param raw_tx - The transaction for which to calculate the fee.
+     * @returns The updated transaction with the fee applied.
+     */
+    private _calculateAndApplyGasFee(raw_tx: Transaction): Transaction {
+        if (!raw_tx.content.gcr_edits || !Array.isArray(raw_tx.content.gcr_edits)) {
+            throw new Error("Failed to generate GCR edits or GCR edits are in an invalid format.")
+        }
+
+        // INFO: The gas fee is calculated by summing up all "remove" balance edits for the sender's account
+        // and then subtracting the actual transaction amount. This gives the value of the fee.
+        const totalRemoved = raw_tx.content.gcr_edits
+            .filter(
+                (edit: any) =>
+                    edit.type === "balance" &&
+                    edit.operation === "remove" &&
+                    edit.account === raw_tx.content.from_ed25519_address,
+            )
+            .reduce((acc: number, edit: any) => acc + edit.amount, 0)
+
+        const calculatedFee = totalRemoved - (raw_tx.content.amount || 0)
+
+        if (calculatedFee < 0) {
+            throw new Error("Calculated gas fee is negative, which is not allowed.")
+        }
+
+        // INFO: This logic handles both initial fee creation and accumulation for re-signed transactions.
+        // To avoid fee accumulation, a new transaction object should be created for each signing.
+        if (!raw_tx.content.transaction_fee) {
+            raw_tx.content.transaction_fee = {
+                network_fee: calculatedFee,
+                rpc_fee: 0,
+                additional_fee: 0,
+            }
+        } else {
+            const existingFee = raw_tx.content.transaction_fee.network_fee || 0
+            if (calculatedFee > existingFee) {
+                raw_tx.content.transaction_fee.network_fee = calculatedFee
+            }
+        }
+        return raw_tx
     }
 
     // L2PS calls are defined here


### PR DESCRIPTION
### **User description**
Description:
- Added logic to calculate GCR edits and apply fees to transaction Fee object in case if it not enough.

Example:
- GCR show that we lose 2 tokens (1 is send amount)
- Fee object is show total 0 fees
- We adding +1 to network fee.

- In case if fee object shows 1+ Fees we skip this because in client side user will see how much will spend.

-----------------------

In the future, when the fee calculation is fully implemented, we can simply remove this calculations.
___

### **PR Type**
Bug fix


___

### **Description**
- Implement gas fee calculation from GCR edits

- Add fallback logic for network fee derivation

- Prevent fee accumulation on transaction re-signing

- Handle missing or invalid GCR edits gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Transaction Creation"] --> B["GCR Generation"]
  B --> C["Calculate Gas Fee"]
  C --> D["Apply Network Fee"]
  D --> E["Transaction Hashing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>demosclass.ts</strong><dd><code>Add gas fee calculation from GCR edits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/websdk/demosclass.ts

<ul><li>Added <code>_calculateAndApplyGasFee</code> private method for fee calculation<br> <li> Integrated gas fee calculation after GCR generation<br> <li> Implemented logic to derive fees from balance removal edits<br> <li> Added error handling for invalid GCR edits and negative fees</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/sdks/pull/46/files#diff-215f207f079e71a4ac98c14e5960ff4b47d16f9815593a2c2889d7d0fe3480c2">+57/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically derives and applies network fees during the signing flow to produce more accurate transaction totals.

* **Bug Fixes**
  * Avoids applying duplicate fees when a transaction is re-signed.

* **Improvements**
  * Fee derivation is non-blocking and failures are logged so signing can continue; acts as an interim fallback when fee info is unavailable from the node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->