### PR TITLE
Add domain identity (website ownership) support

### DIFF
--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -15,6 +15,7 @@ import {
     DiscordProof,
     InferFromDiscordPayload,
     InferFromDomainPayload,
+    DomainProof,
     InferFromTelegramPayload,
     TelegramSignedAttestation,
     FindDemosIdByWeb2IdentityQuery,
@@ -107,6 +108,27 @@ export class Identities {
                             payload.context
                         ].join(", ")}`
                     throw new Error(errorMessage)
+                }
+            }
+
+            // The scheme-only format check above cannot enforce a path suffix,
+            // so validate the full domain proof URL shape here: any caller
+            // (e.g. inferWeb2Identity) passing context "domain" must point at
+            // exactly https://<host>/.well-known/demos-cci.txt.
+            if (payload.context === "domain") {
+                let valid = false
+                try {
+                    const u = new URL(payload.proof)
+                    valid =
+                        u.protocol === "https:" &&
+                        u.pathname === "/.well-known/demos-cci.txt"
+                } catch {
+                    valid = false
+                }
+                if (!valid) {
+                    throw new Error(
+                        "Invalid domain proof URL: must be https://<host>/.well-known/demos-cci.txt",
+                    )
                 }
             }
         }
@@ -477,8 +499,7 @@ export class Identities {
         hostname: string,
         referralCode?: string,
     ) {
-        const host = this.normalizeHostname(hostname)
-        const proofUrl = `https://${host}/.well-known/demos-cci.txt`
+        const { proofUrl, hostname: host } = this.buildDomainProof(hostname)
 
         // Fail fast if the well-known file is missing or unparseable, mirroring
         // addTwitterIdentity's pre-fetch via getTweet.
@@ -487,6 +508,21 @@ export class Identities {
             throw new Error(
                 data.error ||
                     `Could not read domain proof at ${proofUrl}`,
+            )
+        }
+        // Assert the success fields exist (mirrors the Twitter/Discord flows
+        // validating their fetched fields) and confirm the node fetched/verified
+        // the same host we are about to store — both derive from the same URL,
+        // so a mismatch means something rewrote the target.
+        if (!data.hostname) {
+            throw new Error("Domain proof response missing verified hostname")
+        }
+        if (!data.body) {
+            throw new Error(`Empty domain proof at ${proofUrl}`)
+        }
+        if (data.hostname.toLowerCase() !== host) {
+            throw new Error(
+                `Verified host "${data.hostname}" does not match requested "${host}"`,
             )
         }
 
@@ -509,7 +545,8 @@ export class Identities {
      * @returns The response from the RPC call.
      */
     async removeDomainIdentity(demos: Demos, hostname: string) {
-        const host = this.normalizeHostname(hostname)
+        // Same canonicalisation as addDomainIdentity so add/remove round-trip.
+        const { hostname: host } = this.buildDomainProof(hostname)
         return await this.removeIdentity(demos, "web2", {
             context: "domain",
             username: host,
@@ -517,21 +554,49 @@ export class Identities {
     }
 
     /**
-     * Normalize a hostname or URL down to its bare hostname.
-     * "https://example.com/foo" -> "example.com"; "example.com/" -> "example.com".
+     * Build the canonical domain proof URL and hostname from a hostname or URL.
+     *
+     * Parses the input with the URL API (which correctly brackets IPv6 literals
+     * in the resulting URL while exposing the bare host via `.hostname`), forces
+     * https + the well-known CCI path, and strips any query/fragment/userinfo.
+     * Throws on anything that does not parse to a real host — no silent fallback.
+     *
+     * @example "https://Example.COM/x?y" -> { proofUrl: "https://example.com/.well-known/demos-cci.txt", hostname: "example.com" }
+     * @example "[::1]" -> { proofUrl: "https://[::1]/.well-known/demos-cci.txt", hostname: "::1" }
      */
-    private normalizeHostname(input: string): string {
+    private buildDomainProof(input: string): {
+        proofUrl: DomainProof
+        hostname: string
+    } {
         const trimmed = input.trim()
+        if (!trimmed) {
+            throw new Error("hostname must not be empty")
+        }
+
+        let url: URL
         try {
-            return new URL(
+            url = new URL(
                 trimmed.includes("://") ? trimmed : `https://${trimmed}`,
-            ).hostname
+            )
         } catch {
-            // Fall back to stripping protocol + path manually.
-            return trimmed
-                .replace(/^[a-z]+:\/\//i, "")
-                .split("/")[0]
-                .split(":")[0]
+            throw new Error(`Invalid hostname: "${input}"`)
+        }
+
+        if (!url.hostname) {
+            throw new Error(`Invalid hostname: "${input}"`)
+        }
+
+        url.protocol = "https:"
+        url.username = ""
+        url.password = ""
+        url.search = ""
+        url.hash = ""
+        url.pathname = "/.well-known/demos-cci.txt"
+
+        // URL already lower-cases the host; toString() brackets IPv6 correctly.
+        return {
+            proofUrl: url.toString() as DomainProof,
+            hostname: url.hostname.toLowerCase(),
         }
     }
 

--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -14,6 +14,7 @@ import {
     PqcIdentityRemovePayload,
     DiscordProof,
     InferFromDiscordPayload,
+    InferFromDomainPayload,
     InferFromTelegramPayload,
     TelegramSignedAttestation,
     FindDemosIdByWeb2IdentityQuery,
@@ -53,6 +54,7 @@ export class Identities {
                 "https://discord.com/channels",
                 "https://ptb.discord.com/channels",
             ],
+            domain: ["https://"],
         },
     }
 
@@ -424,6 +426,113 @@ export class Identities {
         }
 
         return await this.inferIdentity(demos, "web2", telegramPayload)
+    }
+
+    // SECTION: Domain Identities
+
+    /**
+     * Build the proof payload a domain owner must host to prove control.
+     *
+     * Host the returned string at `https://<host>/.well-known/demos-cci.txt`,
+     * then call {@link addDomainIdentity}. The format is identical to the web2
+     * proof payload, so the node verifies it with the same parser.
+     *
+     * @param demos A connected Demos instance.
+     * @returns The proof payload string (`demos:dw2p:<algorithm>:<signature>`).
+     */
+    async createDomainProofPayload(demos: Demos) {
+        return await this.createWeb2ProofPayload(demos)
+    }
+
+    /**
+     * Add a domain identity to the GCR (CCI).
+     *
+     * Proves the connected wallet controls a web domain by pointing at a
+     * well-known file the owner hosts:
+     * `https://<host>/.well-known/demos-cci.txt`. The file body must be the
+     * payload from {@link createDomainProofPayload}. The node fetches the file
+     * over HTTPS (the TLS cert binds the content to the hostname), verifies the
+     * signed payload against the sender, and writes a `web2.domain` entry on
+     * the CCI.
+     *
+     * Mirrors {@link addTwitterIdentity}.
+     *
+     * @param demos A Demos instance to communicate with the RPC.
+     * @param hostname The domain being claimed (e.g. "example.com"). A full
+     *   URL is also accepted; only the hostname is used.
+     * @param referralCode Optional referral code for incentive points.
+     * @returns The response from the RPC call.
+     *
+     * @example
+     * ```typescript
+     * const identities = new Identities()
+     * // 1. Generate the proof the user hosts at /.well-known/demos-cci.txt
+     * const proof = await identities.createDomainProofPayload(demos)
+     * // 2. After the file is live, link the domain:
+     * await identities.addDomainIdentity(demos, "example.com")
+     * ```
+     */
+    async addDomainIdentity(
+        demos: Demos,
+        hostname: string,
+        referralCode?: string,
+    ) {
+        const host = this.normalizeHostname(hostname)
+        const proofUrl = `https://${host}/.well-known/demos-cci.txt`
+
+        // Fail fast if the well-known file is missing or unparseable, mirroring
+        // addTwitterIdentity's pre-fetch via getTweet.
+        const data = await demos.web2.getDomainProof(proofUrl)
+        if (!data.success) {
+            throw new Error(
+                data.error ||
+                    `Could not read domain proof at ${proofUrl}`,
+            )
+        }
+
+        const domainPayload: InferFromDomainPayload = {
+            context: "domain",
+            proof: proofUrl,
+            username: host,
+            userId: host,
+            referralCode: referralCode,
+        }
+
+        return await this.inferIdentity(demos, "web2", domainPayload)
+    }
+
+    /**
+     * Remove a domain identity from the GCR (CCI).
+     *
+     * @param demos A Demos instance to communicate with the RPC.
+     * @param hostname The domain to unlink (e.g. "example.com").
+     * @returns The response from the RPC call.
+     */
+    async removeDomainIdentity(demos: Demos, hostname: string) {
+        const host = this.normalizeHostname(hostname)
+        return await this.removeIdentity(demos, "web2", {
+            context: "domain",
+            username: host,
+        })
+    }
+
+    /**
+     * Normalize a hostname or URL down to its bare hostname.
+     * "https://example.com/foo" -> "example.com"; "example.com/" -> "example.com".
+     */
+    private normalizeHostname(input: string): string {
+        const trimmed = input.trim()
+        try {
+            return new URL(
+                trimmed.includes("://") ? trimmed : `https://${trimmed}`,
+            ).hostname
+        } catch {
+            // Fall back to stripping protocol + path manually.
+            return trimmed
+                .replace(/^[a-z]+:\/\//i, "")
+                .split("/")[0]
+                .split(":")[0]
+        }
     }
 
     // SECTION: PQC Identities

--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -459,9 +459,12 @@ export class Identities {
      * then call {@link addDomainIdentity}. The format is identical to the web2
      * proof payload, so the node verifies it with the same parser.
      *
-     * The signed message is bound to the domain and the signer
-     * (`dw2p:domain:<host>:<ed25519Address>`), so a proof published for one
-     * domain/identity cannot be lifted onto another (node #897).
+     * The signed message is domain-separated and bound to the host + signer
+     * (`dacs-domain:v1:<host>:<ed25519Address>`), so a signature cannot be
+     * lifted across domains, identities, or web2 contexts (node #897 / DEM-767).
+     * NOTE: the exact message shape MUST stay in lockstep with the node's
+     * verifyWeb2Proof reconstruction. Freshness (nonce/issuedAt) is the Tier-2
+     * follow-up tracked in DEM-767.
      *
      * @param demos A connected Demos instance.
      * @param hostname The domain this proof is for (e.g. "example.com"). Must be
@@ -471,9 +474,8 @@ export class Identities {
     async createDomainProofPayload(demos: Demos, hostname: string) {
         const { hostname: host } = this.buildDomainProof(hostname)
         const sender = await demos.getEd25519Address()
-        // Domain-bound message: ties the proof to this host AND this identity,
-        // so it can't be replayed across domains, identities, or web2 contexts.
-        const message = `dw2p:domain:${host}:${sender}`
+        // Domain-separated, host+signer-bound message (must match the node).
+        const message = `dacs-domain:v1:${host}:${sender}`
         const signature = await demos.crypto.sign(
             demos.algorithm,
             new TextEncoder().encode(message),

--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -581,7 +581,7 @@ export class Identities {
      * Throws on anything that does not parse to a real host — no silent fallback.
      *
      * @example "https://Example.COM/x?y" -> { proofUrl: "https://example.com/.well-known/demos-cci.txt", hostname: "example.com" }
-     * @example "[::1]" -> { proofUrl: "https://[::1]/.well-known/demos-cci.txt", hostname: "::1" }
+     * @example "[::1]" -> { proofUrl: "https://[::1]/.well-known/demos-cci.txt", hostname: "[::1]" }
      */
     private buildDomainProof(input: string): {
         proofUrl: DomainProof

--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -459,11 +459,28 @@ export class Identities {
      * then call {@link addDomainIdentity}. The format is identical to the web2
      * proof payload, so the node verifies it with the same parser.
      *
+     * The signed message is bound to the domain and the signer
+     * (`dw2p:domain:<host>:<ed25519Address>`), so a proof published for one
+     * domain/identity cannot be lifted onto another (node #897).
+     *
      * @param demos A connected Demos instance.
+     * @param hostname The domain this proof is for (e.g. "example.com"). Must be
+     *   the same domain later passed to {@link addDomainIdentity}.
      * @returns The proof payload string (`demos:dw2p:<algorithm>:<signature>`).
      */
-    async createDomainProofPayload(demos: Demos) {
-        return await this.createWeb2ProofPayload(demos)
+    async createDomainProofPayload(demos: Demos, hostname: string) {
+        const { hostname: host } = this.buildDomainProof(hostname)
+        const sender = await demos.getEd25519Address()
+        // Domain-bound message: ties the proof to this host AND this identity,
+        // so it can't be replayed across domains, identities, or web2 contexts.
+        const message = `dw2p:domain:${host}:${sender}`
+        const signature = await demos.crypto.sign(
+            demos.algorithm,
+            new TextEncoder().encode(message),
+        )
+        return `demos:dw2p:${demos.algorithm}:${uint8ArrayToHex(
+            signature.signature,
+        )}`
     }
 
     /**

--- a/src/tests/abstraction/identities.domain.spec.ts
+++ b/src/tests/abstraction/identities.domain.spec.ts
@@ -153,8 +153,9 @@ describe("Domain Identities (offline SDK logic)", () => {
             error: "404 not found",
         })
 
+        // Assert the underlying fetch-failure reason surfaces, not just "some error".
         await expect(
             identities.addDomainIdentity(demos, "missing.com"),
-        ).rejects.toThrow()
+        ).rejects.toThrow(/404 not found/)
     })
 })

--- a/src/tests/abstraction/identities.domain.spec.ts
+++ b/src/tests/abstraction/identities.domain.spec.ts
@@ -1,0 +1,94 @@
+import { Demos } from "@/websdk"
+import { Identities } from "@/abstraction"
+
+const MNEMONIC =
+    "polar scale globe beauty stock employ rail exercise goat into sample embark"
+
+const hexToBytes = (h: string) => {
+    const clean = h.replace(/^0x/, "")
+    return new Uint8Array((clean.match(/.{1,2}/g) ?? []).map(b => parseInt(b, 16)))
+}
+
+describe("Domain Identities (offline SDK logic)", () => {
+    const demos = new Demos()
+    const identities = new Identities()
+
+    beforeAll(async () => {
+        await demos.connectWallet(MNEMONIC) // local crypto only, no node
+    })
+
+    test("createDomainProofPayload returns a validly-signed web2 proof", async () => {
+        const payload = await identities.createDomainProofPayload(demos)
+        const parts = payload.split(":")
+
+        expect(parts).toHaveLength(4)
+        expect(parts[0]).toBe("demos")
+        expect(parts[1]).toBe("dw2p")
+        expect(parts[2]).toBe("ed25519")
+
+        const { publicKey } = await demos.crypto.getIdentity("ed25519")
+        const sigValid = await demos.crypto.verify({
+            algorithm: "ed25519",
+            message: new TextEncoder().encode("dw2p"),
+            signature: hexToBytes(parts[3]),
+            publicKey: publicKey as Uint8Array,
+        } as any)
+
+        expect(sigValid).toBe(true)
+    })
+
+    test("normalizeHostname reduces URLs/hosts to bare hostname", () => {
+        const norm = (input: string): string =>
+            (identities as any).normalizeHostname(input)
+
+        expect(norm("https://example.com/foo")).toBe("example.com")
+        expect(norm("example.com/")).toBe("example.com")
+        expect(norm("http://sub.example.com:8443/x")).toBe("sub.example.com")
+        expect(norm("  example.com  ")).toBe("example.com")
+        expect(norm("example.com")).toBe("example.com")
+    })
+
+    test("addDomainIdentity builds the correct web2/domain request", async () => {
+        const payload = await identities.createDomainProofPayload(demos)
+
+        let proofUrlSeen: string | null = null
+        let signedTx: any = null
+        ;(demos.web2 as any).getDomainProof = async (url: string) => {
+            proofUrlSeen = url
+            return { success: true, hostname: "example.com", body: payload }
+        }
+        ;(demos as any).sign = async (tx: any) => {
+            signedTx = tx
+            return tx
+        }
+        ;(demos as any).confirm = async () => ({ result: 200, response: {} })
+
+        await identities.addDomainIdentity(demos, "https://example.com/some/page")
+
+        expect(proofUrlSeen).toBe(
+            "https://example.com/.well-known/demos-cci.txt",
+        )
+
+        const data = signedTx.content.data
+        expect(data[0]).toBe("identity")
+        expect(data[1].context).toBe("web2")
+        expect(data[1].method).toBe("web2_identity_assign")
+
+        const p = data[1].payload
+        expect(p.context).toBe("domain")
+        expect(p.proof).toBe("https://example.com/.well-known/demos-cci.txt")
+        expect(p.username).toBe("example.com")
+        expect(p.userId).toBe("example.com")
+    })
+
+    test("addDomainIdentity throws a clear error when the file is unreadable", async () => {
+        ;(demos.web2 as any).getDomainProof = async () => ({
+            success: false,
+            error: "404 not found",
+        })
+
+        await expect(
+            identities.addDomainIdentity(demos, "missing.com"),
+        ).rejects.toThrow()
+    })
+})

--- a/src/tests/abstraction/identities.domain.spec.ts
+++ b/src/tests/abstraction/identities.domain.spec.ts
@@ -17,8 +17,8 @@ describe("Domain Identities (offline SDK logic)", () => {
         await demos.connectWallet(MNEMONIC) // local crypto only, no node
     })
 
-    test("createDomainProofPayload returns a validly-signed web2 proof", async () => {
-        const payload = await identities.createDomainProofPayload(demos)
+    test("createDomainProofPayload signs a host+sender-bound message", async () => {
+        const payload = await identities.createDomainProofPayload(demos, "example.com")
         const parts = payload.split(":")
 
         expect(parts).toHaveLength(4)
@@ -26,15 +26,41 @@ describe("Domain Identities (offline SDK logic)", () => {
         expect(parts[1]).toBe("dw2p")
         expect(parts[2]).toBe("ed25519")
 
+        const sender = await demos.getEd25519Address()
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
-        const sigValid = await demos.crypto.verify({
+
+        // Verifies against the bound message (host + sender)...
+        const boundValid = await demos.crypto.verify({
+            algorithm: "ed25519",
+            message: new TextEncoder().encode(`dw2p:domain:example.com:${sender}`),
+            signature: hexToBytes(parts[3]),
+            publicKey: publicKey as Uint8Array,
+        } as any)
+        expect(boundValid).toBe(true)
+
+        // ...and NOT against the bare "dw2p" (the old, unbound format).
+        const bareValid = await demos.crypto.verify({
             algorithm: "ed25519",
             message: new TextEncoder().encode("dw2p"),
             signature: hexToBytes(parts[3]),
             publicKey: publicKey as Uint8Array,
         } as any)
+        expect(bareValid).toBe(false)
+    })
 
-        expect(sigValid).toBe(true)
+    test("domain proof does not verify for a different host (no cross-domain replay)", async () => {
+        const payload = await identities.createDomainProofPayload(demos, "example.com")
+        const sig = hexToBytes(payload.split(":")[3])
+        const sender = await demos.getEd25519Address()
+        const { publicKey } = await demos.crypto.getIdentity("ed25519")
+
+        const liftedToOtherHost = await demos.crypto.verify({
+            algorithm: "ed25519",
+            message: new TextEncoder().encode(`dw2p:domain:evil.com:${sender}`),
+            signature: sig,
+            publicKey: publicKey as Uint8Array,
+        } as any)
+        expect(liftedToOtherHost).toBe(false)
     })
 
     test("buildDomainProof canonicalizes host + URL (incl. IPv6 bracketing)", () => {
@@ -77,7 +103,7 @@ describe("Domain Identities (offline SDK logic)", () => {
     })
 
     test("addDomainIdentity builds the correct web2/domain request", async () => {
-        const payload = await identities.createDomainProofPayload(demos)
+        const payload = await identities.createDomainProofPayload(demos, "example.com")
 
         let proofUrlSeen: string | null = null
         let signedTx: any = null

--- a/src/tests/abstraction/identities.domain.spec.ts
+++ b/src/tests/abstraction/identities.domain.spec.ts
@@ -32,7 +32,7 @@ describe("Domain Identities (offline SDK logic)", () => {
         // Verifies against the bound message (host + sender)...
         const boundValid = await demos.crypto.verify({
             algorithm: "ed25519",
-            message: new TextEncoder().encode(`dw2p:domain:example.com:${sender}`),
+            message: new TextEncoder().encode(`dacs-domain:v1:example.com:${sender}`),
             signature: hexToBytes(parts[3]),
             publicKey: publicKey as Uint8Array,
         } as any)
@@ -56,7 +56,7 @@ describe("Domain Identities (offline SDK logic)", () => {
 
         const liftedToOtherHost = await demos.crypto.verify({
             algorithm: "ed25519",
-            message: new TextEncoder().encode(`dw2p:domain:evil.com:${sender}`),
+            message: new TextEncoder().encode(`dacs-domain:v1:evil.com:${sender}`),
             signature: sig,
             publicKey: publicKey as Uint8Array,
         } as any)

--- a/src/tests/abstraction/identities.domain.spec.ts
+++ b/src/tests/abstraction/identities.domain.spec.ts
@@ -37,15 +37,43 @@ describe("Domain Identities (offline SDK logic)", () => {
         expect(sigValid).toBe(true)
     })
 
-    test("normalizeHostname reduces URLs/hosts to bare hostname", () => {
-        const norm = (input: string): string =>
-            (identities as any).normalizeHostname(input)
+    test("buildDomainProof canonicalizes host + URL (incl. IPv6 bracketing)", () => {
+        const build = (input: string): { proofUrl: string; hostname: string } =>
+            (identities as any).buildDomainProof(input)
 
-        expect(norm("https://example.com/foo")).toBe("example.com")
-        expect(norm("example.com/")).toBe("example.com")
-        expect(norm("http://sub.example.com:8443/x")).toBe("sub.example.com")
-        expect(norm("  example.com  ")).toBe("example.com")
-        expect(norm("example.com")).toBe("example.com")
+        const PATH = "/.well-known/demos-cci.txt"
+
+        expect(build("https://example.com/foo")).toEqual({
+            proofUrl: `https://example.com${PATH}`,
+            hostname: "example.com",
+        })
+        expect(build("Example.COM")).toEqual({
+            proofUrl: `https://example.com${PATH}`,
+            hostname: "example.com",
+        })
+        expect(build("  sub.example.com  ")).toEqual({
+            proofUrl: `https://sub.example.com${PATH}`,
+            hostname: "sub.example.com",
+        })
+        // query/fragment stripped
+        expect(build("https://example.com/x?a=1#f").proofUrl).toBe(
+            `https://example.com${PATH}`,
+        )
+        // IPv6: URL keeps the brackets, producing a valid (not "https://::1/")
+        // proof URL, and the stored host stays consistent with it.
+        expect(build("https://[::1]/x")).toEqual({
+            proofUrl: `https://[::1]${PATH}`,
+            hostname: "[::1]",
+        })
+    })
+
+    test("buildDomainProof rejects empty / degenerate inputs", () => {
+        const build = (input: string) =>
+            (identities as any).buildDomainProof(input)
+
+        expect(() => build("")).toThrow()
+        expect(() => build("   ")).toThrow()
+        expect(() => build("://")).toThrow()
     })
 
     test("addDomainIdentity builds the correct web2/domain request", async () => {
@@ -79,6 +107,18 @@ describe("Domain Identities (offline SDK logic)", () => {
         expect(p.proof).toBe("https://example.com/.well-known/demos-cci.txt")
         expect(p.username).toBe("example.com")
         expect(p.userId).toBe("example.com")
+    })
+
+    test("inferWeb2Identity rejects a domain proof URL with the wrong path", async () => {
+        // A caller bypassing addDomainIdentity must still hit the path check.
+        await expect(
+            identities.inferWeb2Identity(demos, {
+                context: "domain",
+                proof: "https://evil.com/malicious",
+                username: "evil.com",
+                userId: "evil.com",
+            } as any),
+        ).rejects.toThrow(/domain proof URL/i)
     })
 
     test("addDomainIdentity throws a clear error when the file is unreadable", async () => {

--- a/src/types/abstraction/index.ts
+++ b/src/types/abstraction/index.ts
@@ -113,7 +113,7 @@ export type DomainProof = `https://${string}/.well-known/demos-cci.txt`
 
 export interface InferFromDomainPayload extends Web2CoreTargetIdentityPayload {
     context: "domain"
-    proof: string
+    proof: DomainProof
     /** The hostname being claimed (e.g. "example.com"). */
     username: string
     /** Domains have no separate numeric id; mirrors `username`. */

--- a/src/types/abstraction/index.ts
+++ b/src/types/abstraction/index.ts
@@ -102,6 +102,24 @@ export interface InferFromGithubPayload extends Web2CoreTargetIdentityPayload {
     proof: GithubProof
 }
 
+// ANCHOR Domain Identities
+/**
+ * A domain proof is the HTTPS URL of the well-known file the domain owner
+ * hosts to prove control:  https://<host>/.well-known/demos-cci.txt
+ * The file body is the standard web2 proof payload produced by
+ * Identities.createDomainProofPayload (i.e. `demos:dw2p:<algorithm>:<signature>`).
+ */
+export type DomainProof = `https://${string}/.well-known/demos-cci.txt`
+
+export interface InferFromDomainPayload extends Web2CoreTargetIdentityPayload {
+    context: "domain"
+    proof: string
+    /** The hostname being claimed (e.g. "example.com"). */
+    username: string
+    /** Domains have no separate numeric id; mirrors `username`. */
+    userId: string
+}
+
 // ANCHOR X Identities (aka Twitter Identities)
 export type XProof = `https://x.com/${string}/${string}` // TODO Better scope for X posts
 export type TwitterProof = XProof
@@ -178,6 +196,7 @@ export interface Web2IdentityAssignPayload extends BaseWeb2IdentityPayload {
         | InferFromTwitterPayload
         | InferFromTelegramPayload
         | InferFromDiscordPayload
+        | InferFromDomainPayload
 }
 
 export interface Web2IdentityRemovePayload extends BaseWeb2IdentityPayload {
@@ -554,7 +573,7 @@ export interface UserPoints {
 
 export interface FindDemosIdByWeb2IdentityQuery {
     type: "web2"
-    context: "twitter" | "telegram" | "github" | "discord"
+    context: "twitter" | "telegram" | "github" | "discord" | "domain"
     username: string
     userId?: string
 }

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -1674,6 +1674,27 @@ export class Demos {
                 discordUrl,
             })
         },
+        /**
+         * Fetch a domain ownership proof file over HTTPS.
+         *
+         * Retrieves `https://<host>/.well-known/demos-cci.txt` and returns its
+         * body plus the verified hostname. Used by
+         * `Identities.addDomainIdentity` to prove control of a web domain.
+         *
+         * @param url The full proof URL (https://<host>/.well-known/demos-cci.txt).
+         */
+        getDomainProof: async (
+            url: string,
+        ): Promise<{
+            success: boolean
+            hostname?: string
+            body?: string
+            error?: string
+        }> => {
+            return await this.nodeCall("getDomainProof", {
+                url,
+            })
+        },
     }
 
     // REVIEW: Phase 9 - IPFS cost estimation endpoints


### PR DESCRIPTION
Adds the SDK side of website-ownership identity (addDomainIdentity).

A user hosts a wallet-signed proof at https://<host>/.well-known/demos-cci.txt and calls addDomainIdentity(demos, hostname); the domain is then linked to their CCI as a web2.domain attestation. Reuses the existing web2 proof format, so the node verifies it with the same parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added domain-based Web2 identity linking/verification for “web2.domain” using hosted proof files.
  * Introduced domain proof payload creation, plus add/remove domain identity operations with stricter HTTPS and canonical hostname normalization.
  * Added a Web2 SDK helper to fetch domain proofs used during verification.

* **Tests**
  * Added Jest coverage for payload format and signature validation, cross-domain replay protection, hostname/proof canonicalization (including IPv6), and add/remove identity flows (including error handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->