### PR TITLE
fix(l2ps): per-call AES-GCM nonce in encryptTx (was reusing static IV)

### DIFF
--- a/src/l2ps/l2ps.ts
+++ b/src/l2ps/l2ps.ts
@@ -44,6 +44,15 @@ export interface L2PSEncryptedPayload {
     tag: string;
     /** Hash of the original transaction for integrity verification */
     original_hash: string;
+    /**
+     * Base64-encoded AES-GCM nonce (12 bytes) used for this specific
+     * encryption. Required for AES-GCM safety: nonce reuse under the
+     * same key catastrophically breaks confidentiality + authentication.
+     * Optional in the type for backward compatibility — payloads written
+     * by older SDKs predating the per-call-nonce fix do not include it
+     * and `decryptTx` falls back to the instance IV for those.
+     */
+    nonce?: string;
 }
 
 /**
@@ -199,7 +208,12 @@ export default class L2PS {
             const txBuffer = forge.util.createBuffer(txString);
             const cipher = forge.cipher.createCipher('AES-GCM', this.privateKey);
 
-            cipher.start({ iv: this.iv });
+            // Fresh 96-bit nonce per encryption — the instance IV is no
+            // longer used for new ciphertexts. AES-GCM nonce reuse under
+            // the same key is catastrophic (loses confidentiality + auth),
+            // so this MUST be unique per call.
+            const nonce = forge.random.getBytesSync(12);
+            cipher.start({ iv: nonce });
             cipher.update(txBuffer);
 
             if (!cipher.finish()) {
@@ -210,7 +224,8 @@ export default class L2PS {
                 l2ps_uid: this.config?.uid || this.id,
                 encrypted_data: forge.util.encode64(cipher.output.getBytes()),
                 tag: forge.util.encode64(cipher.mode.tag.getBytes()),
-                original_hash: tx.hash
+                original_hash: tx.hash,
+                nonce: forge.util.encode64(nonce)
             };
 
             const encryptedTxContent: L2PSTransactionContent = {
@@ -283,9 +298,16 @@ export default class L2PS {
             const encryptedData = forge.util.createBuffer(forge.util.decode64(encryptedPayload.encrypted_data));
             const tag = forge.util.createBuffer(forge.util.decode64(encryptedPayload.tag));
 
+            // Per-call nonce (new path) when present in payload; fall
+            // back to the instance IV for legacy ciphertexts encrypted
+            // before the per-call-nonce fix.
+            const iv = encryptedPayload.nonce
+                ? forge.util.decode64(encryptedPayload.nonce)
+                : this.iv;
+
             const decipher = forge.cipher.createDecipher('AES-GCM', this.privateKey);
             decipher.start({
-                iv: this.iv,
+                iv,
                 tag: tag
             });
 

--- a/src/l2ps/l2ps.ts
+++ b/src/l2ps/l2ps.ts
@@ -212,8 +212,16 @@ export default class L2PS {
             // longer used for new ciphertexts. AES-GCM nonce reuse under
             // the same key is catastrophic (loses confidentiality + auth),
             // so this MUST be unique per call.
+            //
+            // The nonce is also bound into the authenticated envelope as
+            // AAD. AES-GCM authentication covers ciphertext + AAD but not
+            // the IV itself, so without this an attacker who can modify
+            // the stored payload could flip the `nonce` field and force
+            // decryption to fail — a targeted DoS against specific
+            // ciphertexts. Decrypt mirrors this binding when a per-call
+            // nonce is present on the wire.
             const nonce = forge.random.getBytesSync(12);
-            cipher.start({ iv: nonce });
+            cipher.start({ iv: nonce, additionalData: nonce });
             cipher.update(txBuffer);
 
             if (!cipher.finish()) {
@@ -301,14 +309,34 @@ export default class L2PS {
             // Per-call nonce (new path) when present in payload; fall
             // back to the instance IV for legacy ciphertexts encrypted
             // before the per-call-nonce fix.
-            const iv = encryptedPayload.nonce
-                ? forge.util.decode64(encryptedPayload.nonce)
-                : this.iv;
+            //
+            // `nonce === undefined` is the only legacy signal — any other
+            // value (including `""`) is rejected so a malformed payload
+            // does not silently fall through to the legacy IV. The decoded
+            // nonce MUST be exactly 12 bytes per the AES-GCM contract.
+            let iv: forge.Bytes;
+            if (encryptedPayload.nonce === undefined) {
+                iv = this.iv;
+            } else {
+                iv = forge.util.decode64(encryptedPayload.nonce);
+                if (iv.length !== 12) {
+                    throw new Error(
+                        'Invalid encrypted payload nonce: expected a base64-encoded 12-byte value'
+                    );
+                }
+            }
 
+            // Bind the nonce as AAD on the new path so the auth tag
+            // covers it — see the matching block in `encryptTx`. Legacy
+            // payloads were encrypted without AAD, so we leave it off
+            // when falling back to the instance IV.
             const decipher = forge.cipher.createDecipher('AES-GCM', this.privateKey);
             decipher.start({
                 iv,
-                tag: tag
+                tag,
+                ...(encryptedPayload.nonce !== undefined
+                    ? { additionalData: iv }
+                    : {})
             });
 
             decipher.update(encryptedData);

--- a/tests/l2ps_aad.test.ts
+++ b/tests/l2ps_aad.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect } from "@jest/globals"
+import * as forge from "node-forge"
+import L2PS from "@/l2ps/l2ps"
+import type { Transaction } from "@/types/blockchain/Transaction"
+
+// AES-GCM AAD binding + per-call nonce validation contract for
+// `L2PS.encryptTx` / `L2PS.decryptTx`. Each test covers one rejection
+// path that would otherwise let a malformed or tampered payload either
+// silently fall through to the legacy IV or pass authentication when
+// it should not.
+
+function makeTx(): Transaction {
+    return {
+        content: {
+            type: "native",
+            from: "0x" + "a".repeat(64),
+            to: "0x" + "b".repeat(64),
+            from_ed25519_address: "0x" + "a".repeat(64),
+            amount: "100",
+            data: [
+                "native",
+                { nativeOperation: "send", args: ["0x" + "b".repeat(64), "100"] },
+            ],
+            gcr_edits: [],
+            nonce: 1,
+            timestamp: 1_700_000_000_000,
+            transaction_fee: {
+                network_fee: "0",
+                rpc_fee: "0",
+                additional_fee: "0",
+                rpc_address: null,
+            },
+        },
+        hash: "deadbeef".repeat(8),
+        signature: null,
+        ed25519_signature: null,
+        status: null,
+        blockNumber: null,
+    } as unknown as Transaction
+}
+
+describe("L2PS AES-GCM AAD binding + nonce validation", () => {
+    test("encryptTx → decryptTx round-trips with AAD-bound per-call nonce", async () => {
+        const l2ps = await L2PS.create()
+        const tx = makeTx()
+        const enc = await l2ps.encryptTx(tx)
+        const dec = await l2ps.decryptTx(enc)
+        expect(dec.hash).toBe(tx.hash)
+    })
+
+    test("tampering with the wire nonce field fails authentication", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptTx(makeTx())
+
+        // Flip the nonce on the wire. AAD binding makes the auth tag
+        // depend on the nonce, so a mismatched IV/AAD pair must fail
+        // tag verification instead of silently producing garbage.
+        const tampered = JSON.parse(JSON.stringify(enc))
+        const payload = tampered.content.data[1]
+        const freshNonce = forge.util.encode64(forge.random.getBytesSync(12))
+        expect(freshNonce).not.toBe(payload.nonce)
+        payload.nonce = freshNonce
+
+        await expect(l2ps.decryptTx(tampered)).rejects.toThrow(/Decryption failed/)
+    })
+
+    test("empty-string nonce is rejected (not silently treated as legacy)", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptTx(makeTx())
+
+        const malformed = JSON.parse(JSON.stringify(enc))
+        malformed.content.data[1].nonce = ""
+
+        await expect(l2ps.decryptTx(malformed)).rejects.toThrow(
+            /Invalid encrypted payload nonce/,
+        )
+    })
+
+    test("non-12-byte nonce is rejected", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptTx(makeTx())
+
+        const shortIv = JSON.parse(JSON.stringify(enc))
+        shortIv.content.data[1].nonce = forge.util.encode64(
+            forge.random.getBytesSync(5),
+        )
+
+        await expect(l2ps.decryptTx(shortIv)).rejects.toThrow(
+            /Invalid encrypted payload nonce/,
+        )
+    })
+
+    test("missing nonce (legacy payload) still decrypts via the instance IV", async () => {
+        // Simulate a payload encrypted by a pre-fix SDK: no `nonce`
+        // field, content encrypted with the instance IV and no AAD.
+        const sharedKey = forge.random.getBytesSync(32)
+        const sharedIv = forge.random.getBytesSync(12)
+
+        const cipher = forge.cipher.createCipher("AES-GCM", sharedKey)
+        cipher.start({ iv: sharedIv })
+        const tx = makeTx()
+        cipher.update(forge.util.createBuffer(JSON.stringify(tx)))
+        if (!cipher.finish()) throw new Error("test setup: encrypt failed")
+
+        const legacyEnc = {
+            content: {
+                type: "l2psEncryptedTx",
+                from: tx.content.from,
+                to: tx.content.to,
+                from_ed25519_address: tx.content.from_ed25519_address,
+                amount: 0,
+                data: [
+                    "l2psEncryptedTx",
+                    {
+                        l2ps_uid: "legacy-uid",
+                        encrypted_data: forge.util.encode64(
+                            cipher.output.getBytes(),
+                        ),
+                        tag: forge.util.encode64(cipher.mode.tag.getBytes()),
+                        original_hash: tx.hash,
+                        // no `nonce` field — this is the legacy shape
+                    },
+                ],
+                gcr_edits: [],
+                nonce: tx.content.nonce,
+                timestamp: Date.now(),
+                transaction_fee: tx.content.transaction_fee,
+            },
+            ed25519_signature: tx.ed25519_signature,
+            signature: null,
+            hash: "ignored-in-this-test",
+            status: "pending",
+            blockNumber: null,
+        } as any
+
+        const l2ps = await L2PS.create(sharedKey, sharedIv)
+        // Override the auto-generated uid so the payload's l2ps_uid check passes.
+        ;(l2ps as any).id = "legacy-uid"
+        ;(l2ps as any).config = { uid: "legacy-uid" }
+
+        const dec = await l2ps.decryptTx(legacyEnc)
+        expect(dec.hash).toBe(tx.hash)
+    })
+})


### PR DESCRIPTION
## What

The L2PS instance stores a single IV at construction time and every `encryptTx()` call used `cipher.start({ iv: this.iv })`. With a fixed key + fixed IV across multiple plaintexts, AES-GCM loses both **confidentiality** (plaintext XOR leaks across ciphertexts) AND **authentication** (GHASH subkey recovered → forgeries become feasible). This breaks every subnet that anchors more than one transcript.

## Fix

- `encryptTx` generates a fresh 12-byte random nonce per call via `forge.random.getBytesSync(12)`, uses it for `cipher.start`, and embeds it base64-encoded in `L2PSEncryptedPayload.nonce`
- `decryptTx` reads `payload.nonce` when present; falls back to `this.iv` for backward compatibility with ciphertexts written by the old SDK
- `L2PSEncryptedPayload` gains an optional `nonce?: string` field

## Backward compat

- Old ciphertexts (no `payload.nonce`) still decrypt via the legacy `this.iv` path
- New ciphertexts always include `payload.nonce`
- Instance IV is now legacy/fallback only — not used for new encryptions

## Surfaced where

Independent Codex audit pass on [agent-commerce-demo PR #5](https://github.com/kynesyslabs/agent-commerce-demo/pull/5), where the demo's L2PS anchoring path repeatedly called `encryptTx` on the same subnet instance. Audit flagged as **HIGH severity** upstream blocker for any production L2PS use.

## Smoke test result

```
e1 nonce: fM7HPidvD4Hhgzvp...
e2 nonce: IHmyz4i9N+3ARL2E...
nonces differ:     YES ✓
ciphertexts diff:  YES ✓
roundtrip 1:       OK ✓
roundtrip 2:       OK ✓
```

## Release-side note

This needs a version bump + npm publish for downstream consumers (`node`, `agent-commerce-demo`) to pick it up. Client indicated v4.x.x release candidate is the current track — happy to defer the version-bump decision to whoever owns release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted payloads now include a per-encryption random nonce (base64) to strengthen AES‑GCM binding.

* **Bug Fixes**
  * Nonces are strictly validated; tampered, empty, or wrong‑length nonces are rejected. Legacy payloads without a nonce still decrypt via a secure fallback for compatibility.

* **Tests**
  * Added tests for nonce binding, validation, tampering rejection, and legacy fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->