### PR TITLE
fix(d402): @example amount uses 10^18 (ETH) but Demos OS_PER_DEM is 10^9

### DIFF
--- a/src/d402/server/middleware.ts
+++ b/src/d402/server/middleware.ts
@@ -49,7 +49,7 @@ export interface D402Request {
  * ```typescript
  * app.get('/premium-article',
  *   d402Required({
- *     amount: 5000000000000000000, // 5 DEM in smallest unit
+ *     amount: 5000000000, // 5 DEM in smallest unit (OS); OS_PER_DEM = 10^9
  *     resourceId: 'article-123',
  *     rpcUrl: 'https://node2.demos.sh',
  *     recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb'

--- a/src/d402/server/middleware.ts
+++ b/src/d402/server/middleware.ts
@@ -49,7 +49,7 @@ export interface D402Request {
  * ```typescript
  * app.get('/premium-article',
  *   d402Required({
- *     amount: 5000000000, // 5 DEM in smallest unit (OS); OS_PER_DEM = 10^9
+ *     amount: '5000000000', // 5 DEM in OS (string = OS path; a bare number is treated as DEM and ×10^9). OS_PER_DEM = 10^9
  *     resourceId: 'article-123',
  *     rpcUrl: 'https://node2.demos.sh',
  *     recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb'


### PR DESCRIPTION
**Problem.** `src/d402/server/middleware.ts` `@example` sets `amount: 5000000000000000000 // 5 DEM in smallest unit` — that's 5×10^18, an 18-decimal (ETH-style) assumption. Per the 3.0.0-rc.1 `osDenomination` migration Demos uses **9 decimals**: `OS_PER_DEM = 10^9` (`denomination.demToOs(1) === 1_000_000_000n`). So 5 DEM in the smallest unit (OS) is `5_000_000_000`, not `5×10^18`. A builder copying this `d402Required` example would over-charge by 10^9×.

**Section & path.** `src/d402/server/middleware.ts` (the `d402Required` JSDoc `@example`).

**Fix.** `amount: 5000000000, // 5 DEM in smallest unit (OS); OS_PER_DEM = 10^9`.

One implementer's read from the PATH-OS Labs DACS reference-impl pass — happy to adjust the wording.