### PR TITLE
feat(l2ps): SR-4 SDK delivery — CCI binding, channel envelope, encryp…

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
         "./tlsnotary/service": "./build/tlsnotary/service.js",
         "./tlsnotary/webpack": "./build/tlsnotary/webpack.js",
         "./tlsnotary/auto-init": "./build/tlsnotary/auto-init.js",
-        "./tlsnotary/wasm/*": "./build/tlsnotary/wasm/*"
+        "./tlsnotary/wasm/*": "./build/tlsnotary/wasm/*",
+        "./identity": "./build/identity/index.js",
+        "./identity/cci": "./build/identity/cci/index.js"
     },
     "scripts": {
         "postinstall": "cp .github/hooks/pre-commit .git/hooks/pre-commit 2>/dev/null && chmod +x .git/hooks/pre-commit 2>/dev/null || true",

--- a/src/identity/cci/claim.ts
+++ b/src/identity/cci/claim.ts
@@ -1,0 +1,57 @@
+import type { ClaimReference, ClaimScheme, ParsedClaimRef } from "./types"
+
+export function parseClaimRef(ref: ClaimReference): ParsedClaimRef {
+    if (typeof ref !== "string") {
+        throw new TypeError(`parseClaimRef: expected string, got ${typeof ref}`)
+    }
+    const colon = ref.indexOf(":")
+    if (colon < 1 || colon === ref.length - 1) {
+        throw new Error(
+            `parseClaimRef: malformed ClaimReference "${ref}" (expected "<scheme>:<identifier>")`,
+        )
+    }
+    return {
+        scheme: ref.slice(0, colon) as ClaimScheme,
+        identifier: ref.slice(colon + 1),
+    }
+}
+
+export function demosClaimRefForAddress(address: string): ClaimReference {
+    const normalized = normalizeDemosAddress(address)
+    return `demos:${normalized}` as ClaimReference
+}
+
+export function isDemosClaim(ref: ClaimReference): boolean {
+    try {
+        return parseClaimRef(ref).scheme === "demos"
+    } catch {
+        return false
+    }
+}
+
+export function normalizeDemosAddress(address: string): string {
+    const a = address.startsWith("0x") || address.startsWith("0X")
+        ? address.slice(2)
+        : address
+    if (!/^[0-9a-fA-F]+$/.test(a)) {
+        throw new Error(
+            `normalizeDemosAddress: not a hex string: "${address}"`,
+        )
+    }
+    if (a.length !== 64) {
+        throw new Error(
+            `normalizeDemosAddress: expected 32-byte (64-hex) Ed25519 address, got ${a.length} hex chars`,
+        )
+    }
+    return "0x" + a.toLowerCase()
+}
+
+export function demosAddressFromClaim(ref: ClaimReference): string {
+    const { scheme, identifier } = parseClaimRef(ref)
+    if (scheme !== "demos") {
+        throw new Error(
+            `demosAddressFromClaim: claim scheme "${scheme}" is not "demos"`,
+        )
+    }
+    return normalizeDemosAddress(identifier)
+}

--- a/src/identity/cci/claim.ts
+++ b/src/identity/cci/claim.ts
@@ -1,5 +1,14 @@
 import type { ClaimReference, ClaimScheme, ParsedClaimRef } from "./types"
 
+/**
+ * Split a `ClaimReference` into its scheme and identifier components.
+ *
+ * @param ref - `"<scheme>:<identifier>"` string.
+ * @returns The parsed scheme/identifier pair.
+ * @throws {TypeError} If `ref` is not a string.
+ * @throws {Error}     If `ref` is missing the colon, has an empty scheme,
+ *                     or has an empty identifier.
+ */
 export function parseClaimRef(ref: ClaimReference): ParsedClaimRef {
     if (typeof ref !== "string") {
         throw new TypeError(`parseClaimRef: expected string, got ${typeof ref}`)
@@ -16,11 +25,23 @@ export function parseClaimRef(ref: ClaimReference): ParsedClaimRef {
     }
 }
 
+/**
+ * Build the canonical `demos:<address>` ClaimReference for a Demos
+ * Ed25519 address. The address is lowercased and 0x-prefixed.
+ *
+ * @param address - Hex Ed25519 address, with or without `0x` prefix.
+ * @returns       A `demos:0x...` ClaimReference.
+ * @throws {Error} If `address` is not 64-hex (32-byte).
+ */
 export function demosClaimRefForAddress(address: string): ClaimReference {
     const normalized = normalizeDemosAddress(address)
     return `demos:${normalized}` as ClaimReference
 }
 
+/**
+ * Test whether a ClaimReference parses and has the `demos` scheme.
+ * Safe for arbitrary input — never throws.
+ */
 export function isDemosClaim(ref: ClaimReference): boolean {
     try {
         return parseClaimRef(ref).scheme === "demos"
@@ -29,6 +50,16 @@ export function isDemosClaim(ref: ClaimReference): boolean {
     }
 }
 
+/**
+ * Normalise a Demos Ed25519 address into the canonical lowercase
+ * `0x`-prefixed form. The Demos node accepts both forms; we settle on one
+ * so comparisons (`claimAddress !== connected`) are deterministic.
+ *
+ * @param address - Hex address, with or without `0x` prefix.
+ * @returns       Lowercase `0x`-prefixed 64-hex string.
+ * @throws {Error} If the input is not hex or is the wrong length for an
+ *                 Ed25519 public key (32 bytes = 64 hex chars).
+ */
 export function normalizeDemosAddress(address: string): string {
     const a = address.startsWith("0x") || address.startsWith("0X")
         ? address.slice(2)
@@ -46,6 +77,16 @@ export function normalizeDemosAddress(address: string): string {
     return "0x" + a.toLowerCase()
 }
 
+/**
+ * Extract the normalised Demos Ed25519 address embedded in a `demos:`
+ * ClaimReference. Refuses non-demos schemes — see `parseClaimRef` for the
+ * scheme-agnostic parse.
+ *
+ * @param ref - A `demos:0x...` ClaimReference.
+ * @returns   Lowercase `0x`-prefixed Ed25519 address.
+ * @throws {Error} If the scheme is not `demos` or the identifier is not
+ *                 a valid Ed25519 address.
+ */
 export function demosAddressFromClaim(ref: ClaimReference): string {
     const { scheme, identifier } = parseClaimRef(ref)
     if (scheme !== "demos") {

--- a/src/identity/cci/index.ts
+++ b/src/identity/cci/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Cross-Context Identity (CCI) — primary-claim binding for DACS-3 SR-4.
+ *
+ * Public surface used by L2PS membership binding (WI-1), ChannelMessage
+ * envelope signing (WI-2), and encrypted-transcript anchoring (WI-3).
+ *
+ * Brief: `docs/l2ps-sr4-implementation-brief.md` in the node repo.
+ */
+
+export type { ClaimReference, ClaimScheme, ParsedClaimRef } from "./types"
+
+export {
+    demosClaimRefForAddress,
+    demosAddressFromClaim,
+    isDemosClaim,
+    normalizeDemosAddress,
+    parseClaimRef,
+} from "./claim"
+
+export {
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+} from "./signing"

--- a/src/identity/cci/signing.ts
+++ b/src/identity/cci/signing.ts
@@ -82,7 +82,7 @@ function hexAddressToBytes(address: string): Uint8Array {
     const hex = address.startsWith("0x") ? address.slice(2) : address
     const out = new Uint8Array(hex.length / 2)
     for (let i = 0; i < hex.length; i += 2) {
-        out[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+        out[i / 2] = Number.parseInt(hex.slice(i, i + 2), 16)
     }
     return out
 }

--- a/src/identity/cci/signing.ts
+++ b/src/identity/cci/signing.ts
@@ -1,0 +1,93 @@
+import { Cryptography } from "@/encryption/Cryptography"
+import { Demos } from "@/websdk/demosclass"
+import type { ClaimReference } from "./types"
+import {
+    demosAddressFromClaim,
+    normalizeDemosAddress,
+    parseClaimRef,
+} from "./claim"
+
+/**
+ * Sign a payload with the key controlling a CCI primary claim.
+ *
+ * The brief invariant (DACS-3 §0 / §8.3.2): in-channel signatures MUST be
+ * produced by the key that controls the sender's primary claim — the same
+ * key that holds value on-chain. On Demos that is the Demos Ed25519 key,
+ * NOT the RSA L2PS subnet key.
+ *
+ * Domain separation is the caller's responsibility — pass the full payload
+ * including the `dacs-*:v1:` prefix. WI-0 stays scheme-agnostic.
+ */
+export async function signWithPrimaryClaim(
+    claim: ClaimReference,
+    payload: Uint8Array,
+    demos: Demos,
+): Promise<Uint8Array> {
+    const { scheme } = parseClaimRef(claim)
+    if (scheme !== "demos") {
+        throw new Error(
+            `signWithPrimaryClaim: unsupported scheme "${scheme}". Only "demos" is currently supported.`,
+        )
+    }
+    if (!demos.walletConnected) {
+        throw new Error("signWithPrimaryClaim: Demos wallet not connected")
+    }
+
+    const claimAddress = demosAddressFromClaim(claim)
+    const connected = normalizeDemosAddress(await demos.getEd25519Address())
+    if (claimAddress !== connected) {
+        throw new Error(
+            `signWithPrimaryClaim: claim "${claim}" does not match connected Demos wallet ${connected}`,
+        )
+    }
+
+    const signed = await demos.crypto.sign("ed25519", payload)
+    return toUint8Array(signed.signature as ArrayLike<number>)
+}
+
+/**
+ * Verify an Ed25519 signature produced by `signWithPrimaryClaim`.
+ *
+ * Recovers the public key from the claim identifier and verifies forge-style.
+ * Caller-supplied payload must match the bytes that were signed (including
+ * any `dacs-*:v1:` domain prefix).
+ */
+export function verifyPrimaryClaimSignature(
+    claim: ClaimReference,
+    payload: Uint8Array,
+    signature: Uint8Array,
+): boolean {
+    const { scheme } = parseClaimRef(claim)
+    if (scheme !== "demos") {
+        throw new Error(
+            `verifyPrimaryClaimSignature: unsupported scheme "${scheme}"`,
+        )
+    }
+
+    const publicKey = hexAddressToBytes(demosAddressFromClaim(claim))
+    if (publicKey.length !== 32) {
+        throw new Error(
+            `verifyPrimaryClaimSignature: expected 32-byte Ed25519 public key, got ${publicKey.length}`,
+        )
+    }
+
+    return Cryptography.verify(
+        new TextDecoder().decode(payload),
+        Buffer.from(signature),
+        Buffer.from(publicKey),
+    )
+}
+
+function hexAddressToBytes(address: string): Uint8Array {
+    const hex = address.startsWith("0x") ? address.slice(2) : address
+    const out = new Uint8Array(hex.length / 2)
+    for (let i = 0; i < hex.length; i += 2) {
+        out[i / 2] = parseInt(hex.slice(i, i + 2), 16)
+    }
+    return out
+}
+
+function toUint8Array(buf: ArrayLike<number>): Uint8Array {
+    if (buf instanceof Uint8Array) return buf
+    return Uint8Array.from(buf)
+}

--- a/src/identity/cci/signing.ts
+++ b/src/identity/cci/signing.ts
@@ -17,6 +17,19 @@ import {
  *
  * Domain separation is the caller's responsibility — pass the full payload
  * including the `dacs-*:v1:` prefix. WI-0 stays scheme-agnostic.
+ *
+ * @param claim   - The signer's primary `demos:` ClaimReference. Refuses any
+ *                  other scheme until a controlling-key resolver for them
+ *                  is added.
+ * @param payload - Pre-domain-separated bytes to cover. Caller composes
+ *                  `dacs-*:v1: || canonical_hash`.
+ * @param demos   - Connected `Demos` instance. Its Ed25519 address must
+ *                  match `claim`'s identifier — otherwise we refuse to
+ *                  produce a misattributable signature.
+ * @returns       Raw 64-byte Ed25519 signature.
+ * @throws {Error} If the scheme is not `demos`, the wallet is not
+ *                 connected, or the connected address does not match the
+ *                 claim's address.
  */
 export async function signWithPrimaryClaim(
     claim: ClaimReference,
@@ -51,6 +64,15 @@ export async function signWithPrimaryClaim(
  * Recovers the public key from the claim identifier and verifies forge-style.
  * Caller-supplied payload must match the bytes that were signed (including
  * any `dacs-*:v1:` domain prefix).
+ *
+ * @param claim     - The claimed signer's `demos:` ClaimReference.
+ * @param payload   - Exact bytes that were signed (must roundtrip through
+ *                    UTF-8). Caller composes `dacs-*:v1: || hash`.
+ * @param signature - Raw 64-byte Ed25519 signature.
+ * @returns        `true` iff the signature verifies under the public key
+ *                 encoded in `claim`; `false` for cryptographic mismatch.
+ * @throws {Error} If the scheme is not `demos` or the recovered public
+ *                 key is not 32 bytes (malformed claim).
  */
 export function verifyPrimaryClaimSignature(
     claim: ClaimReference,

--- a/src/identity/cci/types.ts
+++ b/src/identity/cci/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Cross-Context Identity (CCI) — type definitions.
+ *
+ * A ClaimReference is the label that names an identity across substrates.
+ * It is NOT a key; the key controlling the claim signs in-channel messages.
+ * See `docs/l2ps-sr4-implementation-brief.md` §0 in the node repo for the
+ * full claim-vs-key distinction.
+ */
+
+export type ClaimScheme = "demos" | (string & {})
+
+export type ClaimReference = `${string}:${string}`
+
+export interface ParsedClaimRef {
+    scheme: ClaimScheme
+    identifier: string
+}

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -1,0 +1,2 @@
+export * as humanpassport from "./humanpassport"
+export * as cci from "./cci"

--- a/src/l2ps/anchor/anchor.ts
+++ b/src/l2ps/anchor/anchor.ts
@@ -18,11 +18,11 @@ import type {
     UnsignedChannelTranscript,
 } from "../channel/types"
 import {
-    signatureFromHex,
-    signatureToHex,
     stripTranscriptSignatures,
     transcriptSigningBytes,
 } from "../channel/canonical"
+import { verifyTranscript } from "../channel/transcript"
+import { bytesToHex, signatureFromHex, signatureToHex } from "../utils/hex"
 import type {
     AnchoredTranscriptPayload,
     AttestationRef,
@@ -169,11 +169,19 @@ export interface DecryptAnchoredTranscriptOpts {
 }
 
 /**
- * Fetch + decrypt + verify the original transcript. Throws if:
- *   - SP not found / not the expected shape
- *   - ciphertext hash does not match the stored contentHash (tamper)
+ * Fetch + decrypt + fully verify the original transcript. Throws on the
+ * first failure of any of:
+ *   - SP not found / wrong shape / unknown transcriptVersion
+ *   - ciphertext hash does not match the stored `contentHash` (tamper)
  *   - AES-GCM auth fails (= caller's L2PS instance is not a subnet member)
- *   - transcript-plaintext signature does not verify under `signer`
+ *   - decrypted `channelId` does not match the anchor's `channelId`
+ *   - anchor-party transcript signature is invalid
+ *   - any embedded ChannelMessage signature, sequence, sender ∈ members,
+ *     or per-message channelId check fails (delegated to `verifyTranscript`)
+ *
+ * The return value is therefore a transcript every property of which has
+ * been validated end-to-end; callers do not need to run `verifyTranscript`
+ * again afterwards.
  */
 export async function decryptAnchoredTranscript(
     opts: DecryptAnchoredTranscriptOpts,
@@ -219,7 +227,20 @@ export async function decryptAnchoredTranscript(
             "decryptAnchoredTranscript: transcript signature verification failed",
         )
 
-    return { ...transcript, signatures: [payload.signature] }
+    const fullTranscript: ChannelTranscript = {
+        ...transcript,
+        signatures: [payload.signature],
+    }
+
+    // Run the audit verifier on the assembled transcript so the caller's
+    // return value is end-to-end validated, not just the anchor wrapper.
+    const audit = verifyTranscript(fullTranscript)
+    if (!audit.ok)
+        throw new Error(
+            `decryptAnchoredTranscript: transcript audit failed — ${audit.errors.join("; ")}`,
+        )
+
+    return fullTranscript
 }
 
 export interface VerifyAnchorIntegrityResult {
@@ -273,14 +294,6 @@ export async function verifyAnchorIntegrity(opts: {
     }
 
     return { ok: errors.length === 0, errors }
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-    let out = ""
-    for (let i = 0; i < bytes.length; i++) {
-        out += bytes[i].toString(16).padStart(2, "0")
-    }
-    return out
 }
 
 function base64ToBytes(b64: string): Uint8Array {

--- a/src/l2ps/anchor/anchor.ts
+++ b/src/l2ps/anchor/anchor.ts
@@ -190,7 +190,7 @@ export async function decryptAnchoredTranscript(
         opts.rpcUrl,
         opts.storageAddress,
     )
-    if (!sp || !sp.data || typeof sp.data !== "object")
+    if (!sp?.data || typeof sp.data !== "object")
         throw new Error(
             `decryptAnchoredTranscript: no storage program at ${opts.storageAddress}`,
         )
@@ -263,7 +263,7 @@ export async function verifyAnchorIntegrity(opts: {
         opts.rpcUrl,
         opts.storageAddress,
     )
-    if (!sp || !sp.data || typeof sp.data !== "object") {
+    if (!sp?.data || typeof sp.data !== "object") {
         errors.push(`no storage program at ${opts.storageAddress}`)
         return { ok: false, errors }
     }

--- a/src/l2ps/anchor/anchor.ts
+++ b/src/l2ps/anchor/anchor.ts
@@ -1,0 +1,289 @@
+import { sha256 } from "@noble/hashes/sha2"
+import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import {
+    demosAddressFromClaim,
+    isDemosClaim,
+    normalizeDemosAddress,
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+    type ClaimReference,
+} from "@/identity/cci"
+import { Demos } from "@/websdk/demosclass"
+import { DemosTransactions } from "@/websdk/DemosTransactions"
+import { StorageProgram } from "@/storage/StorageProgram"
+import type { Transaction } from "@/types"
+import L2PS from "../l2ps"
+import type {
+    ChannelTranscript,
+    UnsignedChannelTranscript,
+} from "../channel/types"
+import {
+    signatureFromHex,
+    signatureToHex,
+    stripTranscriptSignatures,
+    transcriptSigningBytes,
+} from "../channel/canonical"
+import type {
+    AnchoredTranscriptPayload,
+    AttestationRef,
+    TranscriptDisclosurePolicy,
+} from "./types"
+
+/**
+ * Deterministic per-channel Storage Program name. One anchor per
+ * channelId; a redo of the same channel reuses the slot (the SP's
+ * `mode: "owner"` ACL guarantees only the original signer can overwrite).
+ */
+export function anchorProgramName(channelId: string): string {
+    return `l2ps-transcript:${channelId}`
+}
+
+export interface AnchorEncryptedTranscriptOpts {
+    transcript: ChannelTranscript
+    /** Provides the AES-GCM key for encrypt-to-member-set. */
+    l2ps: L2PS
+    demos: Demos
+    /** Must be a member of `transcript.members` and match the connected Demos wallet. */
+    signer: ClaimReference
+    policy: TranscriptDisclosurePolicy
+    /** Required to actually anchor when `policy === "encrypted-anchored-recommended"`. */
+    consent?: boolean
+}
+
+/**
+ * §8.7 anchor entrypoint.
+ *
+ * - `none`             → throws (caller should not have invoked this).
+ * - `recommended`      → only anchors when `consent === true`; otherwise returns `null`.
+ * - `required`         → always anchors; broadcast failures propagate so the
+ *                        caller's phase can fail per §8.7.
+ *
+ * On success returns `{ anchor: storageAddress, contentHash }`. The SP is
+ * deployed via SR-2 with `mode: "public"` (anyone can read the ciphertext
+ * + the hash for tamper-evidence; only the owner can overwrite).
+ */
+export async function anchorEncryptedTranscript(
+    opts: AnchorEncryptedTranscriptOpts,
+): Promise<AttestationRef | null> {
+    if (opts.policy === "none") {
+        throw new Error(
+            "anchorEncryptedTranscript: policy is 'none' — do not call this helper",
+        )
+    }
+    if (
+        opts.policy === "encrypted-anchored-recommended" &&
+        opts.consent !== true
+    ) {
+        return null
+    }
+    if (!isDemosClaim(opts.signer)) {
+        throw new Error(
+            `anchorEncryptedTranscript: signer must be a demos: ClaimReference, got "${opts.signer}"`,
+        )
+    }
+    if (!opts.transcript.members.includes(opts.signer)) {
+        throw new Error(
+            `anchorEncryptedTranscript: signer "${opts.signer}" is not in transcript.members`,
+        )
+    }
+    const signerAddress = demosAddressFromClaim(opts.signer)
+    const connected = normalizeDemosAddress(await opts.demos.getEd25519Address())
+    if (signerAddress !== connected) {
+        throw new Error(
+            `anchorEncryptedTranscript: signer "${opts.signer}" does not match connected wallet ${connected}`,
+        )
+    }
+
+    const unsignedView = stripTranscriptSignatures(opts.transcript)
+    const plaintextBytes = new TextEncoder().encode(
+        canonicalJSONStringify(unsignedView),
+    )
+
+    const encrypted = await opts.l2ps.encryptBytes(plaintextBytes)
+    const contentHash = bytesToHex(
+        sha256(base64ToBytes(encrypted.ciphertext)),
+    )
+
+    const sigBytes = await signWithPrimaryClaim(
+        opts.signer,
+        transcriptSigningBytes(unsignedView),
+        opts.demos,
+    )
+
+    const payload: AnchoredTranscriptPayload = {
+        transcriptVersion: "1",
+        channelId: opts.transcript.channelId,
+        encrypted,
+        contentHash,
+        signature: {
+            sigVersion: "1",
+            signer: opts.signer,
+            signature: signatureToHex(sigBytes),
+        },
+    }
+
+    const storageAddress = await deployAnchorSP(
+        opts.demos,
+        anchorProgramName(opts.transcript.channelId),
+        payload,
+    )
+
+    return { anchor: storageAddress, contentHash }
+}
+
+async function deployAnchorSP(
+    demos: Demos,
+    programName: string,
+    payload: AnchoredTranscriptPayload,
+): Promise<string> {
+    const deployer = normalizeDemosAddress(await demos.getEd25519Address())
+    const nonce = (await demos.getAddressNonce(deployer)) + 1
+    const spPayload = StorageProgram.createStorageProgram(
+        deployer,
+        programName,
+        payload as unknown as Record<string, unknown>,
+        "json",
+        { mode: "public" },
+        { nonce },
+    )
+
+    const tx = DemosTransactions.empty() as Transaction
+    tx.content.to = spPayload.storageAddress
+    tx.content.nonce = nonce
+    tx.content.amount = 0
+    tx.content.type = "storageProgram"
+    tx.content.timestamp = Date.now()
+    tx.content.data = ["storageProgram", spPayload] as any
+
+    const signed = await demos.sign(tx)
+    const validity = await demos.confirm(signed)
+    await demos.broadcast(validity)
+
+    return spPayload.storageAddress
+}
+
+export interface DecryptAnchoredTranscriptOpts {
+    rpcUrl: string
+    storageAddress: string
+    l2ps: L2PS
+}
+
+/**
+ * Fetch + decrypt + verify the original transcript. Throws if:
+ *   - SP not found / not the expected shape
+ *   - ciphertext hash does not match the stored contentHash (tamper)
+ *   - AES-GCM auth fails (= caller's L2PS instance is not a subnet member)
+ *   - transcript-plaintext signature does not verify under `signer`
+ */
+export async function decryptAnchoredTranscript(
+    opts: DecryptAnchoredTranscriptOpts,
+): Promise<ChannelTranscript> {
+    const sp = await StorageProgram.getByAddress(
+        opts.rpcUrl,
+        opts.storageAddress,
+    )
+    if (!sp || !sp.data || typeof sp.data !== "object")
+        throw new Error(
+            `decryptAnchoredTranscript: no storage program at ${opts.storageAddress}`,
+        )
+
+    const payload = sp.data as unknown as AnchoredTranscriptPayload
+    if (payload.transcriptVersion !== "1")
+        throw new Error("decryptAnchoredTranscript: unknown transcriptVersion")
+
+    const ctHash = bytesToHex(
+        sha256(base64ToBytes(payload.encrypted.ciphertext)),
+    )
+    if (ctHash !== payload.contentHash)
+        throw new Error(
+            "decryptAnchoredTranscript: ciphertext hash does not match stored contentHash (tamper)",
+        )
+
+    const plaintext = await opts.l2ps.decryptBytes(payload.encrypted)
+    const transcript = JSON.parse(
+        new TextDecoder().decode(plaintext),
+    ) as UnsignedChannelTranscript
+
+    if (transcript.channelId !== payload.channelId)
+        throw new Error(
+            "decryptAnchoredTranscript: decrypted channelId does not match anchor channelId",
+        )
+
+    const sigOk = verifyPrimaryClaimSignature(
+        payload.signature.signer,
+        transcriptSigningBytes(transcript),
+        signatureFromHex(payload.signature.signature),
+    )
+    if (!sigOk)
+        throw new Error(
+            "decryptAnchoredTranscript: transcript signature verification failed",
+        )
+
+    return { ...transcript, signatures: [payload.signature] }
+}
+
+export interface VerifyAnchorIntegrityResult {
+    ok: boolean
+    errors: string[]
+}
+
+/**
+ * Public tamper-check that needs no decryption keys. Hashes the on-chain
+ * ciphertext and compares with the stored `contentHash`; also asserts
+ * `channelId` lines up and the SP owner matches the embedded signer's
+ * address. Useful for auditors / non-members.
+ */
+export async function verifyAnchorIntegrity(opts: {
+    rpcUrl: string
+    storageAddress: string
+}): Promise<VerifyAnchorIntegrityResult> {
+    const errors: string[] = []
+    const sp = await StorageProgram.getByAddress(
+        opts.rpcUrl,
+        opts.storageAddress,
+    )
+    if (!sp || !sp.data || typeof sp.data !== "object") {
+        errors.push(`no storage program at ${opts.storageAddress}`)
+        return { ok: false, errors }
+    }
+    const payload = sp.data as unknown as AnchoredTranscriptPayload
+    if (payload.transcriptVersion !== "1")
+        errors.push(`unknown transcriptVersion ${payload.transcriptVersion}`)
+
+    try {
+        const hash = bytesToHex(
+            sha256(base64ToBytes(payload.encrypted.ciphertext)),
+        )
+        if (hash !== payload.contentHash)
+            errors.push("ciphertext hash does not match stored contentHash")
+    } catch (e) {
+        errors.push(`hash check failed: ${(e as Error).message}`)
+    }
+
+    try {
+        const signerAddress = demosAddressFromClaim(payload.signature.signer)
+        if (normalizeDemosAddress(sp.owner) !== signerAddress)
+            errors.push(
+                `storage program owner ${sp.owner} does not match signer claim ${payload.signature.signer}`,
+            )
+    } catch (e) {
+        errors.push(
+            `signer claim address check failed: ${(e as Error).message}`,
+        )
+    }
+
+    return { ok: errors.length === 0, errors }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    let out = ""
+    for (let i = 0; i < bytes.length; i++) {
+        out += bytes[i].toString(16).padStart(2, "0")
+    }
+    return out
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+    const bin = Buffer.from(b64, "base64")
+    return new Uint8Array(bin.buffer, bin.byteOffset, bin.byteLength)
+}

--- a/src/l2ps/anchor/anchor.ts
+++ b/src/l2ps/anchor/anchor.ts
@@ -33,9 +33,12 @@ import type {
  * Deterministic per-channel Storage Program name. One anchor per
  * channelId; a redo of the same channel reuses the slot (the SP's
  * `mode: "owner"` ACL guarantees only the original signer can overwrite).
+ *
+ * @param channelId - Per-session `channelId` (matches `ChannelTranscript.channelId`).
+ * @returns         The SR-2 program name used by `anchorEncryptedTranscript`.
  */
 export function anchorProgramName(channelId: string): string {
-    return `l2ps-transcript:${channelId}`
+    return `l2ps-transcript:${encodeURIComponent(channelId)}`
 }
 
 export interface AnchorEncryptedTranscriptOpts {
@@ -51,16 +54,28 @@ export interface AnchorEncryptedTranscriptOpts {
 }
 
 /**
- * §8.7 anchor entrypoint.
+ * §8.7 anchor entrypoint. Encrypts a `ChannelTranscript` to the L2PS
+ * member set, anchors the ciphertext via SR-2, and signs the plaintext
+ * hash with the connected Demos key.
  *
- * - `none`             → throws (caller should not have invoked this).
- * - `recommended`      → only anchors when `consent === true`; otherwise returns `null`.
- * - `required`         → always anchors; broadcast failures propagate so the
- *                        caller's phase can fail per §8.7.
+ * Policy behaviour:
+ * - `none`            → throws (caller should not have invoked this).
+ * - `recommended`     → only anchors when `consent === true`; otherwise returns `null`.
+ * - `required`        → always anchors; broadcast failures propagate so
+ *                       the caller's phase can fail per §8.7.
  *
- * On success returns `{ anchor: storageAddress, contentHash }`. The SP is
- * deployed via SR-2 with `mode: "public"` (anyone can read the ciphertext
- * + the hash for tamper-evidence; only the owner can overwrite).
+ * The SP is deployed via SR-2 with `mode: "public"` (anyone reads the
+ * ciphertext + the public content hash for tamper-evidence; only the
+ * owner can overwrite).
+ *
+ * @param opts - Transcript + L2PS instance (for the AES-GCM key) +
+ *               connected Demos (for the signing key + broadcast) +
+ *               signer claim + policy/consent.
+ * @returns   `{ anchor, contentHash }` on success, `null` only when the
+ *            recommended policy is in effect and consent is missing.
+ * @throws {Error} On `policy === "none"`, non-demos signer, non-member
+ *                 signer, signer-wallet mismatch, or broadcast failure
+ *                 under `required` policy.
  */
 export async function anchorEncryptedTranscript(
     opts: AnchorEncryptedTranscriptOpts,
@@ -169,19 +184,21 @@ export interface DecryptAnchoredTranscriptOpts {
 }
 
 /**
- * Fetch + decrypt + fully verify the original transcript. Throws on the
- * first failure of any of:
+ * Fetch + decrypt + fully verify the original transcript.
+ *
+ * @param opts - RPC URL + Storage Program address + L2PS instance (caller
+ *               must be a subnet member; otherwise AES-GCM auth fails).
+ * @returns   A `ChannelTranscript` whose every component has been
+ *            validated end-to-end — callers do not need to run
+ *            `verifyTranscript` again.
+ * @throws {Error} On the first of:
  *   - SP not found / wrong shape / unknown transcriptVersion
  *   - ciphertext hash does not match the stored `contentHash` (tamper)
  *   - AES-GCM auth fails (= caller's L2PS instance is not a subnet member)
  *   - decrypted `channelId` does not match the anchor's `channelId`
  *   - anchor-party transcript signature is invalid
  *   - any embedded ChannelMessage signature, sequence, sender ∈ members,
- *     or per-message channelId check fails (delegated to `verifyTranscript`)
- *
- * The return value is therefore a transcript every property of which has
- * been validated end-to-end; callers do not need to run `verifyTranscript`
- * again afterwards.
+ *     or per-message channelId check fails (delegated to `verifyTranscript`).
  */
 export async function decryptAnchoredTranscript(
     opts: DecryptAnchoredTranscriptOpts,
@@ -250,9 +267,14 @@ export interface VerifyAnchorIntegrityResult {
 
 /**
  * Public tamper-check that needs no decryption keys. Hashes the on-chain
- * ciphertext and compares with the stored `contentHash`; also asserts
- * `channelId` lines up and the SP owner matches the embedded signer's
- * address. Useful for auditors / non-members.
+ * ciphertext and compares with the stored `contentHash`; also asserts the
+ * SP owner address matches the embedded signer's CCI claim. Useful for
+ * auditors and non-members verifying an anchor without subnet access.
+ *
+ * @param opts - RPC URL + Storage Program address.
+ * @returns   `{ ok, errors }` — `ok` only when every public check passes;
+ *            `errors` contains every failure (collected in one pass so
+ *            auditors see the full picture, not the first failure).
  */
 export async function verifyAnchorIntegrity(opts: {
     rpcUrl: string

--- a/src/l2ps/anchor/index.ts
+++ b/src/l2ps/anchor/index.ts
@@ -1,0 +1,25 @@
+/**
+ * DACS-3 §8.7 — encrypted transcript anchoring (SR-4 WI-3).
+ *
+ * Encrypts a `ChannelTranscript` to the subnet member set via the
+ * existing L2PS AES-GCM key, anchors the ciphertext + public content hash
+ * via SR-2 Storage Program, and signs the transcript-plaintext hash with
+ * the caller's Demos key.
+ */
+
+export {
+    anchorEncryptedTranscript,
+    anchorProgramName,
+    decryptAnchoredTranscript,
+    verifyAnchorIntegrity,
+    type AnchorEncryptedTranscriptOpts,
+    type DecryptAnchoredTranscriptOpts,
+    type VerifyAnchorIntegrityResult,
+} from "./anchor"
+
+export type {
+    AnchoredTranscriptPayload,
+    AnchoredTranscriptSignature,
+    AttestationRef,
+    TranscriptDisclosurePolicy,
+} from "./types"

--- a/src/l2ps/anchor/types.ts
+++ b/src/l2ps/anchor/types.ts
@@ -1,0 +1,43 @@
+import type { ClaimReference } from "@/identity/cci"
+import type { L2PSEncryptedBytes } from "../l2ps"
+
+/**
+ * §8.7 disclosure policy values. Naming verbatim from the brief.
+ */
+export type TranscriptDisclosurePolicy =
+    | "none"
+    | "encrypted-anchored-recommended"
+    | "encrypted-anchored-required"
+
+/**
+ * The reference the negotiate-* phase output carries (brief §2 WI-3 step 4):
+ * a Storage Program address + a hex content hash that anyone can re-derive
+ * by hashing the on-chain ciphertext.
+ */
+export interface AttestationRef {
+    anchor: string
+    contentHash: string
+}
+
+/**
+ * Signature over the transcript-plaintext hash, written verbatim into the
+ * Storage Program so members can re-verify after decryption.
+ */
+export interface AnchoredTranscriptSignature {
+    sigVersion: "1"
+    signer: ClaimReference
+    signature: string
+}
+
+/**
+ * Wire shape stored inside the Storage Program. Self-contained so a
+ * verifier can run `verifyAnchorIntegrity` without prior context.
+ */
+export interface AnchoredTranscriptPayload {
+    transcriptVersion: "1"
+    channelId: string
+    encrypted: L2PSEncryptedBytes
+    /** Hex sha256 of the decoded ciphertext bytes — public tamper-evidence. */
+    contentHash: string
+    signature: AnchoredTranscriptSignature
+}

--- a/src/l2ps/binding/binding.ts
+++ b/src/l2ps/binding/binding.ts
@@ -1,0 +1,216 @@
+import {
+    demosAddressFromClaim,
+    isDemosClaim,
+    normalizeDemosAddress,
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+    type ClaimReference,
+} from "@/identity/cci"
+import { Demos } from "@/websdk/demosclass"
+import { DemosTransactions } from "@/websdk/DemosTransactions"
+import { StorageProgram } from "@/storage/StorageProgram"
+import type { Transaction } from "@/types"
+import type {
+    L2PSMembershipBinding,
+    UnsignedL2PSMembershipBinding,
+} from "./types"
+import {
+    bindingSigningBytes,
+    signatureFromHex,
+    signatureToHex,
+    stripBindingSignature,
+} from "./canonical"
+import L2PS from "../l2ps"
+
+/**
+ * Deterministic Storage Program name for `(channelId, subnetMemberId)`.
+ * Public so `resolveMember` can re-derive it; included verbatim in tests.
+ */
+export function bindingProgramName(
+    channelId: string,
+    subnetMemberId: string,
+): string {
+    return `l2ps-binding:${channelId}:${subnetMemberId}`
+}
+
+/**
+ * Brief calls subnetMemberId "the member's L2PS/RSA identity within the
+ * subnet". L2PS already publishes a stable fingerprint of the RSA key —
+ * we reuse that so the value is derivable on both sides without a separate
+ * registry.
+ */
+export async function subnetMemberIdFromL2PS(l2ps: L2PS): Promise<string> {
+    return await l2ps.getKeyFingerprint()
+}
+
+export interface CreateMembershipBindingOpts {
+    channelId: string
+    subnetMemberId: string
+    claim: ClaimReference
+    demos: Demos
+    /** Defaults to Date.now(). Useful for deterministic test fixtures. */
+    boundAt?: number
+}
+
+/**
+ * Build and sign a binding. The signature is produced by the key
+ * controlling `claim`. Throws if `claim`'s scheme is not `demos:` or if
+ * the controlling address does not match the connected wallet — the
+ * invariant that ties channel signatures to on-chain identity.
+ */
+export async function createMembershipBinding(
+    opts: CreateMembershipBindingOpts,
+): Promise<L2PSMembershipBinding> {
+    const { channelId, subnetMemberId, claim, demos } = opts
+    if (!channelId) throw new Error("createMembershipBinding: channelId required")
+    if (!subnetMemberId)
+        throw new Error("createMembershipBinding: subnetMemberId required")
+    if (!isDemosClaim(claim))
+        throw new Error(
+            `createMembershipBinding: claim must be a "demos:..." ClaimReference, got "${claim}"`,
+        )
+
+    const unsigned: UnsignedL2PSMembershipBinding = {
+        bindingVersion: "1",
+        channelId,
+        subnetMemberId,
+        cciPrimaryClaim: claim,
+        boundAt: opts.boundAt ?? Date.now(),
+    }
+
+    const payload = bindingSigningBytes(unsigned)
+    const sig = await signWithPrimaryClaim(claim, payload, demos)
+
+    return { ...unsigned, signature: signatureToHex(sig) }
+}
+
+/**
+ * Pure signature check — no chain access. Verifies the embedded signature
+ * against the Demos public key encoded in `cciPrimaryClaim`.
+ *
+ * Returns `false` (not throws) on any structural problem so callers can
+ * use it as a filter when iterating SP candidates in `resolveMember`.
+ */
+export function verifyMembershipBinding(
+    binding: L2PSMembershipBinding,
+): boolean {
+    if (!binding || binding.bindingVersion !== "1") return false
+    if (!binding.channelId || !binding.subnetMemberId) return false
+    if (!isDemosClaim(binding.cciPrimaryClaim)) return false
+    if (typeof binding.signature !== "string" || !binding.signature)
+        return false
+
+    try {
+        const payload = bindingSigningBytes(stripBindingSignature(binding))
+        const sig = signatureFromHex(binding.signature)
+        return verifyPrimaryClaimSignature(
+            binding.cciPrimaryClaim,
+            payload,
+            sig,
+        )
+    } catch {
+        return false
+    }
+}
+
+export interface AnchorMembershipBindingResult {
+    storageAddress: string
+    txHash: string
+}
+
+/**
+ * Anchor a signed binding to chain via SR-2 (Storage Program). The SP is
+ * deployed under `bindingProgramName(...)` so `resolveMember` can find it
+ * by name. The deployer (= connected Demos wallet) becomes the SP owner;
+ * that owner check is what makes the resolver safe against impostor SPs
+ * published under the same name.
+ *
+ * Returns once the broadcast succeeds. Callers that need on-chain finality
+ * should poll the returned tx hash before opening the channel.
+ */
+export async function anchorMembershipBinding(
+    binding: L2PSMembershipBinding,
+    demos: Demos,
+): Promise<AnchorMembershipBindingResult> {
+    if (!verifyMembershipBinding(binding))
+        throw new Error(
+            "anchorMembershipBinding: refusing to anchor an unverifiable binding",
+        )
+
+    const claimAddress = demosAddressFromClaim(binding.cciPrimaryClaim)
+    const connected = normalizeDemosAddress(await demos.getEd25519Address())
+    if (claimAddress !== connected)
+        throw new Error(
+            `anchorMembershipBinding: claim "${binding.cciPrimaryClaim}" does not match connected wallet ${connected}`,
+        )
+
+    const nonce = (await demos.getAddressNonce(connected)) + 1
+    const payload = StorageProgram.createStorageProgram(
+        connected,
+        bindingProgramName(binding.channelId, binding.subnetMemberId),
+        binding as unknown as Record<string, unknown>,
+        "json",
+        { mode: "public" },
+        { nonce },
+    )
+
+    const tx = DemosTransactions.empty() as Transaction
+    tx.content.to = payload.storageAddress
+    tx.content.nonce = nonce
+    tx.content.amount = 0
+    tx.content.type = "storageProgram"
+    tx.content.timestamp = Date.now()
+    tx.content.data = ["storageProgram", payload] as any
+
+    const signed = await demos.sign(tx)
+    const validity = await demos.confirm(signed)
+    await demos.broadcast(validity)
+
+    return { storageAddress: payload.storageAddress, txHash: signed.hash }
+}
+
+/**
+ * Find the bound `ClaimReference` for `(channelId, subnetMemberId)`.
+ *
+ * Two-stage check on every candidate Storage Program:
+ *   1. Embedded signature verifies under the embedded claim's key.
+ *   2. SP owner's Demos address matches that claim's address — so only
+ *      the actual key-holder could have deployed this SP under this name.
+ *
+ * Both checks must pass. Returns `null` when no candidate qualifies.
+ * Membership is fixed for channel lifetime (CH-1) so callers SHOULD cache
+ * the result for the session.
+ */
+export async function resolveMember(
+    channelId: string,
+    subnetMemberId: string,
+    rpcUrl: string,
+): Promise<ClaimReference | null> {
+    const name = bindingProgramName(channelId, subnetMemberId)
+    const list = await StorageProgram.searchByName(rpcUrl, name, {
+        exactMatch: true,
+    })
+
+    for (const item of list) {
+        const sp = await StorageProgram.getByAddress(rpcUrl, item.storageAddress)
+        if (!sp || sp.encoding !== "json" || !sp.data) continue
+        if (typeof sp.data !== "object") continue
+
+        const binding = sp.data as unknown as L2PSMembershipBinding
+        if (binding.channelId !== channelId) continue
+        if (binding.subnetMemberId !== subnetMemberId) continue
+        if (!verifyMembershipBinding(binding)) continue
+
+        let claimAddress: string
+        try {
+            claimAddress = demosAddressFromClaim(binding.cciPrimaryClaim)
+        } catch {
+            continue
+        }
+        if (normalizeDemosAddress(sp.owner) !== claimAddress) continue
+
+        return binding.cciPrimaryClaim
+    }
+
+    return null
+}

--- a/src/l2ps/binding/binding.ts
+++ b/src/l2ps/binding/binding.ts
@@ -25,12 +25,19 @@ import L2PS from "../l2ps"
 /**
  * Deterministic Storage Program name for `(channelId, subnetMemberId)`.
  * Public so `resolveMember` can re-derive it; included verbatim in tests.
+ *
+ * Components are percent-encoded so the layout stays one-to-one. Without
+ * this guard, the pairs `("a:b", "c")` and `("a", "b:c")` would collide on
+ * the same SP name and `resolveMember` could be tricked into returning a
+ * binding from one channel/member context for a lookup of another.
  */
 export function bindingProgramName(
     channelId: string,
     subnetMemberId: string,
 ): string {
-    return `l2ps-binding:${channelId}:${subnetMemberId}`
+    return `l2ps-binding:${encodeURIComponent(channelId)}:${encodeURIComponent(
+        subnetMemberId,
+    )}`
 }
 
 /**
@@ -70,12 +77,18 @@ export async function createMembershipBinding(
             `createMembershipBinding: claim must be a "demos:..." ClaimReference, got "${claim}"`,
         )
 
+    const boundAt = opts.boundAt ?? Date.now()
+    if (!Number.isSafeInteger(boundAt) || boundAt < 0)
+        throw new Error(
+            "createMembershipBinding: boundAt must be a non-negative safe-integer unix-ms timestamp",
+        )
+
     const unsigned: UnsignedL2PSMembershipBinding = {
         bindingVersion: "1",
         channelId,
         subnetMemberId,
         cciPrimaryClaim: claim,
-        boundAt: opts.boundAt ?? Date.now(),
+        boundAt,
     }
 
     const payload = bindingSigningBytes(unsigned)
@@ -97,6 +110,11 @@ export function verifyMembershipBinding(
     if (binding?.bindingVersion !== "1") return false
     if (!binding.channelId || !binding.subnetMemberId) return false
     if (!isDemosClaim(binding.cciPrimaryClaim)) return false
+    if (
+        !Number.isSafeInteger(binding.boundAt) ||
+        (binding.boundAt as number) < 0
+    )
+        return false
     if (typeof binding.signature !== "string" || !binding.signature)
         return false
 

--- a/src/l2ps/binding/binding.ts
+++ b/src/l2ps/binding/binding.ts
@@ -94,7 +94,7 @@ export async function createMembershipBinding(
 export function verifyMembershipBinding(
     binding: L2PSMembershipBinding,
 ): boolean {
-    if (!binding || binding.bindingVersion !== "1") return false
+    if (binding?.bindingVersion !== "1") return false
     if (!binding.channelId || !binding.subnetMemberId) return false
     if (!isDemosClaim(binding.cciPrimaryClaim)) return false
     if (typeof binding.signature !== "string" || !binding.signature)
@@ -193,7 +193,7 @@ export async function resolveMember(
 
     for (const item of list) {
         const sp = await StorageProgram.getByAddress(rpcUrl, item.storageAddress)
-        if (!sp || sp.encoding !== "json" || !sp.data) continue
+        if (sp?.encoding !== "json" || !sp.data) continue
         if (typeof sp.data !== "object") continue
 
         const binding = sp.data as unknown as L2PSMembershipBinding

--- a/src/l2ps/binding/binding.ts
+++ b/src/l2ps/binding/binding.ts
@@ -201,13 +201,17 @@ export async function resolveMember(
         if (binding.subnetMemberId !== subnetMemberId) continue
         if (!verifyMembershipBinding(binding)) continue
 
-        let claimAddress: string
+        // Both parses are inside the same try so a single adversarially-
+        // crafted candidate (malformed claim ref OR malformed sp.owner)
+        // gets skipped instead of aborting the whole resolution loop —
+        // otherwise a squatter publishing a poisoned binding under our
+        // deterministic name could deny-of-service every consumer.
         try {
-            claimAddress = demosAddressFromClaim(binding.cciPrimaryClaim)
+            const claimAddress = demosAddressFromClaim(binding.cciPrimaryClaim)
+            if (normalizeDemosAddress(sp.owner) !== claimAddress) continue
         } catch {
             continue
         }
-        if (normalizeDemosAddress(sp.owner) !== claimAddress) continue
 
         return binding.cciPrimaryClaim
     }

--- a/src/l2ps/binding/canonical.ts
+++ b/src/l2ps/binding/canonical.ts
@@ -1,0 +1,60 @@
+import { sha256 } from "@noble/hashes/sha2"
+import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import type {
+    L2PSMembershipBinding,
+    UnsignedL2PSMembershipBinding,
+} from "./types"
+
+/**
+ * Domain prefix for binding signatures. The brief specifies prefixes for
+ * channelmsg and transcript but not for the binding itself; per §5 of the
+ * brief, all signatures in this family must be domain-separated, so we
+ * align with the established `dacs-*:v1:` pattern.
+ */
+export const BINDING_DOMAIN_PREFIX = "dacs-binding:v1:"
+
+/**
+ * Bytes that the binding signature covers:
+ *   `dacs-binding:v1:` || sha256(JCS(binding_without_signature))
+ *
+ * Domain separation prevents this signature from being lifted into a
+ * channelmsg or transcript context (or vice versa).
+ */
+export function bindingSigningBytes(
+    unsigned: UnsignedL2PSMembershipBinding,
+): Uint8Array {
+    const canonical = canonicalJSONStringify(unsigned)
+    const digestHex = bytesToHex(sha256(new TextEncoder().encode(canonical)))
+    return new TextEncoder().encode(BINDING_DOMAIN_PREFIX + digestHex)
+}
+
+export function stripBindingSignature(
+    b: L2PSMembershipBinding,
+): UnsignedL2PSMembershipBinding {
+    const { signature: _signature, ...rest } = b
+    return rest
+}
+
+export function signatureFromHex(hex: string): Uint8Array {
+    const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex
+    if (h.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(h)) {
+        throw new Error(`signatureFromHex: not a valid hex string`)
+    }
+    const out = new Uint8Array(h.length / 2)
+    for (let i = 0; i < h.length; i += 2) {
+        out[i / 2] = parseInt(h.slice(i, i + 2), 16)
+    }
+    return out
+}
+
+export function signatureToHex(sig: Uint8Array): string {
+    return "0x" + bytesToHex(sig)
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    let out = ""
+    for (let i = 0; i < bytes.length; i++) {
+        out += bytes[i].toString(16).padStart(2, "0")
+    }
+    return out
+}

--- a/src/l2ps/binding/canonical.ts
+++ b/src/l2ps/binding/canonical.ts
@@ -1,5 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2"
 import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import { bytesToHex, signatureFromHex, signatureToHex } from "../utils/hex"
 import type {
     L2PSMembershipBinding,
     UnsignedL2PSMembershipBinding,
@@ -35,26 +36,6 @@ export function stripBindingSignature(
     return rest
 }
 
-export function signatureFromHex(hex: string): Uint8Array {
-    const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex
-    if (h.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(h)) {
-        throw new Error(`signatureFromHex: not a valid hex string`)
-    }
-    const out = new Uint8Array(h.length / 2)
-    for (let i = 0; i < h.length; i += 2) {
-        out[i / 2] = parseInt(h.slice(i, i + 2), 16)
-    }
-    return out
-}
-
-export function signatureToHex(sig: Uint8Array): string {
-    return "0x" + bytesToHex(sig)
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-    let out = ""
-    for (let i = 0; i < bytes.length; i++) {
-        out += bytes[i].toString(16).padStart(2, "0")
-    }
-    return out
-}
+// Re-exported from the shared utility so existing imports of
+// `signatureFromHex` / `signatureToHex` from this module keep working.
+export { signatureFromHex, signatureToHex }

--- a/src/l2ps/binding/index.ts
+++ b/src/l2ps/binding/index.ts
@@ -1,0 +1,31 @@
+/**
+ * L2PS membership binding — DACS-3 §8.3.2 (SR-4 WI-1).
+ *
+ * Anchors `(channelId, subnetMemberId) -> CCI ClaimReference` proofs to
+ * chain via SR-2 Storage Programs so channel signatures can be verified
+ * against the same identity used in DACS-2.
+ */
+
+export {
+    BINDING_DOMAIN_PREFIX,
+    bindingSigningBytes,
+    signatureFromHex,
+    signatureToHex,
+    stripBindingSignature,
+} from "./canonical"
+
+export type {
+    L2PSMembershipBinding,
+    UnsignedL2PSMembershipBinding,
+} from "./types"
+
+export {
+    anchorMembershipBinding,
+    bindingProgramName,
+    createMembershipBinding,
+    resolveMember,
+    subnetMemberIdFromL2PS,
+    verifyMembershipBinding,
+    type AnchorMembershipBindingResult,
+    type CreateMembershipBindingOpts,
+} from "./binding"

--- a/src/l2ps/binding/types.ts
+++ b/src/l2ps/binding/types.ts
@@ -1,0 +1,25 @@
+import type { ClaimReference } from "@/identity/cci"
+
+/**
+ * DACS-3 §8.3.2 interim membership binding.
+ *
+ * Until L2PS is natively CCI-keyed, each subnet member publishes one of
+ * these so channel signatures can be tied back to the same identity used
+ * in DACS-2. The signature MUST be produced by the key controlling
+ * `cciPrimaryClaim` — on Demos, the Demos Ed25519 key (NOT the RSA subnet
+ * key the L2PS class is configured with).
+ */
+export interface L2PSMembershipBinding {
+    bindingVersion: "1"
+    channelId: string
+    subnetMemberId: string
+    cciPrimaryClaim: ClaimReference
+    boundAt: number
+    /** Hex (0x-prefixed) Ed25519 signature over `bindingSigningBytes`. */
+    signature: string
+}
+
+export type UnsignedL2PSMembershipBinding = Omit<
+    L2PSMembershipBinding,
+    "signature"
+>

--- a/src/l2ps/channel/canonical.ts
+++ b/src/l2ps/channel/canonical.ts
@@ -1,0 +1,90 @@
+import { sha256 } from "@noble/hashes/sha2"
+import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import type {
+    ChannelMessage,
+    ChannelTranscript,
+    UnsignedChannelMessage,
+    UnsignedChannelTranscript,
+} from "./types"
+
+/**
+ * Domain separation prefixes — verbatim from the brief (§2 WI-2, WI-3) and
+ * the spec references at §B.7. A signature lifted from one domain (e.g.
+ * channelmsg) fails verification in any other (e.g. transcript / binding).
+ */
+export const CHANNEL_MESSAGE_DOMAIN_PREFIX = "dacs-channelmsg:v1:"
+export const TRANSCRIPT_DOMAIN_PREFIX = "dacs-transcript:v1:"
+
+/**
+ * Hex digest of `JCS(envelope_without_signature)`. Exposed as a primitive
+ * so auditors can re-derive the hash independently from the wire envelope.
+ */
+export function envelopeHashHex(unsigned: UnsignedChannelMessage): string {
+    const canonical = canonicalJSONStringify(unsigned)
+    return bytesToHex(sha256(new TextEncoder().encode(canonical)))
+}
+
+/**
+ * Bytes the channel-message signature covers:
+ *   `dacs-channelmsg:v1:` || envelope_hash_hex
+ */
+export function channelMessageSigningBytes(
+    unsigned: UnsignedChannelMessage,
+): Uint8Array {
+    return new TextEncoder().encode(
+        CHANNEL_MESSAGE_DOMAIN_PREFIX + envelopeHashHex(unsigned),
+    )
+}
+
+export function stripChannelMessageSignature(
+    msg: ChannelMessage,
+): UnsignedChannelMessage {
+    const { signature: _signature, ...rest } = msg
+    return rest
+}
+
+export function transcriptHashHex(
+    unsigned: UnsignedChannelTranscript,
+): string {
+    const canonical = canonicalJSONStringify(unsigned)
+    return bytesToHex(sha256(new TextEncoder().encode(canonical)))
+}
+
+export function transcriptSigningBytes(
+    unsigned: UnsignedChannelTranscript,
+): Uint8Array {
+    return new TextEncoder().encode(
+        TRANSCRIPT_DOMAIN_PREFIX + transcriptHashHex(unsigned),
+    )
+}
+
+export function stripTranscriptSignatures(
+    t: ChannelTranscript,
+): UnsignedChannelTranscript {
+    const { signatures: _signatures, ...rest } = t
+    return rest
+}
+
+export function signatureToHex(sig: Uint8Array): string {
+    return "0x" + bytesToHex(sig)
+}
+
+export function signatureFromHex(hex: string): Uint8Array {
+    const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex
+    if (h.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(h)) {
+        throw new Error("signatureFromHex: not a valid hex string")
+    }
+    const out = new Uint8Array(h.length / 2)
+    for (let i = 0; i < h.length; i += 2) {
+        out[i / 2] = parseInt(h.slice(i, i + 2), 16)
+    }
+    return out
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+    let out = ""
+    for (let i = 0; i < bytes.length; i++) {
+        out += bytes[i].toString(16).padStart(2, "0")
+    }
+    return out
+}

--- a/src/l2ps/channel/canonical.ts
+++ b/src/l2ps/channel/canonical.ts
@@ -1,5 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2"
 import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import { bytesToHex, signatureFromHex, signatureToHex } from "../utils/hex"
 import type {
     ChannelMessage,
     ChannelTranscript,
@@ -65,26 +66,6 @@ export function stripTranscriptSignatures(
     return rest
 }
 
-export function signatureToHex(sig: Uint8Array): string {
-    return "0x" + bytesToHex(sig)
-}
-
-export function signatureFromHex(hex: string): Uint8Array {
-    const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex
-    if (h.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(h)) {
-        throw new Error("signatureFromHex: not a valid hex string")
-    }
-    const out = new Uint8Array(h.length / 2)
-    for (let i = 0; i < h.length; i += 2) {
-        out[i / 2] = parseInt(h.slice(i, i + 2), 16)
-    }
-    return out
-}
-
-function bytesToHex(bytes: Uint8Array): string {
-    let out = ""
-    for (let i = 0; i < bytes.length; i++) {
-        out += bytes[i].toString(16).padStart(2, "0")
-    }
-    return out
-}
+// Re-exported from the shared utility so existing imports of
+// `signatureFromHex` / `signatureToHex` from this module keep working.
+export { signatureFromHex, signatureToHex }

--- a/src/l2ps/channel/channelIdRegistry.ts
+++ b/src/l2ps/channel/channelIdRegistry.ts
@@ -1,0 +1,31 @@
+/**
+ * CH-6 per-session channelId uniqueness — pluggable persistence.
+ *
+ * The substrate (L2PS subnet UID) already produces a unique value per
+ * session in honest deployments, but the brief requires explicit rejection
+ * of any session reusing a prior `channelId`. SDK ships an in-memory
+ * default; production callers wire their own store (durable DB, chain
+ * lookup, app-side persistence).
+ */
+export interface ChannelIdRegistry {
+    /** Throws if `channelId` has been registered before. */
+    register(channelId: string): Promise<void>
+    has(channelId: string): Promise<boolean>
+}
+
+export class InMemoryChannelIdRegistry implements ChannelIdRegistry {
+    private readonly seen = new Set<string>()
+
+    async register(channelId: string): Promise<void> {
+        if (!channelId) throw new Error("ChannelIdRegistry: channelId required")
+        if (this.seen.has(channelId))
+            throw new Error(
+                `ChannelIdRegistry: channelId "${channelId}" already registered (CH-6 violation)`,
+            )
+        this.seen.add(channelId)
+    }
+
+    async has(channelId: string): Promise<boolean> {
+        return this.seen.has(channelId)
+    }
+}

--- a/src/l2ps/channel/envelope.ts
+++ b/src/l2ps/channel/envelope.ts
@@ -57,7 +57,7 @@ export async function signChannelMessage(
  * are handled by `ChannelSession` — this function does crypto only.
  */
 export function verifyChannelMessage(msg: ChannelMessage): boolean {
-    if (!msg || !msg.signature || msg.signature.sigVersion !== "1") return false
+    if (msg?.signature?.sigVersion !== "1") return false
     if (!isDemosClaim(msg.sender)) return false
     if (!Number.isInteger(msg.sequence) || msg.sequence < 1) return false
     if (!msg.channelId) return false

--- a/src/l2ps/channel/envelope.ts
+++ b/src/l2ps/channel/envelope.ts
@@ -1,0 +1,87 @@
+import {
+    isDemosClaim,
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+    type ClaimReference,
+} from "@/identity/cci"
+import { Demos } from "@/websdk/demosclass"
+import type {
+    ChannelMessage,
+    ChannelMessageSignature,
+    UnsignedChannelMessage,
+} from "./types"
+import {
+    channelMessageSigningBytes,
+    signatureFromHex,
+    signatureToHex,
+    stripChannelMessageSignature,
+} from "./canonical"
+
+/**
+ * Sign a `ChannelMessage` envelope with the sender's primary-claim key.
+ *
+ * The signature covers `dacs-channelmsg:v1:` || sha256(JCS(envelope w/o
+ * signature)). Transport-level wrappers MUST NOT alter the bytes returned
+ * here. Throws if `unsigned.sender` is not a demos: ClaimReference or
+ * does not match the connected wallet — preserves the
+ * in-channel-signer == on-chain-party invariant.
+ */
+export async function signChannelMessage(
+    unsigned: UnsignedChannelMessage,
+    demos: Demos,
+): Promise<ChannelMessage> {
+    if (!isDemosClaim(unsigned.sender))
+        throw new Error(
+            `signChannelMessage: sender must be a demos: ClaimReference, got "${unsigned.sender}"`,
+        )
+    if (!Number.isInteger(unsigned.sequence) || unsigned.sequence < 1)
+        throw new Error(
+            `signChannelMessage: sequence must be a positive integer (got ${unsigned.sequence})`,
+        )
+    if (!unsigned.channelId)
+        throw new Error("signChannelMessage: channelId required")
+
+    const payload = channelMessageSigningBytes(unsigned)
+    const sigBytes = await signWithPrimaryClaim(unsigned.sender, payload, demos)
+    const signature: ChannelMessageSignature = {
+        sigVersion: "1",
+        signature: signatureToHex(sigBytes),
+    }
+    return { ...unsigned, signature }
+}
+
+/**
+ * Pure signature check: verifies `msg.signature` covers JCS(msg without
+ * signature) with the `dacs-channelmsg:v1:` prefix under the key encoded
+ * in `msg.sender`. Membership (`sender ∈ members`) and sequence enforcement
+ * are handled by `ChannelSession` — this function does crypto only.
+ */
+export function verifyChannelMessage(msg: ChannelMessage): boolean {
+    if (!msg || !msg.signature || msg.signature.sigVersion !== "1") return false
+    if (!isDemosClaim(msg.sender)) return false
+    if (!Number.isInteger(msg.sequence) || msg.sequence < 1) return false
+    if (!msg.channelId) return false
+
+    try {
+        const payload = channelMessageSigningBytes(
+            stripChannelMessageSignature(msg),
+        )
+        const sig = signatureFromHex(msg.signature.signature)
+        return verifyPrimaryClaimSignature(msg.sender, payload, sig)
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Pure membership check. Kept separate so `verifyChannelMessage` can be
+ * called in contexts where the member set hasn't been resolved yet (e.g.
+ * audit replay from a transcript).
+ */
+export function isSenderInMembers(
+    msg: ChannelMessage,
+    members: Iterable<ClaimReference>,
+): boolean {
+    for (const m of members) if (m === msg.sender) return true
+    return false
+}

--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -1,0 +1,52 @@
+/**
+ * DACS-3 §8.3.3 / §8.7 — channel message envelope, session-level
+ * sequence + channelId enforcement, transcript export (SR-4 WI-2).
+ *
+ * All signatures use the sender's primary-claim key (on Demos: the
+ * connected Demos Ed25519 keypair) via WI-0's `signWithPrimaryClaim`;
+ * never the RSA L2PS subnet key.
+ */
+
+export type {
+    ChannelMessage,
+    ChannelMessageSignature,
+    ChannelMessageType,
+    ChannelTranscript,
+    TranscriptSignature,
+    UnsignedChannelMessage,
+    UnsignedChannelTranscript,
+} from "./types"
+
+export {
+    CHANNEL_MESSAGE_DOMAIN_PREFIX,
+    TRANSCRIPT_DOMAIN_PREFIX,
+    channelMessageSigningBytes,
+    envelopeHashHex,
+    signatureFromHex,
+    signatureToHex,
+    stripChannelMessageSignature,
+    stripTranscriptSignatures,
+    transcriptHashHex,
+    transcriptSigningBytes,
+} from "./canonical"
+
+export {
+    isSenderInMembers,
+    signChannelMessage,
+    verifyChannelMessage,
+} from "./envelope"
+
+export {
+    InMemoryChannelIdRegistry,
+    type ChannelIdRegistry,
+} from "./channelIdRegistry"
+
+export { ChannelSession, type ChannelSessionOpts } from "./session"
+
+export {
+    buildUnsignedTranscript,
+    exportTranscript,
+    signTranscript,
+    verifyTranscript,
+    type TranscriptVerificationResult,
+} from "./transcript"

--- a/src/l2ps/channel/session.ts
+++ b/src/l2ps/channel/session.ts
@@ -88,9 +88,15 @@ export class ChannelSession {
         repliesTo?: number
     }): Promise<ChannelMessage> {
         this.assertOpened()
+        // Reserve the sequence slot SYNCHRONOUSLY before any await — two
+        // concurrent sendOutgoing() calls would otherwise read the same
+        // `highestSeen`, sign two messages with identical sequence
+        // numbers, and silently violate the anti-replay invariant on the
+        // receiver side.
+        const sequence = ++this.highestSeen
         const unsigned: UnsignedChannelMessage = {
             channelId: this.channelId,
-            sequence: this.highestSeen + 1,
+            sequence,
             sender: this.me,
             sentAt: opts.sentAt ?? Date.now(),
             type: opts.type,
@@ -100,7 +106,6 @@ export class ChannelSession {
             }),
         }
         const signed = await signChannelMessage(unsigned, this.demos)
-        this.highestSeen = signed.sequence
         this.transcript.push(signed)
         return signed
     }

--- a/src/l2ps/channel/session.ts
+++ b/src/l2ps/channel/session.ts
@@ -1,0 +1,150 @@
+import { Demos } from "@/websdk/demosclass"
+import type { ClaimReference } from "@/identity/cci"
+import type {
+    ChannelMessage,
+    ChannelMessageType,
+    UnsignedChannelMessage,
+} from "./types"
+import {
+    isSenderInMembers,
+    signChannelMessage,
+    verifyChannelMessage,
+} from "./envelope"
+import type { ChannelIdRegistry } from "./channelIdRegistry"
+
+export interface ChannelSessionOpts {
+    channelId: string
+    members: ClaimReference[]
+    /** This party's primary claim — must be in `members`. */
+    me: ClaimReference
+    demos: Demos
+    /**
+     * Optional CH-6 enforcement. If provided, `open()` registers the
+     * channelId here and throws on reuse.
+     */
+    channelIdRegistry?: ChannelIdRegistry
+}
+
+/**
+ * Per-channel session — owns the monotonic sequence counter and applies
+ * the four invariants from §8.3.3 / §8.12 on every message:
+ *
+ *   1. signature verifies under sender's CCI key
+ *   2. sender ∈ members (CH-1)
+ *   3. sequence is monotonic per channel (anti-replay)
+ *   4. channelId matches the session's channelId
+ *
+ * A single counter is shared across senders, as the brief specifies
+ * (`sequence: number  // monotonic per channel, starts at 1`). Outgoing
+ * messages get `current + 1`; incoming messages must use a sequence
+ * strictly greater than every value already seen.
+ */
+export class ChannelSession {
+    readonly channelId: string
+    readonly members: ReadonlyArray<ClaimReference>
+    readonly me: ClaimReference
+    private readonly demos: Demos
+    private readonly registry: ChannelIdRegistry | undefined
+    private opened = false
+    private highestSeen = 0
+    private readonly transcript: ChannelMessage[] = []
+
+    constructor(opts: ChannelSessionOpts) {
+        if (!opts.channelId) throw new Error("ChannelSession: channelId required")
+        if (!opts.members?.length)
+            throw new Error("ChannelSession: members required")
+        if (!opts.members.includes(opts.me))
+            throw new Error(
+                `ChannelSession: me (${opts.me}) is not in members`,
+            )
+
+        this.channelId = opts.channelId
+        this.members = [...opts.members]
+        this.me = opts.me
+        this.demos = opts.demos
+        this.registry = opts.channelIdRegistry
+    }
+
+    /**
+     * Register the channelId (CH-6) and prepare for messaging. Idempotent
+     * within a session — calling twice throws via the registry.
+     */
+    async open(): Promise<void> {
+        if (this.opened)
+            throw new Error("ChannelSession: already opened")
+        if (this.registry) await this.registry.register(this.channelId)
+        this.opened = true
+    }
+
+    /**
+     * Build, sign, append-to-local-transcript, and return the next
+     * outgoing `ChannelMessage`. Sequence is `highestSeen + 1` so it is
+     * monotonic across both directions.
+     */
+    async sendOutgoing(opts: {
+        type: ChannelMessageType
+        body: unknown
+        sentAt?: number
+        repliesTo?: number
+    }): Promise<ChannelMessage> {
+        this.assertOpened()
+        const unsigned: UnsignedChannelMessage = {
+            channelId: this.channelId,
+            sequence: this.highestSeen + 1,
+            sender: this.me,
+            sentAt: opts.sentAt ?? Date.now(),
+            type: opts.type,
+            body: opts.body,
+            ...(opts.repliesTo !== undefined && {
+                refs: { repliesTo: opts.repliesTo },
+            }),
+        }
+        const signed = await signChannelMessage(unsigned, this.demos)
+        this.highestSeen = signed.sequence
+        this.transcript.push(signed)
+        return signed
+    }
+
+    /**
+     * Validate an incoming `ChannelMessage`. Throws with a precise reason
+     * on any failure — caller should treat throw as channel-fatal per
+     * §8.12 (a single tampered message invalidates the session's record).
+     */
+    async receiveIncoming(msg: ChannelMessage): Promise<void> {
+        this.assertOpened()
+        if (msg.channelId !== this.channelId)
+            throw new Error(
+                `ChannelSession: channelId mismatch (expected ${this.channelId}, got ${msg.channelId})`,
+            )
+        if (!isSenderInMembers(msg, this.members))
+            throw new Error(
+                `ChannelSession: sender "${msg.sender}" not in members (CH-1)`,
+            )
+        if (!Number.isInteger(msg.sequence) || msg.sequence < 1)
+            throw new Error(
+                `ChannelSession: invalid sequence ${msg.sequence}`,
+            )
+        if (msg.sequence <= this.highestSeen)
+            throw new Error(
+                `ChannelSession: non-monotonic sequence ${msg.sequence} (highest seen ${this.highestSeen})`,
+            )
+        if (!verifyChannelMessage(msg))
+            throw new Error(
+                "ChannelSession: signature verification failed",
+            )
+        this.highestSeen = msg.sequence
+        this.transcript.push(msg)
+    }
+
+    /** Read-only snapshot of all messages this session has signed or accepted. */
+    messages(): ReadonlyArray<ChannelMessage> {
+        return this.transcript
+    }
+
+    private assertOpened(): void {
+        if (!this.opened)
+            throw new Error(
+                "ChannelSession: call open() before sending or receiving",
+            )
+    }
+}

--- a/src/l2ps/channel/transcript.ts
+++ b/src/l2ps/channel/transcript.ts
@@ -1,0 +1,179 @@
+import {
+    isDemosClaim,
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+    type ClaimReference,
+} from "@/identity/cci"
+import { Demos } from "@/websdk/demosclass"
+import type {
+    ChannelMessage,
+    ChannelTranscript,
+    TranscriptSignature,
+    UnsignedChannelTranscript,
+} from "./types"
+import {
+    signatureFromHex,
+    signatureToHex,
+    stripTranscriptSignatures,
+    transcriptSigningBytes,
+} from "./canonical"
+import { isSenderInMembers, verifyChannelMessage } from "./envelope"
+
+/**
+ * Build the unsigned transcript shell. Messages must already be in
+ * sequence order — typically `session.messages()`.
+ */
+export function buildUnsignedTranscript(opts: {
+    channelId: string
+    members: ClaimReference[]
+    messages: ReadonlyArray<ChannelMessage>
+    generatedAt?: number
+}): UnsignedChannelTranscript {
+    return {
+        transcriptVersion: "1",
+        channelId: opts.channelId,
+        members: [...opts.members],
+        messages: [...opts.messages],
+        generatedAt: opts.generatedAt ?? Date.now(),
+    }
+}
+
+/**
+ * Produce one party's `TranscriptSignature` over the unsigned transcript.
+ * Domain-separated under `dacs-transcript:v1:` — cannot be confused with
+ * a channel-message or binding signature.
+ */
+export async function signTranscript(
+    unsigned: UnsignedChannelTranscript,
+    signer: ClaimReference,
+    demos: Demos,
+): Promise<TranscriptSignature> {
+    if (!isDemosClaim(signer))
+        throw new Error(
+            `signTranscript: signer must be a demos: ClaimReference, got "${signer}"`,
+        )
+    const payload = transcriptSigningBytes(unsigned)
+    const sigBytes = await signWithPrimaryClaim(signer, payload, demos)
+    return {
+        sigVersion: "1",
+        signer,
+        signature: signatureToHex(sigBytes),
+    }
+}
+
+/**
+ * Convenience: assemble the full transcript with one or more party
+ * signatures. Pass signers in the order their signatures should appear.
+ */
+export async function exportTranscript(opts: {
+    channelId: string
+    members: ClaimReference[]
+    messages: ReadonlyArray<ChannelMessage>
+    signers: Array<{ claim: ClaimReference; demos: Demos }>
+    generatedAt?: number
+}): Promise<ChannelTranscript> {
+    const unsigned = buildUnsignedTranscript(opts)
+    const signatures: TranscriptSignature[] = []
+    for (const s of opts.signers) {
+        signatures.push(await signTranscript(unsigned, s.claim, s.demos))
+    }
+    return { ...unsigned, signatures }
+}
+
+export interface TranscriptVerificationResult {
+    ok: boolean
+    errors: string[]
+}
+
+/**
+ * Verify every claim about a transcript a non-member can check given only
+ * the public keys: (a) each `TranscriptSignature` is valid, (b) each
+ * `ChannelMessage` carries a valid signature, (c) every message's sender
+ * is in `members`, (d) sequences are strictly monotonic per channel,
+ * (e) every message's `channelId` matches the transcript.
+ *
+ * Returns a list of errors rather than throwing so auditors can collect
+ * every failure in one pass.
+ */
+export function verifyTranscript(
+    t: ChannelTranscript,
+): TranscriptVerificationResult {
+    const errors: string[] = []
+    if (!t || t.transcriptVersion !== "1") {
+        errors.push("transcriptVersion is not 1")
+        return { ok: false, errors }
+    }
+    if (!t.channelId) errors.push("missing channelId")
+    if (!t.members?.length) errors.push("missing members")
+
+    let unsigned: UnsignedChannelTranscript
+    try {
+        unsigned = stripTranscriptSignatures(t)
+    } catch {
+        errors.push("could not strip signatures")
+        return { ok: false, errors }
+    }
+
+    if (!t.signatures?.length) {
+        errors.push("no transcript signatures")
+    } else {
+        const payload = transcriptSigningBytes(unsigned)
+        for (const s of t.signatures) {
+            if (s.sigVersion !== "1") {
+                errors.push(`transcript signature: unknown sigVersion ${s.sigVersion}`)
+                continue
+            }
+            if (!t.members.includes(s.signer)) {
+                errors.push(
+                    `transcript signature signer "${s.signer}" not in members`,
+                )
+                continue
+            }
+            try {
+                const ok = verifyPrimaryClaimSignature(
+                    s.signer,
+                    payload,
+                    signatureFromHex(s.signature),
+                )
+                if (!ok)
+                    errors.push(
+                        `transcript signature by "${s.signer}" failed verification`,
+                    )
+            } catch (e) {
+                errors.push(
+                    `transcript signature by "${s.signer}" malformed: ${(e as Error).message}`,
+                )
+            }
+        }
+    }
+
+    let highestSeen = 0
+    for (const msg of t.messages ?? []) {
+        if (msg.channelId !== t.channelId) {
+            errors.push(
+                `message seq=${msg.sequence}: channelId mismatch (${msg.channelId} vs ${t.channelId})`,
+            )
+        }
+        if (!isSenderInMembers(msg, t.members)) {
+            errors.push(
+                `message seq=${msg.sequence}: sender "${msg.sender}" not in members`,
+            )
+        }
+        if (!Number.isInteger(msg.sequence) || msg.sequence < 1) {
+            errors.push(`message: invalid sequence ${msg.sequence}`)
+        } else if (msg.sequence <= highestSeen) {
+            errors.push(
+                `message seq=${msg.sequence}: non-monotonic (highest seen ${highestSeen})`,
+            )
+        } else {
+            highestSeen = msg.sequence
+        }
+        if (!verifyChannelMessage(msg)) {
+            errors.push(
+                `message seq=${msg.sequence}: signature verification failed`,
+            )
+        }
+    }
+
+    return { ok: errors.length === 0, errors }
+}

--- a/src/l2ps/channel/transcript.ts
+++ b/src/l2ps/channel/transcript.ts
@@ -99,7 +99,7 @@ export function verifyTranscript(
     t: ChannelTranscript,
 ): TranscriptVerificationResult {
     const errors: string[] = []
-    if (!t || t.transcriptVersion !== "1") {
+    if (t?.transcriptVersion !== "1") {
         errors.push("transcriptVersion is not 1")
         return { ok: false, errors }
     }

--- a/src/l2ps/channel/types.ts
+++ b/src/l2ps/channel/types.ts
@@ -1,0 +1,67 @@
+import type { ClaimReference } from "@/identity/cci"
+
+/**
+ * Allowed message types — verbatim from DACS-3 §8.3.3. Closed union by
+ * design: the substrate enforces the conformance set; application bodies
+ * are carried in `body: unknown`.
+ */
+export type ChannelMessageType =
+    | "offer"
+    | "counter"
+    | "accept"
+    | "reject"
+    | "sealed-envelope-commit"
+    | "sealed-envelope-reveal"
+    | "abort"
+
+/**
+ * Brief doesn't define the wire shape of the signature container. Versioned
+ * for forward compatibility (e.g. PQC swap-out) without breaking the
+ * envelope layout. Signature is hex-encoded over `channelMessageSigningBytes`.
+ */
+export interface ChannelMessageSignature {
+    sigVersion: "1"
+    signature: string
+}
+
+/**
+ * DACS-3 §8.3.3 envelope — verbatim. Transport-level fields may wrap this
+ * but MUST NOT change the bytes that the signature covers.
+ */
+export interface ChannelMessage {
+    channelId: string
+    sequence: number
+    sender: ClaimReference
+    sentAt: number
+    type: ChannelMessageType
+    body: unknown
+    refs?: { repliesTo?: number }
+    signature: ChannelMessageSignature
+}
+
+export type UnsignedChannelMessage = Omit<ChannelMessage, "signature">
+
+/**
+ * Per-signer transcript signature. Each member signs the full transcript
+ * (without `signatures`) — see WI-3 reference in the brief.
+ */
+export interface TranscriptSignature {
+    sigVersion: "1"
+    signer: ClaimReference
+    signature: string
+}
+
+/**
+ * DACS-3 §8.7 — the ordered, member-signed record of a channel session.
+ * Consumed by WI-3 for encrypted-anchor flows.
+ */
+export interface ChannelTranscript {
+    transcriptVersion: "1"
+    channelId: string
+    members: ClaimReference[]
+    messages: ChannelMessage[]
+    generatedAt: number
+    signatures: TranscriptSignature[]
+}
+
+export type UnsignedChannelTranscript = Omit<ChannelTranscript, "signatures">

--- a/src/l2ps/index.ts
+++ b/src/l2ps/index.ts
@@ -1,4 +1,8 @@
 import L2PS from "./l2ps"
-import { L2PSConfig, L2PSEncryptedPayload } from "./l2ps"
+import { L2PSConfig, L2PSEncryptedBytes, L2PSEncryptedPayload } from "./l2ps"
 
-export { L2PS, L2PSConfig, L2PSEncryptedPayload }
+export { L2PS, L2PSConfig, L2PSEncryptedBytes, L2PSEncryptedPayload }
+
+export * as binding from "./binding"
+export * as channel from "./channel"
+export * as anchor from "./anchor"

--- a/src/l2ps/l2ps.ts
+++ b/src/l2ps/l2ps.ts
@@ -56,6 +56,22 @@ export interface L2PSEncryptedPayload {
 }
 
 /**
+ * Payload shape for `L2PS.encryptBytes` / `L2PS.decryptBytes`. Used by
+ * SR-4 WI-3 to encrypt channel transcripts to the subnet member set
+ * without dragging the L2PS-transaction envelope into a non-tx context.
+ */
+export interface L2PSEncryptedBytes {
+    /** UID of the L2PS network that encrypted these bytes. */
+    l2ps_uid: string;
+    /** Base64-encoded AES-GCM ciphertext. */
+    ciphertext: string;
+    /** Base64-encoded AES-GCM authentication tag. */
+    tag: string;
+    /** Base64-encoded AES-GCM nonce (always 12 bytes, fresh per call). */
+    nonce: string;
+}
+
+/**
  * L2PS (Layer 2 Private Subnets) class for encrypted transaction processing.
  * 
  * This class implements a multi-singleton pattern to manage multiple L2PS networks.
@@ -398,5 +414,67 @@ export default class L2PS {
      */
     async getKeyFingerprint(): Promise<string> {
         return Hashing.sha256(this.privateKey).substring(0, 16);
+    }
+
+    /**
+     * AES-GCM-encrypt arbitrary bytes under the subnet key.
+     *
+     * Mirrors the per-call-nonce + nonce-as-AAD pattern in `encryptTx`: a
+     * fresh 12-byte nonce per call, bound into the auth tag via AAD so an
+     * attacker cannot DoS specific ciphertexts by flipping the stored
+     * nonce. Used by SR-4 WI-3 to encrypt channel transcripts to the
+     * subnet member set; nothing in the payload shape is L2PS-transaction
+     * specific.
+     */
+    async encryptBytes(plaintext: Uint8Array): Promise<L2PSEncryptedBytes> {
+        const cipher = forge.cipher.createCipher('AES-GCM', this.privateKey);
+        const nonce = forge.random.getBytesSync(12);
+        cipher.start({ iv: nonce, additionalData: nonce });
+        cipher.update(
+            forge.util.createBuffer(
+                Buffer.from(plaintext).toString('binary'),
+                'binary' as any,
+            ),
+        );
+        if (!cipher.finish()) {
+            throw new Error('L2PS.encryptBytes: AES-GCM finish() failed');
+        }
+        return {
+            l2ps_uid: this.config?.uid || this.id,
+            ciphertext: forge.util.encode64(cipher.output.getBytes()),
+            tag: forge.util.encode64(cipher.mode.tag.getBytes()),
+            nonce: forge.util.encode64(nonce),
+        };
+    }
+
+    /**
+     * Inverse of `encryptBytes`. Verifies the `l2ps_uid` matches this
+     * instance and that the AES-GCM auth tag (covering nonce + ciphertext)
+     * is intact; throws on either failure.
+     */
+    async decryptBytes(payload: L2PSEncryptedBytes): Promise<Uint8Array> {
+        if (payload.l2ps_uid !== (this.config?.uid || this.id)) {
+            throw new Error('L2PS.decryptBytes: payload encrypted for different L2PS uid');
+        }
+        const ciphertext = forge.util.createBuffer(
+            forge.util.decode64(payload.ciphertext),
+        );
+        const tag = forge.util.createBuffer(forge.util.decode64(payload.tag));
+        const iv = forge.util.decode64(payload.nonce);
+        if (iv.length !== 12) {
+            throw new Error(
+                'L2PS.decryptBytes: invalid nonce (expected base64-encoded 12-byte value)',
+            );
+        }
+        const decipher = forge.cipher.createDecipher('AES-GCM', this.privateKey);
+        decipher.start({ iv, tag, additionalData: iv });
+        decipher.update(ciphertext);
+        if (!decipher.finish()) {
+            throw new Error('L2PS.decryptBytes: AES-GCM authentication failed');
+        }
+        const bin = decipher.output.getBytes();
+        const out = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i) & 0xff;
+        return out;
     }
 }

--- a/src/l2ps/l2ps.ts
+++ b/src/l2ps/l2ps.ts
@@ -456,6 +456,18 @@ export default class L2PS {
         if (payload.l2ps_uid !== (this.config?.uid || this.id)) {
             throw new Error('L2PS.decryptBytes: payload encrypted for different L2PS uid');
         }
+        // Storage-loaded JSON can violate the L2PSEncryptedBytes shape at
+        // runtime; without an explicit shape check forge would throw a
+        // base64 error that does not tell the caller which field is wrong.
+        if (
+            typeof payload.ciphertext !== 'string' ||
+            typeof payload.tag !== 'string' ||
+            typeof payload.nonce !== 'string'
+        ) {
+            throw new Error(
+                'L2PS.decryptBytes: payload must include base64 strings for ciphertext, tag, and nonce',
+            );
+        }
         const ciphertext = forge.util.createBuffer(
             forge.util.decode64(payload.ciphertext),
         );

--- a/src/l2ps/utils/hex.ts
+++ b/src/l2ps/utils/hex.ts
@@ -1,0 +1,29 @@
+/**
+ * Hex encoding helpers shared across the SR-4 modules
+ * (binding / channel / anchor) so the signature wire format stays
+ * identical in every place that produces or consumes a hex string.
+ */
+
+export function bytesToHex(bytes: Uint8Array): string {
+    let out = ""
+    for (let i = 0; i < bytes.length; i++) {
+        out += bytes[i].toString(16).padStart(2, "0")
+    }
+    return out
+}
+
+export function signatureToHex(sig: Uint8Array): string {
+    return "0x" + bytesToHex(sig)
+}
+
+export function signatureFromHex(hex: string): Uint8Array {
+    const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex
+    if (h.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(h)) {
+        throw new Error("signatureFromHex: not a valid hex string")
+    }
+    const out = new Uint8Array(h.length / 2)
+    for (let i = 0; i < h.length; i += 2) {
+        out[i / 2] = parseInt(h.slice(i, i + 2), 16)
+    }
+    return out
+}

--- a/src/l2ps/utils/hex.ts
+++ b/src/l2ps/utils/hex.ts
@@ -23,7 +23,7 @@ export function signatureFromHex(hex: string): Uint8Array {
     }
     const out = new Uint8Array(h.length / 2)
     for (let i = 0; i < h.length; i += 2) {
-        out[i / 2] = parseInt(h.slice(i, i + 2), 16)
+        out[i / 2] = Number.parseInt(h.slice(i, i + 2), 16)
     }
     return out
 }

--- a/src/l2ps/utils/hex.ts
+++ b/src/l2ps/utils/hex.ts
@@ -4,6 +4,11 @@
  * identical in every place that produces or consumes a hex string.
  */
 
+/**
+ * Encode raw bytes as a lowercase, unprefixed hex string. Used for hash
+ * digests carried in signing payloads (the wire signature wrappers use
+ * the `0x`-prefixed `signatureToHex` instead).
+ */
 export function bytesToHex(bytes: Uint8Array): string {
     let out = ""
     for (let i = 0; i < bytes.length; i++) {
@@ -12,10 +17,23 @@ export function bytesToHex(bytes: Uint8Array): string {
     return out
 }
 
+/**
+ * Wire encoding for an Ed25519 signature — lowercase `0x`-prefixed hex.
+ * Match for `signatureFromHex` on the verify side.
+ */
 export function signatureToHex(sig: Uint8Array): string {
     return "0x" + bytesToHex(sig)
 }
 
+/**
+ * Decode a hex string (with or without a `0x` / `0X` prefix) into a
+ * `Uint8Array`. Rejects odd-length input and non-hex characters so a
+ * malformed wire signature surfaces immediately instead of producing a
+ * silently truncated byte array.
+ *
+ * @throws {Error} If the cleaned hex string is odd-length or contains
+ *                 non-hex characters.
+ */
 export function signatureFromHex(hex: string): Uint8Array {
     const h = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex
     if (h.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(h)) {

--- a/src/tests/identity/cci.test.ts
+++ b/src/tests/identity/cci.test.ts
@@ -1,0 +1,203 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import {
+    demosClaimRefForAddress,
+    demosAddressFromClaim,
+    isDemosClaim,
+    normalizeDemosAddress,
+    parseClaimRef,
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+    type ClaimReference,
+} from "@/identity/cci"
+
+describe("CCI ClaimReference", () => {
+    describe("parseClaimRef", () => {
+        it("parses a demos claim", () => {
+            const claim = "demos:0xabcdef" as ClaimReference
+            expect(parseClaimRef(claim)).toEqual({
+                scheme: "demos",
+                identifier: "0xabcdef",
+            })
+        })
+
+        it("parses a forward-compat scheme", () => {
+            const claim = "eip155:0x1234" as ClaimReference
+            expect(parseClaimRef(claim)).toEqual({
+                scheme: "eip155",
+                identifier: "0x1234",
+            })
+        })
+
+        it("rejects a malformed ref (no colon)", () => {
+            expect(() =>
+                parseClaimRef("malformed" as ClaimReference),
+            ).toThrow(/malformed ClaimReference/)
+        })
+
+        it("rejects an empty identifier", () => {
+            expect(() =>
+                parseClaimRef("demos:" as ClaimReference),
+            ).toThrow(/malformed ClaimReference/)
+        })
+
+        it("rejects a missing scheme", () => {
+            expect(() =>
+                parseClaimRef(":0xabc" as ClaimReference),
+            ).toThrow(/malformed ClaimReference/)
+        })
+    })
+
+    describe("demosClaimRefForAddress", () => {
+        it("builds a demos: claim from a 0x address", () => {
+            const addr = "0x" + "a".repeat(64)
+            expect(demosClaimRefForAddress(addr)).toBe(`demos:${addr}`)
+        })
+
+        it("lowercases the address", () => {
+            const addr = "0x" + "AB".repeat(32)
+            expect(demosClaimRefForAddress(addr)).toBe(
+                `demos:0x${"ab".repeat(32)}`,
+            )
+        })
+
+        it("accepts an un-prefixed hex address", () => {
+            const addr = "a".repeat(64)
+            expect(demosClaimRefForAddress(addr)).toBe(
+                `demos:0x${"a".repeat(64)}`,
+            )
+        })
+
+        it("rejects a non-hex string", () => {
+            expect(() => demosClaimRefForAddress("not-hex")).toThrow()
+        })
+
+        it("rejects a wrong-length hex", () => {
+            expect(() => demosClaimRefForAddress("0xab")).toThrow(
+                /Ed25519 address/,
+            )
+        })
+    })
+
+    describe("isDemosClaim", () => {
+        it("true for demos:", () => {
+            expect(
+                isDemosClaim(
+                    ("demos:0x" + "a".repeat(64)) as ClaimReference,
+                ),
+            ).toBe(true)
+        })
+
+        it("false for eip155:", () => {
+            expect(
+                isDemosClaim("eip155:0x1234" as ClaimReference),
+            ).toBe(false)
+        })
+
+        it("false for malformed", () => {
+            expect(isDemosClaim("nope" as ClaimReference)).toBe(false)
+        })
+    })
+
+    describe("demosAddressFromClaim", () => {
+        it("returns the normalized address", () => {
+            const claim = ("demos:0x" + "A".repeat(64)) as ClaimReference
+            expect(demosAddressFromClaim(claim)).toBe("0x" + "a".repeat(64))
+        })
+
+        it("throws for non-demos scheme", () => {
+            expect(() =>
+                demosAddressFromClaim("eip155:0xabc" as ClaimReference),
+            ).toThrow(/scheme/)
+        })
+    })
+
+    describe("normalizeDemosAddress", () => {
+        it("adds 0x prefix and lowercases", () => {
+            expect(normalizeDemosAddress("A".repeat(64))).toBe(
+                "0x" + "a".repeat(64),
+            )
+        })
+
+        it("rejects non-hex", () => {
+            expect(() => normalizeDemosAddress("not-hex".repeat(10))).toThrow()
+        })
+
+        it("rejects wrong length", () => {
+            expect(() => normalizeDemosAddress("ab")).toThrow(/Ed25519/)
+        })
+    })
+})
+
+describe("CCI signWithPrimaryClaim / verifyPrimaryClaimSignature", () => {
+    let demos: Demos
+    let auth: DemosWebAuth
+    let claim: ClaimReference
+
+    beforeAll(async () => {
+        demos = new Demos()
+        auth = new DemosWebAuth()
+        await auth.create()
+        await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+        claim = demosClaimRefForAddress(await demos.getEd25519Address())
+    })
+
+    it("signs and verifies a payload via the connected Demos key", async () => {
+        const payload = new TextEncoder().encode("dacs-channelmsg:v1:abc123")
+        const sig = await signWithPrimaryClaim(claim, payload, demos)
+        expect(sig).toBeInstanceOf(Uint8Array)
+        expect(sig.length).toBe(64)
+        expect(verifyPrimaryClaimSignature(claim, payload, sig)).toBe(true)
+    })
+
+    it("verify returns false for a tampered payload", async () => {
+        const payload = new TextEncoder().encode("dacs-channelmsg:v1:abc123")
+        const sig = await signWithPrimaryClaim(claim, payload, demos)
+        const tampered = new TextEncoder().encode("dacs-channelmsg:v1:abc124")
+        expect(verifyPrimaryClaimSignature(claim, tampered, sig)).toBe(false)
+    })
+
+    it("verify returns false for a wrong-key claim", async () => {
+        const payload = new TextEncoder().encode("dacs-binding:v1:xyz")
+        const sig = await signWithPrimaryClaim(claim, payload, demos)
+        const otherAuth = new DemosWebAuth()
+        await otherAuth.create()
+        const otherDemos = new Demos()
+        await otherDemos.connectWallet(
+            otherAuth.keypair.privateKey as Uint8Array,
+        )
+        const otherClaim = demosClaimRefForAddress(
+            await otherDemos.getEd25519Address(),
+        )
+        expect(verifyPrimaryClaimSignature(otherClaim, payload, sig)).toBe(
+            false,
+        )
+    })
+
+    it("refuses non-demos schemes", async () => {
+        const payload = new TextEncoder().encode("anything")
+        await expect(
+            signWithPrimaryClaim(
+                "eip155:0x1234" as ClaimReference,
+                payload,
+                demos,
+            ),
+        ).rejects.toThrow(/unsupported scheme/)
+    })
+
+    it("refuses if claim does not match connected wallet", async () => {
+        const otherAuth = new DemosWebAuth()
+        await otherAuth.create()
+        const otherDemos = new Demos()
+        await otherDemos.connectWallet(
+            otherAuth.keypair.privateKey as Uint8Array,
+        )
+        const otherClaim = demosClaimRefForAddress(
+            await otherDemos.getEd25519Address(),
+        )
+
+        const payload = new TextEncoder().encode("dacs-binding:v1:abc")
+        await expect(
+            signWithPrimaryClaim(otherClaim, payload, demos),
+        ).rejects.toThrow(/does not match connected/)
+    })
+})

--- a/src/tests/l2ps/anchor.test.ts
+++ b/src/tests/l2ps/anchor.test.ts
@@ -125,6 +125,29 @@ describe("L2PS.encryptBytes / decryptBytes (WI-3 building block)", () => {
         }
         await expect(l2ps.decryptBytes(bad)).rejects.toThrow(/12-byte/)
     })
+
+    // Regression for CodeRabbit finding on l2ps.ts:466. Storage-loaded
+    // JSON can violate the L2PSEncryptedBytes shape; without the explicit
+    // shape guard forge throws an opaque base64 error.
+    it("rejects payload with missing ciphertext / tag / nonce fields", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptBytes(new TextEncoder().encode("x"))
+        for (const field of ["ciphertext", "tag", "nonce"] as const) {
+            const bad = { ...enc, [field]: undefined } as unknown as L2PSEncryptedBytes
+            await expect(l2ps.decryptBytes(bad)).rejects.toThrow(
+                /base64 strings for ciphertext, tag, and nonce/,
+            )
+        }
+    })
+
+    it("rejects payload with non-string field types", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptBytes(new TextEncoder().encode("x"))
+        const bad = { ...enc, ciphertext: 12345 } as unknown as L2PSEncryptedBytes
+        await expect(l2ps.decryptBytes(bad)).rejects.toThrow(
+            /base64 strings for ciphertext, tag, and nonce/,
+        )
+    })
 })
 
 describe("anchorEncryptedTranscript — policy gating (WI-3)", () => {

--- a/src/tests/l2ps/anchor.test.ts
+++ b/src/tests/l2ps/anchor.test.ts
@@ -1,0 +1,406 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import {
+    demosClaimRefForAddress,
+    type ClaimReference,
+} from "@/identity/cci"
+import L2PS from "@/l2ps/l2ps"
+import { L2PSEncryptedBytes } from "@/l2ps/l2ps"
+import {
+    anchorProgramName,
+    type AnchoredTranscriptPayload,
+} from "@/l2ps/anchor"
+import {
+    ChannelSession,
+    exportTranscript,
+    type ChannelMessage,
+    type ChannelTranscript,
+} from "@/l2ps/channel"
+
+const CHANNEL = "ch-7f9a"
+
+async function newConnectedDemos(): Promise<{
+    demos: Demos
+    claim: ClaimReference
+}> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return {
+        demos,
+        claim: demosClaimRefForAddress(await demos.getEd25519Address()),
+    }
+}
+
+async function buildTranscript(
+    alice: { demos: Demos; claim: ClaimReference },
+    bob: { demos: Demos; claim: ClaimReference },
+): Promise<ChannelTranscript> {
+    const a = new ChannelSession({
+        channelId: CHANNEL,
+        members: [alice.claim, bob.claim],
+        me: alice.claim,
+        demos: alice.demos,
+    })
+    const b = new ChannelSession({
+        channelId: CHANNEL,
+        members: [alice.claim, bob.claim],
+        me: bob.claim,
+        demos: bob.demos,
+    })
+    await a.open()
+    await b.open()
+    const m1 = await a.sendOutgoing({ type: "offer", body: { price: 100 } })
+    await b.receiveIncoming(m1)
+    const m2 = await b.sendOutgoing({
+        type: "accept",
+        body: {},
+        repliesTo: 1,
+    })
+    await a.receiveIncoming(m2)
+    return exportTranscript({
+        channelId: CHANNEL,
+        members: [alice.claim, bob.claim],
+        messages: [m1, m2],
+        signers: [{ claim: alice.claim, demos: alice.demos }],
+    })
+}
+
+describe("anchorProgramName", () => {
+    it("is deterministic per channelId", () => {
+        expect(anchorProgramName("ch-A")).toBe("l2ps-transcript:ch-A")
+    })
+})
+
+describe("L2PS.encryptBytes / decryptBytes (WI-3 building block)", () => {
+    it("round-trips raw bytes", async () => {
+        const l2ps = await L2PS.create()
+        const plain = new TextEncoder().encode("hello transcript")
+        const enc = await l2ps.encryptBytes(plain)
+        expect(enc.l2ps_uid).toBe(l2ps.getId())
+        expect(enc.nonce.length).toBeGreaterThan(0)
+        const back = await l2ps.decryptBytes(enc)
+        expect(new TextDecoder().decode(back)).toBe("hello transcript")
+    })
+
+    it("uses a fresh nonce per encryption", async () => {
+        const l2ps = await L2PS.create()
+        const plain = new TextEncoder().encode("same plaintext")
+        const a = await l2ps.encryptBytes(plain)
+        const b = await l2ps.encryptBytes(plain)
+        expect(a.nonce).not.toBe(b.nonce)
+        expect(a.ciphertext).not.toBe(b.ciphertext)
+    })
+
+    it("rejects payload encrypted for a different L2PS uid", async () => {
+        const a = await L2PS.create()
+        const b = await L2PS.create()
+        const enc = await a.encryptBytes(new TextEncoder().encode("x"))
+        await expect(b.decryptBytes(enc)).rejects.toThrow(/different L2PS/)
+    })
+
+    it("rejects tampered ciphertext (AES-GCM auth)", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptBytes(
+            new TextEncoder().encode("secret"),
+        )
+        // Flip a single base64 character in the ciphertext
+        const tampered: L2PSEncryptedBytes = {
+            ...enc,
+            ciphertext:
+                (enc.ciphertext[0] === "A" ? "B" : "A") +
+                enc.ciphertext.slice(1),
+        }
+        await expect(l2ps.decryptBytes(tampered)).rejects.toThrow(
+            /authentication/,
+        )
+    })
+
+    it("rejects malformed nonce length", async () => {
+        const l2ps = await L2PS.create()
+        const enc = await l2ps.encryptBytes(new TextEncoder().encode("x"))
+        const bad: L2PSEncryptedBytes = {
+            ...enc,
+            nonce: Buffer.from(new Uint8Array(8)).toString("base64"),
+        }
+        await expect(l2ps.decryptBytes(bad)).rejects.toThrow(/12-byte/)
+    })
+})
+
+describe("anchorEncryptedTranscript — policy gating (WI-3)", () => {
+    let alice: { demos: Demos; claim: ClaimReference }
+    let bob: { demos: Demos; claim: ClaimReference }
+
+    beforeEach(async () => {
+        alice = await newConnectedDemos()
+        bob = await newConnectedDemos()
+    })
+
+    it("policy 'none' throws", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        await expect(
+            anchorEncryptedTranscript({
+                transcript,
+                l2ps,
+                demos: alice.demos,
+                signer: alice.claim,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/'none'/)
+    })
+
+    it("policy 'recommended' without consent returns null and does NOT broadcast", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const broadcastSpy = jest.spyOn(alice.demos as any, "broadcast")
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        const result = await anchorEncryptedTranscript({
+            transcript,
+            l2ps,
+            demos: alice.demos,
+            signer: alice.claim,
+            policy: "encrypted-anchored-recommended",
+        })
+        expect(result).toBeNull()
+        expect(broadcastSpy).not.toHaveBeenCalled()
+    })
+
+    it("policy 'recommended' WITH consent attempts to anchor (reaches broadcast)", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const broadcastSpy = jest
+            .spyOn(alice.demos as any, "broadcast")
+            .mockResolvedValueOnce({ ok: true })
+        const confirmSpy = jest
+            .spyOn(alice.demos as any, "confirm")
+            .mockResolvedValueOnce({ ok: true })
+        jest.spyOn(alice.demos as any, "getAddressNonce").mockResolvedValue(0)
+
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        const result = await anchorEncryptedTranscript({
+            transcript,
+            l2ps,
+            demos: alice.demos,
+            signer: alice.claim,
+            policy: "encrypted-anchored-recommended",
+            consent: true,
+        })
+        expect(result).not.toBeNull()
+        expect(result!.anchor).toMatch(/^stor-/)
+        expect(result!.contentHash.length).toBe(64)
+        expect(broadcastSpy).toHaveBeenCalledTimes(1)
+        expect(confirmSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("policy 'required' propagates broadcast failure (phase fails)", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        jest.spyOn(alice.demos as any, "getAddressNonce").mockResolvedValue(0)
+        jest.spyOn(alice.demos as any, "confirm").mockResolvedValue({ ok: true })
+        jest
+            .spyOn(alice.demos as any, "broadcast")
+            .mockRejectedValueOnce(new Error("rpc down"))
+
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        await expect(
+            anchorEncryptedTranscript({
+                transcript,
+                l2ps,
+                demos: alice.demos,
+                signer: alice.claim,
+                policy: "encrypted-anchored-required",
+            }),
+        ).rejects.toThrow(/rpc down/)
+    })
+
+    it("refuses signer not in transcript.members", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const eve = await newConnectedDemos()
+        const l2ps = await L2PS.create()
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        await expect(
+            anchorEncryptedTranscript({
+                transcript,
+                l2ps,
+                demos: eve.demos,
+                signer: eve.claim,
+                policy: "encrypted-anchored-required",
+            }),
+        ).rejects.toThrow(/not in transcript.members/)
+    })
+
+    it("refuses non-demos signer", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        await expect(
+            anchorEncryptedTranscript({
+                transcript,
+                l2ps,
+                demos: alice.demos,
+                signer: "eip155:0xabc" as ClaimReference,
+                policy: "encrypted-anchored-required",
+            }),
+        ).rejects.toThrow(/demos:/)
+    })
+
+    it("refuses signer that does not match connected wallet", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        await expect(
+            anchorEncryptedTranscript({
+                transcript,
+                l2ps,
+                demos: alice.demos,
+                signer: bob.claim,
+                policy: "encrypted-anchored-required",
+            }),
+        ).rejects.toThrow(/does not match/)
+    })
+})
+
+describe("decrypt + tamper-evidence (WI-3 acceptance)", () => {
+    let alice: { demos: Demos; claim: ClaimReference }
+    let bob: { demos: Demos; claim: ClaimReference }
+
+    beforeEach(async () => {
+        alice = await newConnectedDemos()
+        bob = await newConnectedDemos()
+    })
+
+    /**
+     * In-memory simulation of the chain: capture the SP payload we'd
+     * broadcast, then run decrypt/verify against that captured payload
+     * without touching the network. This is the closest we can get to an
+     * end-to-end round-trip without a live chain.
+     */
+    async function captureAnchorPayload(
+        transcript: ChannelTranscript,
+        l2ps: L2PS,
+        signer: { demos: Demos; claim: ClaimReference },
+    ): Promise<{
+        payload: AnchoredTranscriptPayload
+        storageAddress: string
+    }> {
+        let captured: AnchoredTranscriptPayload | null = null
+        let address = ""
+        jest.spyOn(signer.demos as any, "getAddressNonce").mockResolvedValue(0)
+        jest.spyOn(signer.demos as any, "confirm").mockImplementation(
+            async (tx: any) => {
+                const inner = tx.content.data[1]
+                captured = inner.data as AnchoredTranscriptPayload
+                address = inner.storageAddress
+                return { ok: true }
+            },
+        )
+        jest.spyOn(signer.demos as any, "broadcast").mockResolvedValue({
+            ok: true,
+        })
+        const { anchorEncryptedTranscript } = await import("@/l2ps/anchor")
+        await anchorEncryptedTranscript({
+            transcript,
+            l2ps,
+            demos: signer.demos,
+            signer: signer.claim,
+            policy: "encrypted-anchored-required",
+        })
+        if (!captured) throw new Error("payload not captured")
+        return { payload: captured, storageAddress: address }
+    }
+
+    it("hash-verifies the on-chain ciphertext (anyone can check)", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { payload } = await captureAnchorPayload(transcript, l2ps, alice)
+        const { sha256 } = await import("@noble/hashes/sha2")
+        const rederived = Buffer.from(
+            sha256(Buffer.from(payload.encrypted.ciphertext, "base64")),
+        ).toString("hex")
+        expect(rederived).toBe(payload.contentHash)
+    })
+
+    it("any tampering of the ciphertext flips the content-hash", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { payload } = await captureAnchorPayload(transcript, l2ps, alice)
+        const tampered: AnchoredTranscriptPayload = {
+            ...payload,
+            encrypted: {
+                ...payload.encrypted,
+                ciphertext:
+                    (payload.encrypted.ciphertext[0] === "A" ? "B" : "A") +
+                    payload.encrypted.ciphertext.slice(1),
+            },
+        }
+        const { sha256 } = await import("@noble/hashes/sha2")
+        const rederived = Buffer.from(
+            sha256(Buffer.from(tampered.encrypted.ciphertext, "base64")),
+        ).toString("hex")
+        expect(rederived).not.toBe(payload.contentHash)
+    })
+
+    it("non-member L2PS instance cannot decrypt", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const memberL2ps = await L2PS.create()
+        const { payload } = await captureAnchorPayload(
+            transcript,
+            memberL2ps,
+            alice,
+        )
+        const nonMemberL2ps = await L2PS.create()
+        await expect(
+            nonMemberL2ps.decryptBytes(payload.encrypted),
+        ).rejects.toThrow(/different L2PS/)
+    })
+
+    it("member L2PS instance decrypts back to the original transcript", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { payload } = await captureAnchorPayload(transcript, l2ps, alice)
+        const plain = await l2ps.decryptBytes(payload.encrypted)
+        const decoded = JSON.parse(new TextDecoder().decode(plain))
+        expect(decoded.channelId).toBe(transcript.channelId)
+        expect(decoded.members).toEqual(transcript.members)
+        expect(decoded.messages.length).toBe(transcript.messages.length)
+        expect(decoded.messages[0].signature.signature).toBe(
+            transcript.messages[0].signature.signature,
+        )
+    })
+
+    it("embedded plaintext-signature re-verifies under the signer's claim", async () => {
+        const transcript = await buildTranscript(alice, bob)
+        const l2ps = await L2PS.create()
+        const { payload } = await captureAnchorPayload(transcript, l2ps, alice)
+        const { transcriptSigningBytes } = await import("@/l2ps/channel")
+        const { verifyPrimaryClaimSignature } = await import("@/identity/cci")
+        const plain = await l2ps.decryptBytes(payload.encrypted)
+        const transcriptUnsigned = JSON.parse(
+            new TextDecoder().decode(plain),
+        )
+        const sig = Buffer.from(
+            payload.signature.signature.slice(2),
+            "hex",
+        )
+        expect(
+            verifyPrimaryClaimSignature(
+                payload.signature.signer,
+                transcriptSigningBytes(transcriptUnsigned),
+                sig,
+            ),
+        ).toBe(true)
+    })
+})
+
+describe("Sanity: transcript fixture used in anchor tests is well-formed", () => {
+    it("has messages in sequence and members with the signer", async () => {
+        const alice = await newConnectedDemos()
+        const bob = await newConnectedDemos()
+        const t = await buildTranscript(alice, bob)
+        expect(t.messages.map((m: ChannelMessage) => m.sequence)).toEqual([1, 2])
+        expect(t.members).toContain(alice.claim)
+        expect(t.members).toContain(bob.claim)
+    })
+})

--- a/src/tests/l2ps/binding.test.ts
+++ b/src/tests/l2ps/binding.test.ts
@@ -8,12 +8,14 @@ import {
     bindingProgramName,
     bindingSigningBytes,
     createMembershipBinding,
+    resolveMember,
     signatureFromHex,
     signatureToHex,
     stripBindingSignature,
     verifyMembershipBinding,
     type L2PSMembershipBinding,
 } from "@/l2ps/binding"
+import { StorageProgram } from "@/storage/StorageProgram"
 
 const CHANNEL = "ch-7f9a"
 const MEMBER = "rsa-fingerprint-1"
@@ -303,6 +305,95 @@ describe("L2PS membership binding (WI-1)", () => {
             expect("signature" in stripped).toBe(false)
             expect(stripped.channelId).toBe(b.channelId)
             expect(stripped.cciPrimaryClaim).toBe(b.cciPrimaryClaim)
+        })
+    })
+
+    describe("resolveMember — DoS resistance (P1 regression)", () => {
+        // Regression for greptile P1 finding on resolveMember: a single
+        // squatter publishing a malformed SP under our deterministic name
+        // must not crash the resolver — it must be skipped so a legitimate
+        // candidate further down the candidate list still resolves.
+        const RPC = "https://rpc.test"
+
+        afterEach(() => jest.restoreAllMocks())
+
+        it("skips a candidate with a malformed sp.owner and keeps iterating", async () => {
+            const valid = await createMembershipBinding({
+                channelId: CHANNEL,
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+            })
+
+            jest.spyOn(StorageProgram, "searchByName").mockResolvedValue([
+                { storageAddress: "stor-malformed", programName: "", encoding: "json", sizeBytes: 0, storageLocation: "onchain", createdAt: "", updatedAt: "" },
+                { storageAddress: "stor-valid", programName: "", encoding: "json", sizeBytes: 0, storageLocation: "onchain", createdAt: "", updatedAt: "" },
+            ] as any)
+
+            jest.spyOn(StorageProgram, "getByAddress").mockImplementation(
+                async (_rpc: string, addr: string) => {
+                    if (addr === "stor-malformed") {
+                        return {
+                            storageAddress: addr,
+                            owner: "not-a-hex-address",
+                            programName: bindingProgramName(CHANNEL, MEMBER),
+                            encoding: "json",
+                            data: valid as unknown as Record<string, unknown>,
+                            metadata: null,
+                            storageLocation: "onchain",
+                            sizeBytes: 0,
+                            createdAt: "",
+                            updatedAt: "",
+                        } as any
+                    }
+                    if (addr === "stor-valid") {
+                        const ownerHex = (await demos.getEd25519Address())
+                            .toLowerCase()
+                        return {
+                            storageAddress: addr,
+                            owner: ownerHex.startsWith("0x")
+                                ? ownerHex
+                                : "0x" + ownerHex,
+                            programName: bindingProgramName(CHANNEL, MEMBER),
+                            encoding: "json",
+                            data: valid as unknown as Record<string, unknown>,
+                            metadata: null,
+                            storageLocation: "onchain",
+                            sizeBytes: 0,
+                            createdAt: "",
+                            updatedAt: "",
+                        } as any
+                    }
+                    return null
+                },
+            )
+
+            // Pre-fix this throws inside normalizeDemosAddress(sp.owner).
+            // Post-fix it returns the valid candidate's claim.
+            const resolved = await resolveMember(CHANNEL, MEMBER, RPC)
+            expect(resolved).toBe(claim)
+        })
+
+        it("returns null when EVERY candidate is malformed (no throws)", async () => {
+            jest.spyOn(StorageProgram, "searchByName").mockResolvedValue([
+                { storageAddress: "stor-bad", programName: "", encoding: "json", sizeBytes: 0, storageLocation: "onchain", createdAt: "", updatedAt: "" },
+            ] as any)
+            jest.spyOn(StorageProgram, "getByAddress").mockResolvedValue({
+                storageAddress: "stor-bad",
+                owner: "not-hex",
+                programName: bindingProgramName(CHANNEL, MEMBER),
+                encoding: "json",
+                data: { bogus: true } as Record<string, unknown>,
+                metadata: null,
+                storageLocation: "onchain",
+                sizeBytes: 0,
+                createdAt: "",
+                updatedAt: "",
+            } as any)
+
+            await expect(
+                resolveMember(CHANNEL, MEMBER, RPC),
+            ).resolves.toBeNull()
         })
     })
 })

--- a/src/tests/l2ps/binding.test.ts
+++ b/src/tests/l2ps/binding.test.ts
@@ -396,4 +396,61 @@ describe("L2PS membership binding (WI-1)", () => {
             ).resolves.toBeNull()
         })
     })
+
+    describe("bindingProgramName injectivity (CodeRabbit regression)", () => {
+        // Regression for CodeRabbit finding on binding.ts:34. Without
+        // percent-encoding the colon-separated layout `("a:b","c")` and
+        // `("a","b:c")` collided on the same SP name.
+        it("does not collide when channelId or subnetMemberId contains a colon", () => {
+            const a = bindingProgramName("a:b", "c")
+            const b = bindingProgramName("a", "b:c")
+            expect(a).not.toBe(b)
+        })
+
+        it("preserves backward-compat for ids without special chars", () => {
+            expect(bindingProgramName("ch-1", "mem-2")).toBe(
+                "l2ps-binding:ch-1:mem-2",
+            )
+        })
+    })
+
+    describe("boundAt validation (CodeRabbit regression)", () => {
+        it("createMembershipBinding refuses a negative boundAt", async () => {
+            await expect(
+                createMembershipBinding({
+                    channelId: CHANNEL,
+                    subnetMemberId: MEMBER,
+                    claim,
+                    demos,
+                    boundAt: -1,
+                }),
+            ).rejects.toThrow(/boundAt/)
+        })
+
+        it("createMembershipBinding refuses a non-integer boundAt", async () => {
+            await expect(
+                createMembershipBinding({
+                    channelId: CHANNEL,
+                    subnetMemberId: MEMBER,
+                    claim,
+                    demos,
+                    boundAt: 1.5,
+                }),
+            ).rejects.toThrow(/boundAt/)
+        })
+
+        it("verifyMembershipBinding rejects a binding whose boundAt was clobbered to NaN at rest", async () => {
+            const ok = await createMembershipBinding({
+                channelId: CHANNEL,
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+            })
+            const clobbered = {
+                ...ok,
+                boundAt: Number.NaN,
+            } as unknown as L2PSMembershipBinding
+            expect(verifyMembershipBinding(clobbered)).toBe(false)
+        })
+    })
 })

--- a/src/tests/l2ps/binding.test.ts
+++ b/src/tests/l2ps/binding.test.ts
@@ -1,0 +1,308 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import {
+    demosClaimRefForAddress,
+    type ClaimReference,
+} from "@/identity/cci"
+import {
+    BINDING_DOMAIN_PREFIX,
+    bindingProgramName,
+    bindingSigningBytes,
+    createMembershipBinding,
+    signatureFromHex,
+    signatureToHex,
+    stripBindingSignature,
+    verifyMembershipBinding,
+    type L2PSMembershipBinding,
+} from "@/l2ps/binding"
+
+const CHANNEL = "ch-7f9a"
+const MEMBER = "rsa-fingerprint-1"
+
+async function newConnectedDemos(): Promise<Demos> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const d = new Demos()
+    await d.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return d
+}
+
+describe("L2PS membership binding (WI-1)", () => {
+    let demos: Demos
+    let claim: ClaimReference
+
+    beforeAll(async () => {
+        demos = await newConnectedDemos()
+        claim = demosClaimRefForAddress(await demos.getEd25519Address())
+    })
+
+    describe("bindingProgramName", () => {
+        it("is deterministic and scoped to channel + member", () => {
+            expect(bindingProgramName(CHANNEL, MEMBER)).toBe(
+                `l2ps-binding:${CHANNEL}:${MEMBER}`,
+            )
+        })
+    })
+
+    describe("bindingSigningBytes", () => {
+        const unsigned = (overrides: Partial<L2PSMembershipBinding> = {}) => ({
+            bindingVersion: "1" as const,
+            channelId: CHANNEL,
+            subnetMemberId: MEMBER,
+            cciPrimaryClaim: ("demos:0x" + "a".repeat(64)) as ClaimReference,
+            boundAt: 1700000000000,
+            ...overrides,
+        })
+
+        it("starts with the dacs-binding:v1: domain prefix", () => {
+            const bytes = bindingSigningBytes(unsigned())
+            const str = new TextDecoder().decode(bytes)
+            expect(str.startsWith(BINDING_DOMAIN_PREFIX)).toBe(true)
+            expect(str.length).toBe(BINDING_DOMAIN_PREFIX.length + 64)
+        })
+
+        it("is stable across invocations", () => {
+            const a = bindingSigningBytes(unsigned())
+            const b = bindingSigningBytes(unsigned())
+            expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true)
+        })
+
+        it("differs when channelId differs", () => {
+            const a = bindingSigningBytes(unsigned({ channelId: "ch-A" }))
+            const b = bindingSigningBytes(unsigned({ channelId: "ch-B" }))
+            expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false)
+        })
+
+        it("differs when subnetMemberId differs", () => {
+            const a = bindingSigningBytes(unsigned({ subnetMemberId: "m-1" }))
+            const b = bindingSigningBytes(unsigned({ subnetMemberId: "m-2" }))
+            expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false)
+        })
+
+        it("differs when boundAt differs", () => {
+            const a = bindingSigningBytes(unsigned({ boundAt: 100 }))
+            const b = bindingSigningBytes(unsigned({ boundAt: 101 }))
+            expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false)
+        })
+    })
+
+    describe("createMembershipBinding", () => {
+        it("produces a binding that verifies", async () => {
+            const b = await createMembershipBinding({
+                channelId: CHANNEL,
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+            })
+            expect(b.bindingVersion).toBe("1")
+            expect(b.channelId).toBe(CHANNEL)
+            expect(b.subnetMemberId).toBe(MEMBER)
+            expect(b.cciPrimaryClaim).toBe(claim)
+            expect(b.signature.startsWith("0x")).toBe(true)
+            expect(verifyMembershipBinding(b)).toBe(true)
+        })
+
+        it("refuses missing channelId", async () => {
+            await expect(
+                createMembershipBinding({
+                    channelId: "",
+                    subnetMemberId: MEMBER,
+                    claim,
+                    demos,
+                }),
+            ).rejects.toThrow(/channelId required/)
+        })
+
+        it("refuses missing subnetMemberId", async () => {
+            await expect(
+                createMembershipBinding({
+                    channelId: CHANNEL,
+                    subnetMemberId: "",
+                    claim,
+                    demos,
+                }),
+            ).rejects.toThrow(/subnetMemberId required/)
+        })
+
+        it("refuses non-demos claim schemes", async () => {
+            await expect(
+                createMembershipBinding({
+                    channelId: CHANNEL,
+                    subnetMemberId: MEMBER,
+                    claim: "eip155:0x1234" as ClaimReference,
+                    demos,
+                }),
+            ).rejects.toThrow(/demos:/)
+        })
+
+        it("refuses if claim does not match connected wallet", async () => {
+            const otherDemos = await newConnectedDemos()
+            const otherClaim = demosClaimRefForAddress(
+                await otherDemos.getEd25519Address(),
+            )
+            await expect(
+                createMembershipBinding({
+                    channelId: CHANNEL,
+                    subnetMemberId: MEMBER,
+                    claim: otherClaim,
+                    demos,
+                }),
+            ).rejects.toThrow(/does not match/)
+        })
+
+        it("honours the provided boundAt", async () => {
+            const at = 1700000000000
+            const b = await createMembershipBinding({
+                channelId: CHANNEL,
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+                boundAt: at,
+            })
+            expect(b.boundAt).toBe(at)
+        })
+    })
+
+    describe("verifyMembershipBinding — tampering detection", () => {
+        let baseline: L2PSMembershipBinding
+
+        beforeAll(async () => {
+            baseline = await createMembershipBinding({
+                channelId: CHANNEL,
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+            })
+        })
+
+        it("accepts the untampered baseline", () => {
+            expect(verifyMembershipBinding(baseline)).toBe(true)
+        })
+
+        it("rejects tampered channelId", () => {
+            expect(
+                verifyMembershipBinding({ ...baseline, channelId: "ch-evil" }),
+            ).toBe(false)
+        })
+
+        it("rejects tampered subnetMemberId", () => {
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    subnetMemberId: "impostor",
+                }),
+            ).toBe(false)
+        })
+
+        it("rejects tampered boundAt", () => {
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    boundAt: baseline.boundAt + 1,
+                }),
+            ).toBe(false)
+        })
+
+        it("rejects swapped cciPrimaryClaim (different key)", async () => {
+            const otherDemos = await newConnectedDemos()
+            const otherClaim = demosClaimRefForAddress(
+                await otherDemos.getEd25519Address(),
+            )
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    cciPrimaryClaim: otherClaim,
+                }),
+            ).toBe(false)
+        })
+
+        it("rejects zero signature", () => {
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    signature: "0x" + "00".repeat(64),
+                }),
+            ).toBe(false)
+        })
+
+        it("rejects malformed signature hex", () => {
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    signature: "not-hex",
+                }),
+            ).toBe(false)
+        })
+
+        it("rejects unknown bindingVersion", () => {
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    bindingVersion: "2",
+                } as unknown as L2PSMembershipBinding),
+            ).toBe(false)
+        })
+
+        it("rejects non-demos claim scheme", () => {
+            expect(
+                verifyMembershipBinding({
+                    ...baseline,
+                    cciPrimaryClaim: "eip155:0xabcd",
+                } as unknown as L2PSMembershipBinding),
+            ).toBe(false)
+        })
+
+        it("rejects a binding lifted from a different channel", async () => {
+            const otherChannel = await createMembershipBinding({
+                channelId: "ch-OTHER",
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+            })
+            const replayed: L2PSMembershipBinding = {
+                ...otherChannel,
+                channelId: CHANNEL,
+            }
+            expect(verifyMembershipBinding(replayed)).toBe(false)
+        })
+    })
+
+    describe("hex helpers", () => {
+        it("roundtrips Uint8Array -> hex -> Uint8Array", () => {
+            const original = new Uint8Array(64)
+            for (let i = 0; i < 64; i++) original[i] = i
+            const hex = signatureToHex(original)
+            const back = signatureFromHex(hex)
+            expect(Buffer.from(back).equals(Buffer.from(original))).toBe(true)
+            expect(hex.length).toBe(2 + 64 * 2)
+        })
+
+        it("signatureFromHex accepts both 0x-prefixed and bare hex", () => {
+            const a = signatureFromHex("0xab")
+            const b = signatureFromHex("ab")
+            expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true)
+        })
+
+        it("signatureFromHex rejects non-hex characters", () => {
+            expect(() => signatureFromHex("0xzz")).toThrow()
+        })
+
+        it("signatureFromHex rejects odd-length hex", () => {
+            expect(() => signatureFromHex("abc")).toThrow()
+        })
+    })
+
+    describe("stripBindingSignature", () => {
+        it("removes the signature field", async () => {
+            const b = await createMembershipBinding({
+                channelId: CHANNEL,
+                subnetMemberId: MEMBER,
+                claim,
+                demos,
+            })
+            const stripped = stripBindingSignature(b)
+            expect("signature" in stripped).toBe(false)
+            expect(stripped.channelId).toBe(b.channelId)
+            expect(stripped.cciPrimaryClaim).toBe(b.cciPrimaryClaim)
+        })
+    })
+})

--- a/src/tests/l2ps/channel.test.ts
+++ b/src/tests/l2ps/channel.test.ts
@@ -534,7 +534,7 @@ describe("ChannelSession.sendOutgoing — concurrency (P1 regression)", () => {
         const [m1, m2] = await Promise.all([p1, p2])
 
         expect(m1.sequence).not.toBe(m2.sequence)
-        const seen = [m1.sequence, m2.sequence].sort()
+        const seen = [m1.sequence, m2.sequence].sort((a, b) => a - b)
         expect(seen).toEqual([1, 2])
     })
 

--- a/src/tests/l2ps/channel.test.ts
+++ b/src/tests/l2ps/channel.test.ts
@@ -1,0 +1,513 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import {
+    demosClaimRefForAddress,
+    type ClaimReference,
+} from "@/identity/cci"
+import {
+    ChannelSession,
+    CHANNEL_MESSAGE_DOMAIN_PREFIX,
+    channelMessageSigningBytes,
+    envelopeHashHex,
+    exportTranscript,
+    InMemoryChannelIdRegistry,
+    signChannelMessage,
+    signTranscript,
+    stripChannelMessageSignature,
+    transcriptSigningBytes,
+    TRANSCRIPT_DOMAIN_PREFIX,
+    verifyChannelMessage,
+    verifyTranscript,
+    type ChannelMessage,
+    type UnsignedChannelMessage,
+} from "@/l2ps/channel"
+
+const CHANNEL = "ch-7f9a"
+
+async function newConnectedDemos(): Promise<{
+    demos: Demos
+    claim: ClaimReference
+}> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return {
+        demos,
+        claim: demosClaimRefForAddress(await demos.getEd25519Address()),
+    }
+}
+
+function unsignedFixture(
+    sender: ClaimReference,
+    overrides: Partial<UnsignedChannelMessage> = {},
+): UnsignedChannelMessage {
+    return {
+        channelId: CHANNEL,
+        sequence: 1,
+        sender,
+        sentAt: 1700000000000,
+        type: "offer",
+        body: { price: 100 },
+        ...overrides,
+    }
+}
+
+describe("Channel canonical bytes (WI-2)", () => {
+    it("envelope signing bytes start with dacs-channelmsg:v1: + 64-hex digest", async () => {
+        const { claim } = await newConnectedDemos()
+        const bytes = channelMessageSigningBytes(unsignedFixture(claim))
+        const str = new TextDecoder().decode(bytes)
+        expect(str.startsWith(CHANNEL_MESSAGE_DOMAIN_PREFIX)).toBe(true)
+        expect(str.length).toBe(CHANNEL_MESSAGE_DOMAIN_PREFIX.length + 64)
+    })
+
+    it("envelopeHashHex is stable across invocations", async () => {
+        const { claim } = await newConnectedDemos()
+        const fx = unsignedFixture(claim)
+        expect(envelopeHashHex(fx)).toBe(envelopeHashHex(fx))
+    })
+
+    it("envelopeHashHex differs when any field differs", async () => {
+        const { claim } = await newConnectedDemos()
+        const a = envelopeHashHex(unsignedFixture(claim, { sequence: 1 }))
+        const b = envelopeHashHex(unsignedFixture(claim, { sequence: 2 }))
+        expect(a).not.toBe(b)
+    })
+
+    it("transcript signing bytes use dacs-transcript:v1:", async () => {
+        const { claim } = await newConnectedDemos()
+        const bytes = transcriptSigningBytes({
+            transcriptVersion: "1",
+            channelId: CHANNEL,
+            members: [claim],
+            messages: [],
+            generatedAt: 1700000000000,
+        })
+        expect(
+            new TextDecoder().decode(bytes).startsWith(TRANSCRIPT_DOMAIN_PREFIX),
+        ).toBe(true)
+    })
+})
+
+describe("signChannelMessage / verifyChannelMessage (WI-2)", () => {
+    it("round-trips: sign → verify true", async () => {
+        const { demos, claim } = await newConnectedDemos()
+        const signed = await signChannelMessage(unsignedFixture(claim), demos)
+        expect(signed.signature.sigVersion).toBe("1")
+        expect(signed.signature.signature.startsWith("0x")).toBe(true)
+        expect(verifyChannelMessage(signed)).toBe(true)
+    })
+
+    it("rejects tampered body", async () => {
+        const { demos, claim } = await newConnectedDemos()
+        const signed = await signChannelMessage(unsignedFixture(claim), demos)
+        const tampered: ChannelMessage = { ...signed, body: { price: 999 } }
+        expect(verifyChannelMessage(tampered)).toBe(false)
+    })
+
+    it("rejects tampered sequence", async () => {
+        const { demos, claim } = await newConnectedDemos()
+        const signed = await signChannelMessage(unsignedFixture(claim), demos)
+        expect(verifyChannelMessage({ ...signed, sequence: 999 })).toBe(false)
+    })
+
+    it("rejects swapped sender claim", async () => {
+        const { demos, claim } = await newConnectedDemos()
+        const other = await newConnectedDemos()
+        const signed = await signChannelMessage(unsignedFixture(claim), demos)
+        expect(verifyChannelMessage({ ...signed, sender: other.claim })).toBe(
+            false,
+        )
+    })
+
+    it("refuses to sign when sender does not match connected wallet", async () => {
+        const { demos } = await newConnectedDemos()
+        const other = await newConnectedDemos()
+        await expect(
+            signChannelMessage(unsignedFixture(other.claim), demos),
+        ).rejects.toThrow(/does not match/)
+    })
+
+    it("refuses non-demos sender", async () => {
+        const { demos } = await newConnectedDemos()
+        const fx = unsignedFixture("eip155:0x1234" as ClaimReference)
+        await expect(signChannelMessage(fx, demos)).rejects.toThrow(
+            /demos:/,
+        )
+    })
+
+    it("refuses sequence < 1", async () => {
+        const { demos, claim } = await newConnectedDemos()
+        await expect(
+            signChannelMessage(unsignedFixture(claim, { sequence: 0 }), demos),
+        ).rejects.toThrow(/sequence/)
+    })
+})
+
+describe("InMemoryChannelIdRegistry (CH-6)", () => {
+    it("rejects channelId reuse", async () => {
+        const reg = new InMemoryChannelIdRegistry()
+        await reg.register("ch-A")
+        await expect(reg.register("ch-A")).rejects.toThrow(
+            /already registered/,
+        )
+    })
+
+    it("allows distinct channelIds", async () => {
+        const reg = new InMemoryChannelIdRegistry()
+        await reg.register("ch-A")
+        await reg.register("ch-B")
+        expect(await reg.has("ch-A")).toBe(true)
+        expect(await reg.has("ch-B")).toBe(true)
+    })
+
+    it("refuses empty channelId", async () => {
+        const reg = new InMemoryChannelIdRegistry()
+        await expect(reg.register("")).rejects.toThrow(/required/)
+    })
+})
+
+describe("ChannelSession (WI-2)", () => {
+    let alice: { demos: Demos; claim: ClaimReference }
+    let bob: { demos: Demos; claim: ClaimReference }
+
+    beforeEach(async () => {
+        alice = await newConnectedDemos()
+        bob = await newConnectedDemos()
+    })
+
+    it("rejects me ∉ members", () => {
+        expect(
+            () =>
+                new ChannelSession({
+                    channelId: CHANNEL,
+                    members: [bob.claim],
+                    me: alice.claim,
+                    demos: alice.demos,
+                }),
+        ).toThrow(/not in members/)
+    })
+
+    it("sendOutgoing → counterparty.receiveIncoming roundtrips", async () => {
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const bSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await aSes.open()
+        await bSes.open()
+
+        const msg = await aSes.sendOutgoing({ type: "offer", body: { x: 1 } })
+        expect(msg.sequence).toBe(1)
+        await expect(bSes.receiveIncoming(msg)).resolves.toBeUndefined()
+
+        const reply = await bSes.sendOutgoing({
+            type: "counter",
+            body: { x: 2 },
+            repliesTo: 1,
+        })
+        expect(reply.sequence).toBe(2)
+        expect(reply.refs?.repliesTo).toBe(1)
+        await expect(aSes.receiveIncoming(reply)).resolves.toBeUndefined()
+    })
+
+    it("rejects out-of-order incoming sequence", async () => {
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const bSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await aSes.open()
+        await bSes.open()
+
+        const m1 = await aSes.sendOutgoing({ type: "offer", body: 1 })
+        const m2 = await aSes.sendOutgoing({ type: "offer", body: 2 })
+        await bSes.receiveIncoming(m2)
+        await expect(bSes.receiveIncoming(m1)).rejects.toThrow(
+            /non-monotonic/,
+        )
+    })
+
+    it("rejects duplicate incoming sequence", async () => {
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const bSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await aSes.open()
+        await bSes.open()
+
+        const m1 = await aSes.sendOutgoing({ type: "offer", body: 1 })
+        await bSes.receiveIncoming(m1)
+        await expect(bSes.receiveIncoming(m1)).rejects.toThrow(
+            /non-monotonic/,
+        )
+    })
+
+    it("rejects message with different channelId (replay into wrong channel)", async () => {
+        const aSes = new ChannelSession({
+            channelId: "ch-A",
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const bSes = new ChannelSession({
+            channelId: "ch-B",
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await aSes.open()
+        await bSes.open()
+
+        const m1 = await aSes.sendOutgoing({ type: "offer", body: 1 })
+        await expect(bSes.receiveIncoming(m1)).rejects.toThrow(
+            /channelId mismatch/,
+        )
+    })
+
+    it("rejects message from non-member sender", async () => {
+        const eve = await newConnectedDemos()
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        await aSes.open()
+        const eveMsg = await signChannelMessage(
+            unsignedFixture(eve.claim, { sequence: 1 }),
+            eve.demos,
+        )
+        await expect(aSes.receiveIncoming(eveMsg)).rejects.toThrow(
+            /not in members/,
+        )
+    })
+
+    it("rejects message with invalid signature", async () => {
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const bSes = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await aSes.open()
+        await bSes.open()
+        const m1 = await aSes.sendOutgoing({ type: "offer", body: 1 })
+        const tampered: ChannelMessage = { ...m1, body: 999 }
+        await expect(bSes.receiveIncoming(tampered)).rejects.toThrow(
+            /signature/,
+        )
+    })
+
+    it("CH-6: registry rejects channelId reuse across sessions", async () => {
+        const registry = new InMemoryChannelIdRegistry()
+        const a = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim],
+            me: alice.claim,
+            demos: alice.demos,
+            channelIdRegistry: registry,
+        })
+        await a.open()
+
+        const b = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim],
+            me: alice.claim,
+            demos: alice.demos,
+            channelIdRegistry: registry,
+        })
+        await expect(b.open()).rejects.toThrow(/CH-6/)
+    })
+
+    it("refuses sendOutgoing before open", async () => {
+        const a = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        await expect(
+            a.sendOutgoing({ type: "offer", body: {} }),
+        ).rejects.toThrow(/open/)
+    })
+
+    it("messages() returns ordered local transcript", async () => {
+        const a = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const b = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await a.open()
+        await b.open()
+        const m1 = await a.sendOutgoing({ type: "offer", body: 1 })
+        await b.receiveIncoming(m1)
+        const m2 = await b.sendOutgoing({ type: "counter", body: 2 })
+        await a.receiveIncoming(m2)
+
+        expect(a.messages().map(m => m.sequence)).toEqual([1, 2])
+        expect(b.messages().map(m => m.sequence)).toEqual([1, 2])
+    })
+
+    it("stripChannelMessageSignature drops signature only", async () => {
+        const { demos, claim } = await newConnectedDemos()
+        const signed = await signChannelMessage(unsignedFixture(claim), demos)
+        const stripped = stripChannelMessageSignature(signed)
+        expect("signature" in stripped).toBe(false)
+        expect(stripped.sequence).toBe(signed.sequence)
+    })
+})
+
+describe("Transcript (WI-2 → consumed by WI-3)", () => {
+    let alice: { demos: Demos; claim: ClaimReference }
+    let bob: { demos: Demos; claim: ClaimReference }
+
+    beforeEach(async () => {
+        alice = await newConnectedDemos()
+        bob = await newConnectedDemos()
+    })
+
+    async function runSession(): Promise<{
+        members: ClaimReference[]
+        messages: ChannelMessage[]
+    }> {
+        const a = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const b = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await a.open()
+        await b.open()
+        const m1 = await a.sendOutgoing({ type: "offer", body: { price: 100 } })
+        await b.receiveIncoming(m1)
+        const m2 = await b.sendOutgoing({
+            type: "counter",
+            body: { price: 90 },
+            repliesTo: 1,
+        })
+        await a.receiveIncoming(m2)
+        const m3 = await a.sendOutgoing({
+            type: "accept",
+            body: {},
+            repliesTo: 2,
+        })
+        await b.receiveIncoming(m3)
+        return {
+            members: [alice.claim, bob.claim],
+            messages: [m1, m2, m3],
+        }
+    }
+
+    it("exportTranscript produces a transcript that re-verifies", async () => {
+        const { members, messages } = await runSession()
+        const t = await exportTranscript({
+            channelId: CHANNEL,
+            members,
+            messages,
+            signers: [
+                { claim: alice.claim, demos: alice.demos },
+                { claim: bob.claim, demos: bob.demos },
+            ],
+        })
+        expect(t.transcriptVersion).toBe("1")
+        expect(t.signatures.length).toBe(2)
+        const result = verifyTranscript(t)
+        expect(result.ok).toBe(true)
+        expect(result.errors).toEqual([])
+    })
+
+    it("verifyTranscript catches a tampered message", async () => {
+        const { members, messages } = await runSession()
+        const t = await exportTranscript({
+            channelId: CHANNEL,
+            members,
+            messages,
+            signers: [{ claim: alice.claim, demos: alice.demos }],
+        })
+        const tampered = {
+            ...t,
+            messages: [{ ...t.messages[0], body: { price: 1 } }, ...t.messages.slice(1)],
+        }
+        const result = verifyTranscript(tampered)
+        expect(result.ok).toBe(false)
+        expect(result.errors.some(e => /signature verification/.test(e))).toBe(
+            true,
+        )
+    })
+
+    it("verifyTranscript catches non-member transcript signer", async () => {
+        const { members, messages } = await runSession()
+        const eve = await newConnectedDemos()
+        const t = await exportTranscript({
+            channelId: CHANNEL,
+            members,
+            messages,
+            signers: [{ claim: eve.claim, demos: eve.demos }],
+        })
+        const result = verifyTranscript(t)
+        expect(result.ok).toBe(false)
+        expect(
+            result.errors.some(e => /not in members/.test(e)),
+        ).toBe(true)
+    })
+
+    it("signTranscript refuses non-demos signer", async () => {
+        const { members, messages } = await runSession()
+        const unsigned = {
+            transcriptVersion: "1" as const,
+            channelId: CHANNEL,
+            members,
+            messages,
+            generatedAt: 1700000000000,
+        }
+        await expect(
+            signTranscript(
+                unsigned,
+                "eip155:0xabc" as ClaimReference,
+                alice.demos,
+            ),
+        ).rejects.toThrow(/demos:/)
+    })
+})

--- a/src/tests/l2ps/channel.test.ts
+++ b/src/tests/l2ps/channel.test.ts
@@ -511,3 +511,49 @@ describe("Transcript (WI-2 → consumed by WI-3)", () => {
         ).rejects.toThrow(/demos:/)
     })
 })
+
+describe("ChannelSession.sendOutgoing — concurrency (P1 regression)", () => {
+    // Regression for greptile P1 on session.ts: sendOutgoing read
+    // `highestSeen` BEFORE await signChannelMessage and wrote it AFTER,
+    // so two unawaited concurrent calls produced duplicate sequence
+    // numbers. Post-fix, the slot is reserved synchronously via ++.
+    it("two unawaited sendOutgoing calls get distinct, monotonic sequence numbers", async () => {
+        const alice = await newConnectedDemos()
+        const bob = await newConnectedDemos()
+        const session = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        await session.open()
+
+        // Fire BOTH calls before awaiting either, then await together.
+        const p1 = session.sendOutgoing({ type: "offer", body: { i: 1 } })
+        const p2 = session.sendOutgoing({ type: "offer", body: { i: 2 } })
+        const [m1, m2] = await Promise.all([p1, p2])
+
+        expect(m1.sequence).not.toBe(m2.sequence)
+        const seen = [m1.sequence, m2.sequence].sort()
+        expect(seen).toEqual([1, 2])
+    })
+
+    it("burst of 5 concurrent sendOutgoing calls gets 5 distinct sequences", async () => {
+        const alice = await newConnectedDemos()
+        const bob = await newConnectedDemos()
+        const session = new ChannelSession({
+            channelId: CHANNEL,
+            members: [alice.claim, bob.claim],
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        await session.open()
+
+        const promises = Array.from({ length: 5 }, (_, i) =>
+            session.sendOutgoing({ type: "offer", body: { i } }),
+        )
+        const msgs = await Promise.all(promises)
+        const seqs = msgs.map(m => m.sequence).sort((a, b) => a - b)
+        expect(seqs).toEqual([1, 2, 3, 4, 5])
+    })
+})

--- a/src/websdk/BroadcastFailedError.ts
+++ b/src/websdk/BroadcastFailedError.ts
@@ -13,7 +13,7 @@
  */
 export class BroadcastFailedError extends Error {
     public readonly txHash: string
-    public readonly cause: unknown
+    public override readonly cause: unknown
 
     constructor(opts: { txHash: string; cause: unknown; message?: string }) {
         const causeMessage =

--- a/src/websdk/TransportError.ts
+++ b/src/websdk/TransportError.ts
@@ -9,7 +9,7 @@
  */
 export class TransportError extends Error {
     public readonly attempts: number
-    public readonly cause: unknown
+    public override readonly cause: unknown
 
     constructor(message: string, opts: { cause: unknown; attempts: number }) {
         super(message)


### PR DESCRIPTION
…ted transcript anchor

Closes the three 🟡 gaps in DACS-3 CORE §A.4 so `negotiate-rfq` and `negotiate-sealed-envelope` can run end-to-end on a real private channel.

The invariant from §0 — in-channel signer == on-chain party — is enforced substrate-side: every signature path here goes through the connected Demos Ed25519 key (NEVER the RSA L2PS subnet key). All signatures are domain-separated (`dacs-binding:v1:`, `dacs-channelmsg:v1:`, `dacs-transcript:v1:`) over RFC 8785 JCS canonical bytes per §B.7.

What is shipped:

- WI-0 — `identity/cci`: `ClaimReference` + `signWithPrimaryClaim` / `verifyPrimaryClaimSignature`. Required because the brief assumes types that did not yet exist in SDK.

- WI-1 — `l2ps/binding`: `L2PSMembershipBinding` + SR-2 anchor + `resolveMember`. Resolver enforces the dual check (signature + SP-owner matches claim address) so an impostor cannot poison a binding name.

- WI-2 — `l2ps/channel`: `ChannelMessage` envelope (verbatim §8.3.3), monotonic per-channel sequence + `InMemoryChannelIdRegistry` (CH-6), `ChannelSession` orchestrator, transcript export + audit verifier.

- WI-3 — `l2ps/anchor`: `anchorEncryptedTranscript` with the three §8.7 policies. Reuses L2PS subnet AES-GCM (new `encryptBytes`/`decryptBytes` primitives on the L2PS class, mirroring the per-call-nonce + AAD pattern from `encryptTx`). Anchored payload carries a public content hash so non-members can verify tamper-evidence without the key.

Also: add `override` to `cause: unknown` in BroadcastFailedError and TransportError — pre-existing TS4114 in main (noImplicitOverride) that was blocking the build hook.

New package exports: `@kynesyslabs/demosdk/identity` and `@kynesyslabs/demosdk/identity/cci`. The l2ps barrel now also exposes `binding`, `channel`, `anchor` namespaces.

Tests: 98 unit tests (jest) across the four work items — round-trips, tampering detection, replay/forking, policy gating, signing-key mismatches. Integration tests against a live chain are deferred until the dev environment is back up.

Linear: DEM-760 (epic), DEM-761/762/763/764 (WI-0..WI-3).
Brief: docs/l2ps-sr4-implementation-brief.md in the node repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cross-Context Identity (CCI) system for managing claim references and Ed25519 primary claim signatures
  * Introduced L2PS membership bindings to anchor channel membership on-chain with cryptographic verification
  * Enabled encrypted transcript anchoring with tamper-evidence validation and decryption recovery
  * Launched channel messaging session framework with built-in transcript generation, signing, and comprehensive verification

* **Tests**
  * Added extensive test coverage for identity, bindings, anchoring, and channel messaging functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->