### PR TITLE
test(denomination): add networkUpgrade/networkUpgradeVote roundTripHash fixtures

### DIFF
--- a/src/denomination/roundTripHash.test.ts
+++ b/src/denomination/roundTripHash.test.ts
@@ -217,6 +217,129 @@ describe("round-trip hash equality — SDK post-fork == node post-fork", () => {
         expect(parsed.amount).toBe("100")
     })
 
+    test("networkUpgrade content (post-sign canonical shape) round-trips", () => {
+        // Mirrors what `DemosTransactions.proposeNetworkUpgrade()` ships
+        // AFTER `demos.sign()` normalises the content via
+        // `raw_tx.content = JSON.parse(serialized)`. The wire shape that
+        // reaches the node has:
+        //   - top-level `amount` as OS string
+        //   - `transaction_fee.*` as OS strings
+        //   - `gcr_edits[].balance.amount` already canonicalised to OS
+        //     string by the SDK's `transformEditPostFork` walk
+        // Asserts the byte-equality contract holds for governance content
+        // shapes — closes the coverage gap revealed by dev.node2 propose
+        // failures (see kynesyslabs/node@a0957941 battery report).
+        const content: TransactionContent = {
+            type: "networkUpgrade",
+            from: "0xsender",
+            to: "0xsender",
+            amount: "0",
+            data: [
+                "networkUpgrade",
+                {
+                    proposalId: "00000000-0000-0000-0000-000000000001",
+                    proposedParameters: { blockTimeMs: 1100 },
+                    rationale: "smoke",
+                    effectiveAtBlock: 1000,
+                },
+            ] as unknown as TransactionContent["data"],
+            nonce: 1,
+            timestamp: 1_700_000_000_000,
+            transaction_fee: {
+                network_fee: "1000000000",
+                rpc_fee: "1000000000",
+                additional_fee: "0",
+                rpc_address: null,
+            },
+            from_ed25519_address: "0xsender",
+            gcr_edits: [
+                {
+                    type: "networkUpgrade",
+                    isRollback: false,
+                    account: "0xsender",
+                    proposalId: "00000000-0000-0000-0000-000000000001",
+                    proposedParameters: { blockTimeMs: 1100 },
+                    rationale: "smoke",
+                    effectiveAtBlock: 1000,
+                    txhash: "",
+                } as unknown as GCREdit,
+                {
+                    type: "balance",
+                    isRollback: false,
+                    operation: "remove",
+                    account: "0xsender",
+                    amount: "1000000000",
+                    txhash: "",
+                },
+                {
+                    type: "nonce",
+                    isRollback: false,
+                    operation: "add",
+                    account: "0xsender",
+                    amount: 1,
+                    txhash: "",
+                },
+            ],
+        }
+        const sdkBytes = serializeTransactionContent(content, true)
+        const nodeBytes = nodeSerializeTransactionContent(content, true)
+        expect(sdkBytes).toBe(nodeBytes)
+    })
+
+    test("networkUpgradeVote content (post-sign canonical shape) round-trips", () => {
+        const content: TransactionContent = {
+            type: "networkUpgradeVote",
+            from: "0xsender",
+            to: "0xsender",
+            amount: "0",
+            data: [
+                "networkUpgradeVote",
+                {
+                    proposalId: "00000000-0000-0000-0000-000000000001",
+                    approve: true,
+                },
+            ] as unknown as TransactionContent["data"],
+            nonce: 2,
+            timestamp: 1_700_000_000_001,
+            transaction_fee: {
+                network_fee: "1000000000",
+                rpc_fee: "1000000000",
+                additional_fee: "0",
+                rpc_address: null,
+            },
+            from_ed25519_address: "0xsender",
+            gcr_edits: [
+                {
+                    type: "networkUpgradeVote",
+                    isRollback: false,
+                    account: "0xsender",
+                    proposalId: "00000000-0000-0000-0000-000000000001",
+                    approve: true,
+                    txhash: "",
+                } as unknown as GCREdit,
+                {
+                    type: "balance",
+                    isRollback: false,
+                    operation: "remove",
+                    account: "0xsender",
+                    amount: "1000000000",
+                    txhash: "",
+                },
+                {
+                    type: "nonce",
+                    isRollback: false,
+                    operation: "add",
+                    account: "0xsender",
+                    amount: 2,
+                    txhash: "",
+                },
+            ],
+        }
+        const sdkBytes = serializeTransactionContent(content, true)
+        const nodeBytes = nodeSerializeTransactionContent(content, true)
+        expect(sdkBytes).toBe(nodeBytes)
+    })
+
     test("pre-fork branch: SDK and node both stringify content as-is", () => {
         // For pre-fork content with no internal bigints / OS strings,
         // both branches produce `JSON.stringify(content)` verbatim.

--- a/src/denomination/roundTripHash.test.ts
+++ b/src/denomination/roundTripHash.test.ts
@@ -262,7 +262,7 @@ describe("round-trip hash equality — SDK post-fork == node post-fork", () => {
                     rationale: "smoke",
                     effectiveAtBlock: 1000,
                     txhash: "",
-                } as unknown as GCREdit,
+                } satisfies GCREdit,
                 {
                     type: "balance",
                     isRollback: false,
@@ -316,7 +316,7 @@ describe("round-trip hash equality — SDK post-fork == node post-fork", () => {
                     proposalId: "00000000-0000-0000-0000-000000000001",
                     approve: true,
                     txhash: "",
-                } as unknown as GCREdit,
+                } satisfies GCREdit,
                 {
                     type: "balance",
                     isRollback: false,

--- a/src/websdk/BroadcastFailedError.ts
+++ b/src/websdk/BroadcastFailedError.ts
@@ -13,7 +13,7 @@
  */
 export class BroadcastFailedError extends Error {
     public readonly txHash: string
-    public readonly cause: unknown
+    public override readonly cause: unknown
 
     constructor(opts: { txHash: string; cause: unknown; message?: string }) {
         const causeMessage =

--- a/src/websdk/TransportError.ts
+++ b/src/websdk/TransportError.ts
@@ -9,7 +9,7 @@
  */
 export class TransportError extends Error {
     public readonly attempts: number
-    public readonly cause: unknown
+    public override readonly cause: unknown
 
     constructor(message: string, opts: { cause: unknown; attempts: number }) {
         super(message)


### PR DESCRIPTION
## Summary

- Adds two missing fixtures to `src/denomination/roundTripHash.test.ts` covering `networkUpgrade` and `networkUpgradeVote` content shapes — the only canonical-byte-equality test in the SDK had `native`/`balance`/`escrow`/`nonce`/`validatorStake` coverage but no governance shapes.
- Two trivial `override` modifier fixups on `BroadcastFailedError.cause` and `TransportError.cause` so the build passes under TypeScript ≥ 5.6's stricter override checking (currently `release v4.0.3` fails to compile on TS6).

## Context

The gap surfaced while running a deployed-node battery against `dev.node2`. Native pay / stake / unstake confirm cleanly through the SDK↔node boundary; `DemosTransactions.proposeNetworkUpgrade()` hits `[Tx Validation] [SIGNATURE ERROR] Transaction hash mismatch` from the node's `isCoherent` check. The full root-cause is still being chased on the node side (the deployed binary is `dirty=true` so on-host bytes ≠ committed sources), but regardless of which side has the bug, the SDK had no round-trip fixture for governance content. This PR closes that gap so any future drift in the byte shape the SDK ships for `networkUpgrade(Vote)` fails CI before reaching a node.

Both fixtures mirror the post-sign canonical shape — the wire bytes that reach the node after `demos.sign()` normalises content via `raw_tx.content = JSON.parse(serialized)`:

- top-level `amount` as OS string
- `transaction_fee.*` as OS strings
- `gcr_edits[].balance.amount` already canonicalised to OS string by `transformEditPostFork`
- `gcr_edits[].networkUpgrade(Vote)` carries the type-specific edit

## Test plan

- [x] `yarn jest src/denomination/roundTripHash.test.ts` — all 7 tests pass (5 existing + 2 new)
- [x] `yarn build` — compiles cleanly on TS6 with the override fixups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Web SDK error types now properly override the base `cause` property for clearer, more compatible error propagation.

* **Tests**
  * Added tests verifying byte-for-byte post-sign serialization parity between SDK and node serializers for governance transaction types (network upgrade and network upgrade vote).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kynesyslabs/sdks/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->