### PR TITLE
Canonical JSON payloads + surface requestHash in results/payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "test:referrals": "rm -rf build && jest --testMatch '**/tests/**/referrals.spec*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose",
         "test:evm": "rm -rf build && jest --testMatch '**/tests/**/evm.spec*.ts' --testPathIgnorePatterns **/tests/**/chainProvider* **/tests/utils/* **/tests/**/template*  --verbose",
         "test:aptos": "node --require ts-node/register --require tsconfig-paths/register --test src/tests/multichain/aptos.node.spec.ts",
-        "test:aptos:only": "node --require ts-node/register --require tsconfig-paths/register --test --test-only src/tests/multichain/aptos.node.spec.ts"
+        "test:aptos:only": "node --require ts-node/register --require tsconfig-paths/register --test --test-only src/tests/multichain/aptos.node.spec.ts",
+        "test:canonical": "jest --testPathPattern=utils.test.ts --verbose"
     },
     "dependencies": {
         "@aptos-labs/ts-sdk": "^1.28.0",

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,21 +1,281 @@
-import { getSampleTranfers, verifyNumberOrder } from './utils';
+import { getSampleTranfers, verifyNumberOrder } from "./utils"
+import {
+    canonicalJSONStringify,
+    validatePureJson,
+    looksLikeJsonString,
+} from "../websdk/utils/canonicalJson"
 
-describe('TEST UTILS TESTS', () => {
-	test('getSampleTranfers', () => {
-		const address = '0xSomething';
-		const length = 3;
+describe("TEST UTILS TESTS", () => {
+    test("getSampleTranfers", () => {
+        const address = "0xSomething"
+        const length = 3
 
-		const transfers = getSampleTranfers(address, 1, length);
+        const transfers = getSampleTranfers(address, 1, length)
 
-		expect(transfers.length).toEqual(length);
-		expect(transfers[0].address).toEqual(address);
-	});
+        expect(transfers.length).toEqual(length)
+        expect(transfers[0].address).toEqual(address)
+    })
 
-	test('verifyNumbersOrder', () => {
-		// INFO: Transfers' amounts are sorted in ascending order
-		const sorted_items = getSampleTranfers('0xSomething', 5);
+    test("verifyNumbersOrder", () => {
+        // INFO: Transfers' amounts are sorted in ascending order
+        const sorted_items = getSampleTranfers("0xSomething", 5)
 
-		expect(verifyNumberOrder(sorted_items, 'amount')).toBe(true);
-		expect(verifyNumberOrder(sorted_items.reverse(), 'amount')).toBe(false);
-	});
-});
+        expect(verifyNumberOrder(sorted_items, "amount")).toBe(true)
+        expect(verifyNumberOrder(sorted_items.reverse(), "amount")).toBe(false)
+    })
+})
+
+// Mock crypto for testing (in real environment this would be Node.js crypto)
+const mockCreateHash = (data: string) => ({
+    update: (input: string) => ({
+        digest: (encoding: string) => {
+            // Simple hash simulation for testing
+            let hash = 0
+            for (let i = 0; i < input.length; i++) {
+                const char = input.charCodeAt(i)
+                hash = (hash << 5) - hash + char
+                hash = hash & hash // Convert to 32-bit integer
+            }
+            return hash.toString(16)
+        },
+    }),
+})
+
+// Use real crypto if available (Node.js environment)
+const createHash =
+    typeof global !== "undefined" &&
+    global.process &&
+    global.process.versions &&
+    global.process.versions.node
+        ? require("crypto").createHash
+        : mockCreateHash
+
+describe("canonicalJSONStringify", () => {
+    // Test hash determinism across different environments
+    test("produces consistent hashes across platforms for complex objects", () => {
+        const testObj = {
+            "key with spaces": "value",
+            another_key: 123,
+            nested: {
+                z: true,
+                a: null,
+                array: [1, "two", { c: 3, b: 2 }],
+            },
+            unicode_key_é: "value_ü",
+            empty_array: [],
+            empty_object: {},
+            number_zero: 0,
+            boolean_false: false,
+        }
+
+        // Expected canonical JSON with consistent key ordering and encoding
+        const expectedCanonicalJson =
+            '{"another_key":123,"boolean_false":false,"empty_array":[],"empty_object":{},"key with spaces":"value","nested":{"a":null,"array":[1,"two",{"b":2,"c":3}],"z":true},"number_zero":0,"unicode_key_é":"value_ü"}'
+        const expectedHash = createHash("sha256")
+            .update(expectedCanonicalJson)
+            .digest("hex")
+
+        const actualCanonicalJson = canonicalJSONStringify(testObj)
+        const actualHash = createHash("sha256")
+            .update(actualCanonicalJson)
+            .digest("hex")
+
+        expect(actualCanonicalJson).toBe(expectedCanonicalJson)
+        expect(actualHash).toBe(expectedHash)
+    })
+
+    test("handles strings with escaped quotes correctly", () => {
+        const testObj = {
+            key: 'value with "quotes" and \\backslashes\\',
+            another: "simple",
+        }
+        const expectedCanonicalJson =
+            '{"another":"simple","key":"value with \\"quotes\\" and \\\\backslashes\\\\"}'
+        const expectedHash = createHash("sha256")
+            .update(expectedCanonicalJson)
+            .digest("hex")
+
+        const actualCanonicalJson = canonicalJSONStringify(testObj)
+        const actualHash = createHash("sha256")
+            .update(actualCanonicalJson)
+            .digest("hex")
+
+        expect(actualCanonicalJson).toBe(expectedCanonicalJson)
+        expect(actualHash).toBe(expectedHash)
+    })
+
+    test("handles simple objects with consistent key ordering", () => {
+        const obj = { b: 2, a: 1 }
+        expect(canonicalJSONStringify(obj)).toBe('{"a":1,"b":2}')
+    })
+
+    test("handles nested objects and arrays with consistent ordering", () => {
+        const obj = { c: { y: 2, x: 1 }, a: [3, { z: 4, w: 5 }] }
+        expect(canonicalJSONStringify(obj)).toBe(
+            '{"a":[3,{"w":5,"z":4}],"c":{"x":1,"y":2}}',
+        )
+    })
+
+    test("handles null, boolean, number, string primitives", () => {
+        expect(canonicalJSONStringify(null)).toBe("null")
+        expect(canonicalJSONStringify(true)).toBe("true")
+        expect(canonicalJSONStringify(123)).toBe("123")
+        expect(canonicalJSONStringify("test")).toBe('"test"')
+    })
+
+    test("produces identical output for multiple calls with same input", () => {
+        const obj = { b: 2, a: 1, nested: { y: 2, x: 1 } }
+        const first = canonicalJSONStringify(obj)
+        const second = canonicalJSONStringify(obj)
+        const third = canonicalJSONStringify(obj)
+
+        expect(first).toBe(second)
+        expect(second).toBe(third)
+        expect(first).toBe(third)
+    })
+
+    test("handles empty objects and arrays", () => {
+        expect(canonicalJSONStringify({})).toBe("{}")
+        expect(canonicalJSONStringify([])).toBe("[]")
+        expect(canonicalJSONStringify({ empty: {} })).toBe('{"empty":{}}')
+        expect(canonicalJSONStringify({ empty: [] })).toBe('{"empty":[]}')
+    })
+
+    test("handles unicode characters consistently", () => {
+        const obj = { émoji: "🚀", chinese: "测试", quotes: 'mixed "quotes"' }
+        const result = canonicalJSONStringify(obj)
+        expect(result).toContain('"émoji":"🚀"')
+        expect(result).toContain('"chinese":"测试"')
+        expect(result).toContain('"quotes":"mixed \\"quotes\\""')
+    })
+
+    test("throws for circular references", () => {
+        const obj: any = {}
+        obj.a = obj
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            "Circular reference detected in JSON payload",
+        )
+    })
+
+    test("throws for non-plain objects (Date)", () => {
+        const obj = { date: new Date() }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            /Only plain objects are supported. Found prototype: Date/,
+        )
+    })
+
+    test("throws for non-plain objects (Map)", () => {
+        const obj = { map: new Map() }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            /Only plain objects are supported. Found prototype: Map/,
+        )
+    })
+
+    test("throws for unsupported non-JSON types (undefined)", () => {
+        const obj = { a: undefined }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            "Non-JSON value encountered: undefined",
+        )
+    })
+
+    test("throws for unsupported non-JSON types (function)", () => {
+        const obj = { a: () => {} }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            "Non-JSON value encountered: function",
+        )
+    })
+
+    test("throws for unsupported non-JSON types (BigInt)", () => {
+        const obj = { a: BigInt(1) }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            "Non-JSON value encountered: bigint",
+        )
+    })
+
+    test("throws for unsupported non-JSON types (Symbol)", () => {
+        const obj = { a: Symbol("test") }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            "Non-JSON value encountered: symbol",
+        )
+    })
+})
+
+describe("validatePureJson", () => {
+    test("allows pure JSON objects", () => {
+        const obj = { a: 1, b: "hello", c: true, d: null, e: [1, { f: false }] }
+        expect(() => validatePureJson(obj)).not.toThrow()
+    })
+
+    test("allows pure JSON arrays", () => {
+        const arr = [1, "hello", { a: true }, null]
+        expect(() => validatePureJson(arr)).not.toThrow()
+    })
+
+    test("allows primitive values", () => {
+        expect(() => validatePureJson(null)).not.toThrow()
+        expect(() => validatePureJson(true)).not.toThrow()
+        expect(() => validatePureJson(123)).not.toThrow()
+        expect(() => validatePureJson("hello")).not.toThrow()
+    })
+
+    test("throws for circular references", () => {
+        const obj: any = {}
+        obj.a = obj
+        expect(() => validatePureJson(obj)).toThrow(
+            "Circular reference detected in JSON payload",
+        )
+    })
+
+    test("throws for non-plain objects (Date)", () => {
+        const obj = { date: new Date() }
+        expect(() => canonicalJSONStringify(obj)).toThrow(
+            /Only plain objects are supported. Found prototype: Date/,
+        )
+    })
+
+    test("throws for non-plain objects (class instance)", () => {
+        class MyClass {}
+        const obj = { instance: new MyClass() }
+        expect(() => validatePureJson(obj)).toThrow(
+            /Only plain objects are supported. Found prototype: MyClass/,
+        )
+    })
+
+    test("throws for unsupported primitive types (undefined)", () => {
+        const obj = { a: undefined }
+        expect(() => validatePureJson(obj)).toThrow(
+            "Non-JSON value encountered: undefined",
+        )
+    })
+
+    test("throws for unsupported primitive types (function)", () => {
+        const obj = { a: () => {} }
+        expect(() => validatePureJson(obj)).toThrow(
+            "Non-JSON value encountered: function",
+        )
+    })
+
+    test("throws for unsupported primitive types (BigInt)", () => {
+        const obj = { a: BigInt(1) }
+        expect(() => validatePureJson(obj)).toThrow(
+            "Non-JSON value encountered: bigint",
+        )
+    })
+})
+
+describe("looksLikeJsonString", () => {
+    test("identifies JSON-like strings", () => {
+        expect(looksLikeJsonString('{"key": "value"}')).toBe(true)
+        expect(looksLikeJsonString("[1, 2, 3]")).toBe(true)
+        expect(looksLikeJsonString('  {"nested": {"key": "value"}}  ')).toBe(
+            true,
+        )
+    })
+
+    test("rejects non-JSON-like strings", () => {
+        expect(looksLikeJsonString("hello world")).toBe(false)
+        expect(looksLikeJsonString("")).toBe(false)
+        expect(looksLikeJsonString('{"incomplete')).toBe(false)
+        expect(looksLikeJsonString('incomplete"}')).toBe(false)
+    })
+})

--- a/src/types/web2/index.ts
+++ b/src/types/web2/index.ts
@@ -12,8 +12,9 @@ export interface IWeb2Result {
     statusText: string
     headers: IncomingHttpHeaders
     data: any
-    dataHash: string
-    headersHash: string
+    responseHash: string
+    responseHeadersHash: string
+    requestHash?: string
     txHash?: string
 }
 

--- a/src/websdk/utils/canonicalJson.ts
+++ b/src/websdk/utils/canonicalJson.ts
@@ -1,0 +1,24 @@
+export function canonicalJSONStringify(value: unknown): string {
+    return stableStringify(value)
+}
+
+function stableStringify(value: unknown): string {
+    if (value === null || typeof value !== "object") {
+        return JSON.stringify(value)
+    }
+
+    if (Array.isArray(value)) {
+        const items = value.map(v => stableStringify(v))
+        return `[${items.join(",")}]`
+    }
+
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    const parts: string[] = []
+    for (const key of keys) {
+        const k = JSON.stringify(key)
+        const v = stableStringify(obj[key])
+        parts.push(`${k}:${v}`)
+    }
+    return `{${parts.join(",")}}`
+}


### PR DESCRIPTION
### **User description**
- Canonicalize outbound JSON payloads to stable bytes.
- Ensure requestHash is surfaced in SDK results and on-chain payload.


___

### **PR Type**
Enhancement


___

### **Description**
- Rename hash fields in IWeb2Result interface for clarity

- Add canonical JSON serialization for deterministic payloads

- Surface requestHash in SDK results and payload

- Implement stable JSON stringify utility function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Web2 Request"] --> B["Canonical JSON Payload"]
  B --> C["Web2Proxy Call"]
  C --> D["Response with Hashes"]
  D --> E["Updated IWeb2Result"]
  E --> F["requestHash Included"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Refactor hash field names and add requestHash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/web2/index.ts

<ul><li>Rename <code>dataHash</code> to <code>responseHash</code> and <code>headersHash</code> to <code>responseHeadersHash</code><br> <li> Add optional <code>requestHash</code> field to IWeb2Result interface</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/sdks/pull/48/files#diff-4bbfceaea5b2ad96ae8ad4eb4b4fdd0a08b913f59fc93c874fb65d1697cf52b2">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Web2Calls.ts</strong><dd><code>Implement canonical JSON and update hash handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/websdk/Web2Calls.ts

<ul><li>Import and use <code>canonicalJSONStringify</code> for payload serialization<br> <li> Update response handling to use new hash field names<br> <li> Conditionally include <code>requestHash</code> in web2Payload result</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/sdks/pull/48/files#diff-b6d8121078770f1d39ec7c98a4093dda54bdcb07866774f6d2432c0f1785038b">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>canonicalJson.ts</strong><dd><code>Add canonical JSON stringify utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/websdk/utils/canonicalJson.ts

<ul><li>Create new utility for deterministic JSON serialization<br> <li> Implement stable stringify with sorted object keys<br> <li> Handle arrays, objects, and primitive values consistently</ul>


</details>


  </td>
  <td><a href="https://github.com/kynesyslabs/sdks/pull/48/files#diff-f74822aacfadef8c934df8e909d53b60ff03837d20a71778555338aab35c4604">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Deterministic JSON payloads for object-based requests and improved JSON-handling behavior.
  - Optional request hash included in web2 responses when available.
  - Canonical JSON stringify and helpers added for consistent serialization and validation.

- Refactor
  - Response fields renamed: dataHash -> responseHash and headersHash -> responseHeadersHash.

- Tests
  - Expanded tests covering canonicalization, validation, and JSON-like string handling.

- Chores
  - New npm script to run canonicalization tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->