### PR TITLE
fix(deps): remove self-dep + bump 4.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
         "@cryptkeeperzk/snarkjs": "^0.7.2",
-        "@kynesyslabs/demosdk": "^2.8.22",
         "@metaplex-foundation/js": "^0.20.1",
         "@multiversx/sdk-core": "^13.17.2",
         "@multiversx/sdk-extension-provider": "^3.0.0",
@@ -437,8 +436,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.30", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q=="],
-
-    "@kynesyslabs/demosdk": ["@kynesyslabs/demosdk@2.8.22", "", { "dependencies": { "@aptos-labs/ts-sdk": "^1.39.0", "@bitcoinerlab/secp256k1": "^1.2.0", "@cosmjs/proto-signing": "^0.32.4", "@cosmjs/stargate": "^0.32.4", "@cryptkeeperzk/snarkjs": "^0.7.2", "@metaplex-foundation/js": "^0.20.1", "@multiversx/sdk-core": "^13.17.2", "@multiversx/sdk-extension-provider": "^3.0.0", "@multiversx/sdk-network-providers": "^2.9.3", "@multiversx/sdk-wallet": "^4.6.0", "@noble/curves": "1.9.4", "@noble/hashes": "1.8.0", "@noble/post-quantum": "^0.4.1", "@project-serum/anchor": "^0.26.0", "@roamhq/wrtc": "^0.8.0", "@scure/bip39": "^2.0.1", "@simplewebauthn/browser": "^11.0.0", "@simplewebauthn/server": "^11.0.0", "@solana/buffer-layout": "^4.0.1", "@solana/web3.js": "1.98.0", "@ton/core": "^0.62.0", "@ton/crypto": "^3.3.0", "@ton/ton": "^16.0.0", "@types/simple-peer": "^9.11.8", "axios": "^1.11.0", "big-integer": "^1.6.52", "bignumber.js": "^9.3.1", "bip32": "^5.0.0-rc.0", "bip39": "^3.1.0", "bitcoinjs-lib": "^6.1.7", "bitcoinjs-message": "^2.2.0", "bs58": "^5.0.0", "buffer": "^6.0.3", "comlink": "^4.4.2", "dotenv": "^16.6.1", "ecpair": "^3.0.0", "ed25519-hd-key": "^1.3.0", "ethers": "^6.15.0", "falcon-js": "^1.0.0", "falcon-sign": "^1.0.4", "js-sha256": "^0.11.1", "js-sha3": "^0.9.3", "libsodium-wrappers-sumo": "^0.7.15", "lodash": "^4.17.21", "micro-ed25519-hdkey": "^0.1.2", "mlkem": "^2.5.0", "near-api-js": "^4.0.4", "node-forge": "^1.3.1", "node-seal": "^5.1.7", "ntru": "^4.0.4", "poseidon-lite": "^0.3.0", "pqcrypto": "^1.0.1", "protobufjs": "^7.5.4", "ripple-keypairs": "^2.0.0", "rubic-sdk": "^5.57.4", "simple-peer": "^9.11.1", "socket.io-client": "^4.8.1", "sphincs": "^3.0.4", "superdilithium": "^2.0.6", "tlsn-js": "0.1.0-alpha.12.0", "tronweb": "^6.0.0", "web3": "^4.16.0", "xrpl": "^3.1.0" } }, "sha512-VuUpEbsrXnImytiSGuwc7vug25c2mUftvHwU5OUwzslmaoi7MjUHEOSQ+lrH0sL1j5nxBYGeYgeUOJeg88SoPw=="],
 
     "@layerzerolabs/scan-client": ["@layerzerolabs/scan-client@0.0.8", "", { "peerDependencies": { "axios": "*" } }, "sha512-V9vvt9GW0+AHoWXfOSNmZ9WUa28fVBmC93J/f9RLeDMEy5VR8srW2Du5pf1mMAg6ncEL0kQ1xkVCu+X6ARFBtQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kynesyslabs/demosdk",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "type": "module",
     "description": "Demosdk is a JavaScript/TypeScript SDK that provides a unified interface for interacting with Demos network",
     "main": "build/index.js",
@@ -101,7 +101,6 @@
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
         "@cryptkeeperzk/snarkjs": "^0.7.2",
-        "@kynesyslabs/demosdk": "^2.8.22",
         "@metaplex-foundation/js": "^0.20.1",
         "@multiversx/sdk-core": "^13.17.2",
         "@multiversx/sdk-extension-provider": "^3.0.0",


### PR DESCRIPTION
## Problem

\`package.json.dependencies[\"@kynesyslabs/demosdk\"]: \"^2.8.22\"\` declares the package as a dependency of itself. Bun obediently installs a SECOND copy of the SDK alongside the top-level one:

\`\`\`
node_modules/@kynesyslabs/demosdk/                              ← 4.0.0
node_modules/@kynesyslabs/demosdk/node_modules/
                                  @kynesyslabs/demosdk/         ← 2.12.2
\`\`\`

Two copies = any import path resolution that lands on the nested copy sees the OLD API surface. Concretely, the post-fork serializer in 2.12.2 does NOT walk \`gcr_edits[].amount\`, so a downstream node validating a 4.0.0-signed tx through the 2.12.2 code path produces a different canonical hash than the SDK that signed it. Symptom: \`GCREdit mismatch\` on every post-fork transfer, even on a node whose source code is correct.

## Fix

- Remove the self-dep line from \`package.json.dependencies\`.
- \`bun install\` collapses the tree to a single copy (verified: bun.lock now has 1 \`@kynesyslabs/demosdk\` entry instead of nested 2.12.2 + top-level 4.0.0).
- Bump to \`4.0.1\` so the consumer-side \`overrides\` block on the node repo can pin specifically away from broken 4.0.0.

## Downstream

A companion node-repo PR will add:
\`\`\`json
\"overrides\": {
  \"@kynesyslabs/demosdk\": \"4.0.1\"
}
\`\`\`

so the override pins the installed version even if some transitive dep tries to pull a different one in.