### PR TITLE
sdks: unified transport (retries + Retry-After) + broadcastAndWait

### DIFF
--- a/src/websdk/BroadcastFailedError.ts
+++ b/src/websdk/BroadcastFailedError.ts
@@ -1,0 +1,29 @@
+/**
+ * Thrown by `DemosTransactions.broadcastAndWait` when the broadcast itself
+ * could not reach the node (no server contact at all). Distinct from
+ * `BroadcastTimeoutError`, which means the broadcast was accepted by the
+ * transport but the SDK never observed a terminal state within the timeout.
+ *
+ * Only raised when the caller opts in via `failFastOnBroadcastError: true`.
+ * The default behavior (lenient) preserves the previous "keep polling and
+ * eventually time out" semantics so existing consumers see no change.
+ *
+ * `cause` is the underlying transport error (typically an AxiosError) so
+ * callers can inspect `.code`, `.response`, etc.
+ */
+export class BroadcastFailedError extends Error {
+    public readonly txHash: string
+    public readonly cause: unknown
+
+    constructor(opts: { txHash: string; cause: unknown; message?: string }) {
+        const causeMessage =
+            (opts.cause as any)?.message ?? String(opts.cause ?? "unknown")
+        super(
+            opts.message ??
+                `Broadcast failed before inclusion polling could begin (txHash=${opts.txHash}): ${causeMessage}`,
+        )
+        this.name = "BroadcastFailedError"
+        this.txHash = opts.txHash
+        this.cause = opts.cause
+    }
+}

--- a/src/websdk/BroadcastTimeoutError.ts
+++ b/src/websdk/BroadcastTimeoutError.ts
@@ -1,0 +1,28 @@
+/**
+ * Thrown by `DemosTransactions.broadcastAndWait` when a broadcast tx has not
+ * been observed in a terminal state (`included` or `failed`) before the
+ * configured timeout elapses.
+ *
+ * The broadcast itself may have succeeded - this only indicates that the
+ * SDK gave up waiting. Callers can resume polling on their own using the
+ * preserved `txHash` and `lastSeenState`.
+ */
+export class BroadcastTimeoutError extends Error {
+    public readonly txHash: string
+    public readonly lastSeenState: string
+    public readonly elapsedMs: number
+
+    constructor(opts: {
+        txHash: string
+        lastSeenState: string
+        elapsedMs: number
+    }) {
+        super(
+            `Broadcast timed out after ${opts.elapsedMs}ms (txHash=${opts.txHash}, lastSeenState=${opts.lastSeenState})`,
+        )
+        this.name = "BroadcastTimeoutError"
+        this.txHash = opts.txHash
+        this.lastSeenState = opts.lastSeenState
+        this.elapsedMs = opts.elapsedMs
+    }
+}

--- a/src/websdk/DemosTransactions.ts
+++ b/src/websdk/DemosTransactions.ts
@@ -14,6 +14,17 @@ import { Cryptography } from "@/encryption"
 import { uint8ArrayToHex } from "@/encryption/unifiedCrypto"
 import { Enigma } from "@/encryption/PQC/enigma"
 import { BroadcastTimeoutError } from "./BroadcastTimeoutError"
+import { BroadcastFailedError } from "./BroadcastFailedError"
+
+// Connection-error codes indicating the request never reached the node.
+// HTTP 5xx is intentionally NOT in this set: a 5xx means the server did
+// answer, so the broadcast may have landed even if the response was lost.
+const NO_SERVER_CONTACT_CODES = new Set([
+    "ECONNREFUSED",
+    "ENOTFOUND",
+    "ECONNRESET",
+    "ETIMEDOUT",
+])
 
 export const DemosTransactions = {
     // REVIEW All this part
@@ -254,23 +265,37 @@ export const DemosTransactions = {
      * the last observed state, and the elapsed time so the caller can
      * resume polling.
      *
+     * When `opts.failFastOnBroadcastError` is true, also throws
+     * `BroadcastFailedError` synchronously when the broadcast itself can't
+     * reach the node (e.g., ECONNREFUSED, ENOTFOUND). HTTP 5xx responses
+     * are NOT considered fail-fast cases - the server did answer, so the
+     * tx may still have landed and polling should run. Defaults to false
+     * for one release to preserve current callers' behavior.
+     *
      * @param validationData - The validity data of the transaction (from `confirm`)
      * @param demos - The demos instance
      * @param opts.timeoutMs - Total time to wait for inclusion. Defaults to 30_000.
      * @param opts.pollIntervalMs - Delay between status polls. Defaults to 500.
+     * @param opts.failFastOnBroadcastError - If true, throw `BroadcastFailedError`
+     *   immediately when the broadcast can't contact the node. Defaults to false.
      *
      * @returns The original broadcast response and the terminal status.
      */
     broadcastAndWait: async function (
         validationData: RPCResponseWithValidityData,
         demos: Demos,
-        opts?: { timeoutMs?: number; pollIntervalMs?: number },
+        opts?: {
+            timeoutMs?: number
+            pollIntervalMs?: number
+            failFastOnBroadcastError?: boolean
+        },
     ): Promise<{
         broadcast: RPCResponse
         status: { state: "included" | "failed"; blockNumber?: number }
     }> {
         const timeout = opts?.timeoutMs ?? 30_000
         const pollInterval = opts?.pollIntervalMs ?? 500
+        const failFast = opts?.failFastOnBroadcastError ?? false
 
         // Extract the tx hash from the validity data before broadcasting so
         // we can include it in any timeout error.
@@ -283,6 +308,33 @@ export const DemosTransactions = {
             validationData,
             demos,
         )
+
+        // 1a. (Opt-in) If the broadcast never reached the node, surface that
+        //     immediately rather than waiting out the full timeout. We detect
+        //     this via the back-compat envelope produced by `demos.call` on
+        //     transport failure: { result: 500, response: <error>, require_reply, ... }.
+        //     Only "no server contact" codes are fail-fast; HTTP 5xx means the
+        //     server did answer and the tx may still have landed, so polling runs.
+        if (failFast) {
+            const isTransportFailureEnvelope =
+                broadcastRes &&
+                typeof broadcastRes === "object" &&
+                (broadcastRes as any).result === 500 &&
+                "require_reply" in broadcastRes
+            if (isTransportFailureEnvelope) {
+                const cause = (broadcastRes as any).response
+                const code: string | undefined = (cause as any)?.code
+                const sawServer =
+                    typeof (cause as any)?.response?.status === "number"
+                const noServerContact =
+                    !sawServer &&
+                    typeof code === "string" &&
+                    NO_SERVER_CONTACT_CODES.has(code)
+                if (noServerContact) {
+                    throw new BroadcastFailedError({ txHash, cause })
+                }
+            }
+        }
 
         const start = Date.now()
         let attempt = 0

--- a/src/websdk/DemosTransactions.ts
+++ b/src/websdk/DemosTransactions.ts
@@ -9,10 +9,11 @@ import type { L2PSHashPayload } from "@/types/blockchain/TransactionSubtypes/L2P
 import { IKeyPair } from "./types/KeyPair"
 import { GCRGeneration } from "./GCRGeneration"
 import { _required as required } from "./utils/required"
-import { RPCResponseWithValidityData } from "@/types/communication/rpc"
+import { RPCResponse, RPCResponseWithValidityData } from "@/types/communication/rpc"
 import { Cryptography } from "@/encryption"
 import { uint8ArrayToHex } from "@/encryption/unifiedCrypto"
 import { Enigma } from "@/encryption/PQC/enigma"
+import { BroadcastTimeoutError } from "./BroadcastTimeoutError"
 
 export const DemosTransactions = {
     // REVIEW All this part
@@ -238,7 +239,114 @@ export const DemosTransactions = {
             return res
         }
     },
-    
+
+    /**
+     * Broadcast a confirmed transaction and wait for inclusion.
+     *
+     * Polls the node's `getTransactionStatus` RPC until the tx is observed
+     * `included` or `failed`, or until `opts.timeoutMs` elapses (default 30s).
+     *
+     * Use this when you want a single call with a deterministic outcome.
+     * Use plain `broadcast()` when you want to handle async confirmation
+     * yourself.
+     *
+     * On timeout, throws `BroadcastTimeoutError` carrying the tx hash,
+     * the last observed state, and the elapsed time so the caller can
+     * resume polling.
+     *
+     * @param validationData - The validity data of the transaction (from `confirm`)
+     * @param demos - The demos instance
+     * @param opts.timeoutMs - Total time to wait for inclusion. Defaults to 30_000.
+     * @param opts.pollIntervalMs - Delay between status polls. Defaults to 500.
+     *
+     * @returns The original broadcast response and the terminal status.
+     */
+    broadcastAndWait: async function (
+        validationData: RPCResponseWithValidityData,
+        demos: Demos,
+        opts?: { timeoutMs?: number; pollIntervalMs?: number },
+    ): Promise<{
+        broadcast: RPCResponse
+        status: { state: "included" | "failed"; blockNumber?: number }
+    }> {
+        const timeout = opts?.timeoutMs ?? 30_000
+        const pollInterval = opts?.pollIntervalMs ?? 500
+
+        // Extract the tx hash from the validity data before broadcasting so
+        // we can include it in any timeout error.
+        const txHash = validationData?.response?.data?.transaction?.hash
+        required(txHash, "Could not find transaction hash on validationData")
+
+        // 1. Broadcast first - reuses existing semantics so any failure here
+        //    surfaces exactly the same way as a plain broadcast() call.
+        const broadcastRes = await DemosTransactions.broadcast(
+            validationData,
+            demos,
+        )
+
+        const start = Date.now()
+        let attempt = 0
+        let lastState: string = "unknown"
+
+        // 2. Poll until terminal state or timeout. Mirrors KeyServerClient's
+        //    pollOAuth pattern: skip the initial sleep on the first attempt
+        //    so a tx that lands instantly returns quickly.
+        while (Date.now() - start < timeout) {
+            attempt++
+
+            if (attempt > 1) {
+                await new Promise(r => setTimeout(r, pollInterval))
+            }
+
+            const statusRes = await demos.call(
+                "nodeCall",
+                "",
+                { hash: txHash },
+                "getTransactionStatus",
+            )
+
+            // `Demos.call("nodeCall", ...)` normally returns the inner
+            // `response` payload directly (e.g. `{ state, blockNumber? }`).
+            // On a terminal transport failure it returns the back-compat
+            // envelope `{ result: 500, response: <error> }`. Tolerate that
+            // as a transient hiccup and keep polling - we don't want a
+            // single 5xx blip to break the wait.
+            const isTransportFailureEnvelope =
+                statusRes &&
+                typeof statusRes === "object" &&
+                "result" in statusRes &&
+                (statusRes as any).result === 500 &&
+                "require_reply" in statusRes
+
+            if (isTransportFailureEnvelope) {
+                continue
+            }
+
+            const state: string | undefined =
+                statusRes && typeof statusRes === "object"
+                    ? (statusRes as any).state
+                    : undefined
+
+            if (typeof state === "string") {
+                lastState = state
+                if (state === "included" || state === "failed") {
+                    const blockNumber: number | undefined =
+                        (statusRes as any).blockNumber
+                    return {
+                        broadcast: broadcastRes,
+                        status: { state, blockNumber },
+                    }
+                }
+            }
+        }
+
+        throw new BroadcastTimeoutError({
+            txHash,
+            lastSeenState: lastState,
+            elapsedMs: Date.now() - start,
+        })
+    },
+
     /**
      * Create a signed DEMOS transaction to store binary data on the blockchain.
      * Data is stored in the sender's account.

--- a/src/websdk/TransportError.ts
+++ b/src/websdk/TransportError.ts
@@ -1,0 +1,20 @@
+/**
+ * Thrown by the SDK transport layer when an HTTP request to the Demos node
+ * exhausts its retry budget. This is intentionally small and local - we
+ * don't want a hierarchy of transport errors at this layer.
+ *
+ * `attempts` is the total number of attempts that were made (including the
+ * final failing one). `cause` is the underlying error (typically an
+ * AxiosError) so callers can inspect `.response`, `.code`, etc.
+ */
+export class TransportError extends Error {
+    public readonly attempts: number
+    public readonly cause: unknown
+
+    constructor(message: string, opts: { cause: unknown; attempts: number }) {
+        super(message)
+        this.name = "TransportError"
+        this.attempts = opts.attempts
+        this.cause = opts.cause
+    }
+}

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -375,6 +375,25 @@ export class Demos {
     }
 
     /**
+     * Broadcast a confirmed transaction and wait until it lands on chain
+     * (or fails) by polling the node's `getTransactionStatus` RPC.
+     *
+     * Throws `BroadcastTimeoutError` if no terminal state is observed
+     * before the timeout elapses. Use plain `broadcast()` if you want to
+     * handle async confirmation yourself.
+     *
+     * @param validationData - The validity data of the transaction
+     * @param opts.timeoutMs - Total time to wait. Defaults to 30_000.
+     * @param opts.pollIntervalMs - Delay between polls. Defaults to 500.
+     */
+    broadcastAndWait(
+        validationData: RPCResponseWithValidityData,
+        opts?: { timeoutMs?: number; pollIntervalMs?: number },
+    ) {
+        return DemosTransactions.broadcastAndWait(validationData, this, opts)
+    }
+
+    /**
      * Signs a transaction.
      *
      * @param raw_tx - The transaction to sign

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -7,6 +7,7 @@ This library contains all the functions that are used to interact with the demos
 import axios from "axios"
 import { Buffer } from "buffer"
 import * as skeletons from "./utils/skeletons"
+import { TransportError } from "./TransportError"
 
 // NOTE Including custom libraries from Demos
 import { DemosTransactions } from "./DemosTransactions"
@@ -635,6 +636,103 @@ export class Demos {
 
     // L2PS calls are defined here
 
+    /**
+     * Single transport wrapper for axios.post against the Demos RPC node.
+     *
+     * Retries:
+     *   - connection-level errors: ECONNRESET, ECONNREFUSED, ETIMEDOUT, ENOTFOUND
+     *   - HTTP 502, 503, 504
+     * Never retries on 4xx (those are client errors, including the node-side
+     * 404 "Unknown message" introduced by Phase 1 item 1).
+     *
+     * Backoff is exponential (baseSleepMs * 2^attempt), capped at 8s. A
+     * Retry-After response header (numeric seconds, or HTTP-date) overrides
+     * the computed backoff for that attempt.
+     *
+     * On terminal failure, throws a TransportError carrying the underlying
+     * cause and the total number of attempts. Callers that need the legacy
+     * "never throws, returns {result: 500, response: error}" behavior should
+     * wrap this in their own try/catch (see `call` below).
+     */
+    private async _doPost<T = RPCResponse>(
+        url: string,
+        request: any,
+        headers: Record<string, string | undefined>,
+        opts: { retries?: number; baseSleepMs?: number } = {},
+    ): Promise<{ data: T }> {
+        const maxRetries = opts.retries ?? 4
+        const baseSleepMs = opts.baseSleepMs ?? 250
+        const RETRYABLE_CODES = new Set([
+            "ECONNRESET",
+            "ECONNREFUSED",
+            "ETIMEDOUT",
+            "ENOTFOUND",
+        ])
+        const RETRYABLE_STATUSES = new Set([502, 503, 504])
+        const MAX_BACKOFF_MS = 8000
+
+        let lastError: unknown = null
+
+        // attempt 0 is the initial try; we then retry up to maxRetries times.
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                const response = await axios.post<T>(url, request, { headers })
+                return { data: response.data }
+            } catch (error: any) {
+                lastError = error
+
+                const code: string | undefined = error?.code
+                const status: number | undefined = error?.response?.status
+
+                const isConnError =
+                    typeof code === "string" && RETRYABLE_CODES.has(code)
+                const isRetryableStatus =
+                    typeof status === "number" &&
+                    RETRYABLE_STATUSES.has(status)
+
+                const shouldRetry =
+                    (isConnError || isRetryableStatus) && attempt < maxRetries
+
+                if (!shouldRetry) {
+                    break
+                }
+
+                // Honor Retry-After if present. Conservative parsing: numeric
+                // seconds first, then HTTP-date via Date.parse, else fallback
+                // to exponential backoff.
+                let waitMs = Math.min(
+                    baseSleepMs * Math.pow(2, attempt),
+                    MAX_BACKOFF_MS,
+                )
+                const retryAfter: string | undefined =
+                    error?.response?.headers?.["retry-after"]
+                if (typeof retryAfter === "string" && retryAfter.length > 0) {
+                    if (/^\d+$/.test(retryAfter.trim())) {
+                        waitMs = parseInt(retryAfter, 10) * 1000
+                    } else {
+                        const parsed = Date.parse(retryAfter)
+                        if (!Number.isNaN(parsed)) {
+                            waitMs = Math.max(0, parsed - Date.now())
+                        }
+                    }
+                }
+
+                await sleep(waitMs)
+            }
+        }
+
+        const attempts = maxRetries + 1
+        const reason =
+            (lastError as any)?.code ??
+            (lastError as any)?.response?.status ??
+            (lastError as any)?.message ??
+            "unknown"
+        throw new TransportError(
+            `Demos RPC POST to ${url} failed after ${attempts} attempt(s): ${reason}`,
+            { cause: lastError, attempts },
+        )
+    }
+
     async rpcCall(
         request: RPCRequest,
         isAuthenticated: boolean = false,
@@ -654,17 +752,24 @@ export class Demos {
             signature = uint8ArrayToHex(_signature.signature)
         }
 
+        const headers = {
+            "Content-Type": "application/json",
+            identity: this.algorithm + ":" + publicKey,
+            signature: signature,
+        }
+
+        // Map the legacy `retries`/`sleepTime` knobs onto _doPost's opts so
+        // existing callers keep working unchanged. Note: the legacy retry
+        // semantics retried on *application-level* non-200 RPC results; the
+        // new transport retries on *connection/5xx* failures. We preserve the
+        // legacy "retry until result==200 or budget exhausted" loop here in
+        // addition to the transport-level retries handled by _doPost.
         try {
-            const response = await axios.post<RPCResponse>(
+            const response = await this._doPost<RPCResponse>(
                 this.rpc_url,
                 request,
-                {
-                    headers: {
-                        "Content-Type": "application/json",
-                        identity: this.algorithm + ":" + publicKey,
-                        signature: signature,
-                    },
-                },
+                headers,
+                { retries, baseSleepMs: sleepTime },
             )
 
             if (
@@ -687,6 +792,9 @@ export class Demos {
 
             return response.data
         } catch (error) {
+            // Preserve legacy not-throwing behavior on terminal transport
+            // failure. Callers that want the typed TransportError can use
+            // _doPost directly.
             console.error(error)
             return {
                 result: 500,
@@ -750,16 +858,20 @@ export class Demos {
             pubkey_signature = uint8ArrayToHex(signature.signature)
         }
 
+        // BACK-COMPAT: existing callers (DemosTransactions.confirm/broadcast,
+        // Web2Calls, contract helpers) rely on `call` never throwing - on
+        // failure they expect `{result: 500, response: <error>}`. We keep that
+        // contract here by catching TransportError (and any unexpected error)
+        // from _doPost. Callers that want the typed TransportError can use
+        // _doPost directly.
         try {
-            const response = await axios.post<RPCResponse>(
+            const response = await this._doPost<RPCResponse>(
                 this.rpc_url,
                 request,
                 {
-                    headers: {
-                        "Content-Type": "application/json",
-                        identity: pubkey_string,
-                        signature: pubkey_signature,
-                    },
+                    "Content-Type": "application/json",
+                    identity: pubkey_string,
+                    signature: pubkey_signature,
                 },
             )
 

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -691,9 +691,10 @@ export class Demos {
         const MAX_BACKOFF_MS = 8000
 
         let lastError: unknown = null
+        let attempt = 0
 
         // attempt 0 is the initial try; we then retry up to maxRetries times.
-        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        for (; attempt <= maxRetries; attempt++) {
             try {
                 const response = await axios.post<T>(url, request, { headers })
                 return { data: response.data }
@@ -718,7 +719,9 @@ export class Demos {
 
                 // Honor Retry-After if present. Conservative parsing: numeric
                 // seconds first, then HTTP-date via Date.parse, else fallback
-                // to exponential backoff.
+                // to exponential backoff. All branches are clamped to
+                // MAX_BACKOFF_MS so a misbehaving node can't stall a single
+                // request indefinitely.
                 let waitMs = Math.min(
                     baseSleepMs * Math.pow(2, attempt),
                     MAX_BACKOFF_MS,
@@ -727,11 +730,17 @@ export class Demos {
                     error?.response?.headers?.["retry-after"]
                 if (typeof retryAfter === "string" && retryAfter.length > 0) {
                     if (/^\d+$/.test(retryAfter.trim())) {
-                        waitMs = parseInt(retryAfter, 10) * 1000
+                        waitMs = Math.min(
+                            parseInt(retryAfter, 10) * 1000,
+                            MAX_BACKOFF_MS,
+                        )
                     } else {
                         const parsed = Date.parse(retryAfter)
                         if (!Number.isNaN(parsed)) {
-                            waitMs = Math.max(0, parsed - Date.now())
+                            waitMs = Math.min(
+                                Math.max(0, parsed - Date.now()),
+                                MAX_BACKOFF_MS,
+                            )
                         }
                     }
                 }
@@ -740,7 +749,10 @@ export class Demos {
             }
         }
 
-        const attempts = maxRetries + 1
+        // attempt is incremented past the last successful iteration on natural
+        // loop exit, and equals the break-point on early exit. Clamp to the
+        // budget so the reported count never exceeds maxRetries+1.
+        const attempts = Math.min(attempt + 1, maxRetries + 1)
         const reason =
             (lastError as any)?.code ??
             (lastError as any)?.response?.status ??

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -789,18 +789,20 @@ export class Demos {
             signature: signature,
         }
 
-        // Map the legacy `retries`/`sleepTime` knobs onto _doPost's opts so
-        // existing callers keep working unchanged. Note: the legacy retry
-        // semantics retried on *application-level* non-200 RPC results; the
-        // new transport retries on *connection/5xx* failures. We preserve the
-        // legacy "retry until result==200 or budget exhausted" loop here in
-        // addition to the transport-level retries handled by _doPost.
+        // The legacy `retries`/`sleepTime` knobs are application-level: they
+        // retry on non-200 RPC *results*. _doPost's retries are a separate
+        // transport-level budget covering connection errors and 5xx. We do
+        // NOT forward `retries` into _doPost - forwarding would (a) disable
+        // transport retries entirely when callers pass the default of 0, and
+        // (b) couple the two layers, multiplying total attempts. _doPost
+        // keeps its own internal default; baseSleepMs is shared because both
+        // layers want the same backoff base.
         try {
             const response = await this._doPost<RPCResponse>(
                 this.rpc_url,
                 request,
                 headers,
-                { retries, baseSleepMs: sleepTime },
+                { baseSleepMs: sleepTime },
             )
 
             if (

--- a/src/websdk/index.ts
+++ b/src/websdk/index.ts
@@ -4,6 +4,7 @@ export { Demos } from "./demosclass"
 export { DemosTransactions } from "./DemosTransactions"
 export { TransportError } from "./TransportError"
 export { BroadcastTimeoutError } from "./BroadcastTimeoutError"
+export { BroadcastFailedError } from "./BroadcastFailedError"
 
 export { RSA } from "./rsa"
 export { DemosWebAuth } from "./DemosWebAuth"

--- a/src/websdk/index.ts
+++ b/src/websdk/index.ts
@@ -3,6 +3,7 @@ export { demos } from "./demos"
 export { Demos } from "./demosclass"
 export { DemosTransactions } from "./DemosTransactions"
 export { TransportError } from "./TransportError"
+export { BroadcastTimeoutError } from "./BroadcastTimeoutError"
 
 export { RSA } from "./rsa"
 export { DemosWebAuth } from "./DemosWebAuth"

--- a/src/websdk/index.ts
+++ b/src/websdk/index.ts
@@ -2,6 +2,7 @@
 export { demos } from "./demos"
 export { Demos } from "./demosclass"
 export { DemosTransactions } from "./DemosTransactions"
+export { TransportError } from "./TransportError"
 
 export { RSA } from "./rsa"
 export { DemosWebAuth } from "./DemosWebAuth"


### PR DESCRIPTION
## Summary

Companion to `kynesyslabs/node#796`. Two SDK changes from Phase 1 of the SpaceFort field-report hardening pass:

| Commit | Item | What |
|---|---|---|
| `5f0076d` | Phase 1 item 6 | Unified axios call sites through `_doPost` with retry on 5xx + connection errors + `Retry-After`; `TransportError` exported |
| `c6a6d26` | Phase 1 item 8 | `DemosTransactions.broadcastAndWait()` + `Demos.broadcastAndWait()` shim; `BroadcastTimeoutError` exported |

## Phase 1 item 6 — unified transport (`5f0076d`)

Two unmerged axios call sites previously diverged: `rpcCall` had recursive retry on its `retries`/`sleepTime` params; `call` had no retry and broadly caught everything into `{result: 500, response: error}`. Both now route through a single private `_doPost<T>` wrapper on `Demos`:

- Retries on connection errors: `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `ENOTFOUND`
- Retries on HTTP `502`, `503`, `504`
- Honors `Retry-After` header (numeric seconds or HTTP-date)
- Exponential backoff: 250ms → 500ms → 1s → 2s, default 4 retries, capped at 8s
- `4xx` is **never** retried (including the new 404 from node-side item 1) — those are client errors
- On terminal failure: throws `TransportError` (new error class, fields `attempts` and `cause`)

`rpcCall` and `call` keep their public signatures unchanged. `call` still returns `{result: 500, response: error}` on terminal failure to preserve back-compat with existing callers — `TransportError` is what surfaces from `rpcCall`'s try/catch path on retry exhaustion.

`TransportError` exported from `src/websdk/index.ts` so consumers can `instanceof` check.

### Two retry layers

The pre-existing application-level recursive retry inside `rpcCall` (gated by the explicit `retries` arg) is **kept** alongside the new transport retry. They're orthogonal:
- `_doPost` retries handle the network layer (5xx, connection drops).
- `rpcCall`'s outer loop retries on **non-200 RPC results** if the caller asked for it.

A flaky 502 will retry up to 4 times in `_doPost`; if the eventual response reports e.g. `result: 400`, the application loop in `rpcCall` may further retry per the `retries` arg.

### Caller audit (no breakage)

Audited every `.call(` site in `src/`: `Web2Calls.ts`, `DemosTransactions.confirm/broadcast`, `Demos.nodeCall`, `ContractInteractor`. All rely on the non-throwing `{result: 500, response: error}` shape on terminal failure — preserved.

## Phase 1 item 8 — broadcastAndWait (`c6a6d26`)

Additive helper on `DemosTransactions` (existing `broadcast()` is unchanged):

```ts
DemosTransactions.broadcastAndWait(
    validationData,
    demos,
    { timeoutMs?: number, pollIntervalMs?: number }
): Promise<{
    broadcast: RPCResponse,
    status: { state: 'included' | 'failed', blockNumber?: number }
}>
```

Defaults: `timeoutMs = 30_000`, `pollIntervalMs = 500`.

Flow:
1. `broadcast(validationData, demos)` — unchanged semantics; failures surface exactly as today.
2. Extract `txHash` from `validationData.response.data.transaction.hash` (signed tx already carries it; computed at sign time as `sha256(JSON.stringify(content))`).
3. Poll the node's `getTransactionStatus(hash)` RPC every `pollIntervalMs` until terminal (`included` / `failed`) or `timeoutMs` elapses.
4. On timeout: throws `BroadcastTimeoutError({ txHash, lastSeenState, elapsedMs })` so the caller can resume polling later.

Polling tolerates transient transport failures (the back-compat `{result: 500, response: error}` envelope from `Demos.call`) by skipping the iteration — a single 5xx blip won't break a 30s wait.

There's also a `Demos.broadcastAndWait(validationData, opts?)` instance shim that delegates to the static, matching the surrounding `pay/transfer/broadcast` ergonomic pattern in `demosclass.ts`.

`BroadcastTimeoutError` exported from `src/websdk/index.ts`.

## Cross-repo dependency

The `getTransactionStatus` RPC that `broadcastAndWait` polls is implemented on the node side in `kynesyslabs/node#796` (commit `node:0def623`). This PR depends on that being deployed.

The 404 / `Retry-After` infrastructure that the new transport behavior consumes also comes from `node#796` (Phase 1 items 1 and 2).

## Health check

`tsc --skipLibCheck --noEmit`: 1 pre-existing error in `src/tests/multichain/ten.spec.ts:115` (`Property 'calculateFeeData'` — unrelated). **0 errors in files this PR adds/modifies.**

## What's intentionally NOT here

- **Phase 2 item 9 — SDK capability detection / version gating.** A complete planning artifact (~600 lines) lives on `kynesyslabs/node` at `docs/planning/sdk-capability-detection.md` and lays out the implementation: decorator + `assertNodeVersion` helper, opt-in `strictCapabilities` flag with deprecation `console.warn`, min-version table for the 10 newly-gated methods, 3-PR breakdown. The next agent picks that file up.
- Test additions. The audit found `src/tests/storagePrograms.spec.ts` is `test.skip`'d and the broader test suite has 800+ pre-existing TS errors in test files — out of scope to fix in this PR.

## Test plan

- [x] `tsc --skipLibCheck --noEmit` — 0 new errors
- [ ] Smoke: `pay → confirm → broadcastAndWait` against a node that has `getTransactionStatus` deployed; assert `{state: "included", blockNumber}`
- [ ] Smoke: same flow against a node where the tx never lands; assert `BroadcastTimeoutError` thrown after `timeoutMs`
- [ ] Smoke: simulate transient 5xx during poll; assert eventual success once node recovers
- [ ] Smoke: trigger a 502 storm; assert `_doPost` retries with backoff and respects `Retry-After`

https://claude.ai/code/session_017o1sbWTjJYror8Q6JuesK9

---
_Generated by [Claude Code](https://claude.ai/code/session_017o1sbWTjJYror8Q6JuesK9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `broadcastAndWait` functionality to broadcast confirmed transactions and automatically poll for completion, with customizable timeout and polling intervals.
  * Added enhanced error handling with new error types providing detailed information about broadcast failures, timeouts, and transport-level issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->