### PR TITLE
Fixed ESM import resolution for types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     },
     "scripts": {
         "postinstall": "cp .github/hooks/pre-commit .git/hooks/pre-commit 2>/dev/null && chmod +x .git/hooks/pre-commit 2>/dev/null || true",
-        "build": "rm -rf build && tsc --skipLibCheck && resolve-tspaths && mv build/src/* build/ && rm -rf build/src && npm run build:copy-wasm",
+        "build": "rm -rf build && tsc --skipLibCheck && resolve-tspaths && mv build/src/* build/ && rm -rf build/src && npm run build:fix-esm && npm run build:copy-wasm",
+        "build:fix-esm": "python3 scripts/fix-esm-imports.py build",
         "build:copy-wasm": "mkdir -p build/tlsnotary/wasm && cp node_modules/tlsn-js/build/*.wasm build/tlsnotary/wasm/ && cp node_modules/tlsn-js/build/*.js build/tlsnotary/wasm/ && cp -r node_modules/tlsn-js/build/snippets build/tlsnotary/wasm/",
         "typedoc": "typedoc",
         "test": "jest",

--- a/scripts/fix-esm-imports.py
+++ b/scripts/fix-esm-imports.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Post-build script to add .js extensions to relative imports in ESM output."""
+
+import os
+import re
+import sys
+
+BUILD_DIR = sys.argv[1] if len(sys.argv) > 1 else "build"
+
+pattern = re.compile(r'(from\s+")(\.\.?/[^"]+?)(")')
+
+def fix_import(match, file_dir):
+    prefix = match.group(1)
+    import_path = match.group(2)
+    suffix = match.group(3)
+
+    # Already has .js extension
+    if import_path.endswith(".js"):
+        return match.group(0)
+
+    resolved = os.path.normpath(os.path.join(file_dir, import_path))
+
+    # If it's a directory, append /index.js
+    if os.path.isdir(resolved):
+        return f'{prefix}{import_path}/index.js{suffix}'
+
+    # Otherwise append .js
+    return f'{prefix}{import_path}.js{suffix}'
+
+count = 0
+for root, dirs, files in os.walk(BUILD_DIR):
+    for f in files:
+        if not f.endswith(".js"):
+            continue
+        path = os.path.join(root, f)
+        with open(path, "r") as fh:
+            content = fh.read()
+        new_content = pattern.sub(lambda m: fix_import(m, root), content)
+        if new_content != content:
+            with open(path, "w") as fh:
+                fh.write(new_content)
+            count += 1
+
+print(f"fix-esm-imports: patched {count} file(s)")


### PR DESCRIPTION
Few bugs in the demos SDK according to claude


14:34
That was 100% a bug in the DEMOS SDK itself — nothing on your end.

Three specific bugs we found and had to patch manually:

Bug 1 — Missing .js extension in token module In build/types/token/index.js the import read from "./TokenUtils" — ESM requires explicit file extensions, so Node couldn't resolve it. Had to patch to from "./TokenUtils.js".

Bug 2 — Directory import in types index build/types/index.js was importing from "./blockchain/TransactionSubtypes" — pointing at a directory, not a file. ESM doesn't support directory imports. Had to patch to from "./blockchain/TransactionSubtypes/index.js".

Bug 3 — Same directory import for token Same file was also importing from "./token" instead of from "./token/index.js".

All three are in the build/types/ path of the SDK. The websdk path itself is fine — the bugs are in the types export which gets pulled in transitively.

Worth flagging to the KyneSys Labs team — these patches will get wiped if anyone runs npm install fresh without knowing to re-apply them. They should be a one-line fix in their build pipeline (just add .js extensions to those three imports before publishing to npm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to include an additional step that ensures ESM imports include explicit file extensions for all relative imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->