### PR TITLE
docs(readme): show preferred bigint-OS transfer amount (3.0.0-rc.1 migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ console.log("Wallet address:", address)
 // Send native DEM tokens
 const tx = await demos.transfer(
   "0x6690580a02d2da2fefa86e414e92a1146ad5357fd71d594cc561776576857ac5",
-  100 // amount in DEM
+  100_000_000_000n // 100 DEM as OS bigint (preferred since 3.0.0-rc.1; OS_PER_DEM = 10^9). A `number` is still accepted as legacy DEM.
 )
 
 // Confirm and broadcast transaction

--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ console.log("Wallet address:", address)
 
 ```typescript
 // Send native DEM tokens
+import { denomination } from "@kynesyslabs/demosdk"
+
 const tx = await demos.transfer(
   "0x6690580a02d2da2fefa86e414e92a1146ad5357fd71d594cc561776576857ac5",
-  100_000_000_000n // 100 DEM as OS bigint (preferred since 3.0.0-rc.1; OS_PER_DEM = 10^9). A `number` is still accepted as legacy DEM.
+  denomination.demToOs(100) // 100 DEM -> OS bigint via the SDK helper (preferred since 3.0.0-rc.1; OS_PER_DEM = 10^9). A bare `number` is still accepted as legacy DEM.
 )
 
 // Confirm and broadcast transaction


### PR DESCRIPTION
**Context.** The README Quick Start “Native Transaction Example” uses `demos.transfer(to, 100 // amount in DEM)`. Per CHANGELOG 3.0.0-rc.1, `Demos.transfer` accepts `bigint` (OS, **preferred**) or `number` (DEM, legacy). The number-DEM form still works, but new builders following the README land on the legacy path.

**Section & path.** `README.md` — Quick Start › Native Transaction Example.

**Suggestion.** Show the preferred bigint-OS form (`100_000_000_000n` = 100 DEM × `OS_PER_DEM` 10^9), noting a `number` is still accepted as legacy DEM. Keeps the canonical example aligned with the migration guide. Open to whatever framing you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Native Transaction Example to demonstrate the proper usage of the SDK's denomination helper function when performing transfer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->