### PR TITLE
fix(websdk): broadcastAndWait passes action name as message, not extra (bump 4.0.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kynesyslabs/demosdk",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "type": "module",
     "description": "Demosdk is a JavaScript/TypeScript SDK that provides a unified interface for interacting with Demos network",
     "main": "build/index.js",

--- a/src/websdk/DemosTransactions.ts
+++ b/src/websdk/DemosTransactions.ts
@@ -439,11 +439,20 @@ export const DemosTransactions = {
                 await new Promise(r => setTimeout(r, pollInterval))
             }
 
+            // demos.call signature: (method, message, data, extra). The
+            // node's rpcDispatch routes by `method`, then
+            // manageNodeCall dispatches by `content.message` against
+            // handlerRegistry. The previous version passed
+            // "getTransactionStatus" as `extra` and an empty string as
+            // `message`, so the lookup landed on `handlerRegistry[""]`
+            // → "Unknown message" (HTTP 404) on EVERY poll. The SDK
+            // then never observed `state` and timed out even though
+            // the tx was on chain. Pass the action name as `message`
+            // so the handler resolves.
             const statusRes = await demos.call(
                 "nodeCall",
-                "",
-                { hash: txHash },
                 "getTransactionStatus",
+                { hash: txHash },
             )
 
             // `Demos.call("nodeCall", ...)` normally returns the inner


### PR DESCRIPTION
## Repro

After all node-side fixes landed (snapshot of gcr_edits, OS-magnitude widening, getTransactionStatus handler), `BROADCAST=1 bun transfer_10pct.mjs` on dev.node2 still timed out at the polling stage. Manual curl proved the node was returning the right answer:

```
curl -X POST … -d '{"method":"nodeCall","params":[{"type":"nodeCall","message":"getTransactionStatus","data":{"hash":"…"}}]}'
→ {"result":200,"response":{"state":"included","blockNumber":4}}
```

But `broadcastAndWait`'s polling call wasn't reaching that handler.

## Root cause

`demos.call` signature is `(method, message, data, extra)`. The poll was passing the action name as the FOURTH arg:

```ts
demos.call("nodeCall", "", { hash: txHash }, "getTransactionStatus")
//          method     message  data           extra
```

So `message: ""` and `extra: "getTransactionStatus"`. On the node side, `rpcDispatch` routes by `method` → `manageNodeCall`, which dispatches by `content.message` against `handlerRegistry`. The empty-string lookup misses every registered handler and returns:

```json
{ "result": 404, "response": { "error": "Unknown message", "message": "" } }
```

The poll loop ignored the 404 envelope (no `state` field), kept retrying, and timed out at 60s.

## Fix

Pass the action name as `message`. `extra` is left unset because no nodeCall handler currently reads it.

```ts
demos.call("nodeCall", "getTransactionStatus", { hash: txHash })
```

## Companion

Bumped to 4.0.3 so node-repo consumers pinning via overrides can upgrade without ambiguity. No other API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 4.0.3

* **Bug Fixes**
  * Fixed transaction status polling mechanism to correctly retrieve and observe transaction state during broadcast operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/sdks/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->