### PR TITLE
feat(l2ps): SR-4 WI-B — negotiate-rfq phase logic

### DIFF
--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -59,3 +59,14 @@ export {
     type SerializedEncryptedMessage,
     type IncomingMessagePayload,
 } from "./transport"
+
+export {
+    RfqSession,
+    type RfqState,
+    type RfqOutcome,
+    type RfqSessionOpts,
+    type RfqProposalBody,
+    type RfqAcceptBody,
+    type RfqEndBody,
+    type StandingProposal,
+} from "./negotiate"

--- a/src/l2ps/channel/negotiate.ts
+++ b/src/l2ps/channel/negotiate.ts
@@ -1,0 +1,256 @@
+/**
+ * SR-4 WI-B — `negotiate-rfq` phase logic.
+ *
+ * A request-for-quote negotiation is a turn-based exchange of `offer` /
+ * `counter` proposals terminating in `accept`, `reject`, or `abort`
+ * (CH-5 termination; DACS-3 §8.3). Per the SR-4 brief the RFQ message
+ * *bodies* are implementation-defined (only sealed-envelope bodies are
+ * spec-locked, §8.4.3), so this layer fixes a minimal body schema and
+ * the state machine while staying agnostic to the actual `terms`.
+ *
+ * `RfqSession` is a pure protocol state machine. It does not move bytes:
+ * the caller wires its `send` callback to a transport (e.g.
+ * `L2PSChannelTransport.send`) and feeds verified inbound envelopes to
+ * `onIncoming`. By the time a message reaches `onIncoming` the channel
+ * layer has already verified the signature, `sender ∈ members`, the
+ * channelId, and monotonic sequence — so this layer only enforces
+ * protocol-level rules (legal transitions, body shape, referencing an
+ * existing offer).
+ */
+
+import type { ChannelMessage, ChannelMessageType } from "./types"
+import type { ClaimReference } from "../../identity/cci"
+
+/** Terminal + in-progress states (CH-5). */
+export type RfqState = "open" | "accepted" | "rejected" | "aborted"
+
+/** Body of an `offer` / `counter` — `terms` is opaque (impl-defined). */
+export interface RfqProposalBody {
+    terms: unknown
+}
+/** Body of an `accept` — references the proposal sequence being accepted. */
+export interface RfqAcceptBody {
+    acceptedSequence: number
+}
+/** Body of a `reject` / `abort`. */
+export interface RfqEndBody {
+    reason?: string
+}
+
+/** A standing proposal on the table. */
+export interface StandingProposal {
+    sequence: number
+    sender: ClaimReference
+    terms: unknown
+}
+
+export interface RfqOutcome {
+    state: RfqState
+    /** Set when `state === "accepted"`: the terms that were agreed. */
+    agreedTerms?: unknown
+    /** Sequence of the proposal that was accepted. */
+    acceptedSequence?: number
+    /** Reason for a reject / abort, if given. */
+    reason?: string
+}
+
+export interface RfqSessionOpts {
+    /** This party's CCI primary claim. */
+    me: ClaimReference
+    /**
+     * Delivers a signed channel message. Wire to the transport's send
+     * (e.g. `L2PSChannelTransport.send`). Returns the signed envelope so
+     * the session can track the sequence it produced.
+     */
+    send: (opts: {
+        type: ChannelMessageType
+        body: unknown
+        repliesTo?: number
+    }) => Promise<ChannelMessage>
+    /** Fired on every state transition (including the terminal one). */
+    onStateChange?: (outcome: RfqOutcome) => void
+    /** Fired when a fresh proposal (offer/counter) lands, ours or theirs. */
+    onProposal?: (proposal: StandingProposal) => void
+}
+
+const RFQ_TYPES: ReadonlySet<ChannelMessageType> = new Set<ChannelMessageType>([
+    "offer",
+    "counter",
+    "accept",
+    "reject",
+    "abort",
+])
+
+export class RfqSession {
+    private readonly me: ClaimReference
+    private readonly sendFn: RfqSessionOpts["send"]
+    private readonly onStateChange?: (o: RfqOutcome) => void
+    private readonly onProposal?: (p: StandingProposal) => void
+
+    private _state: RfqState = "open"
+    private _standing: StandingProposal | null = null
+    /** Every proposal seen, by sequence — so `accept` can resolve its terms. */
+    private readonly proposals = new Map<number, StandingProposal>()
+    private _outcome: RfqOutcome = { state: "open" }
+
+    constructor(opts: RfqSessionOpts) {
+        this.me = opts.me
+        this.sendFn = opts.send
+        this.onStateChange = opts.onStateChange
+        this.onProposal = opts.onProposal
+    }
+
+    get state(): RfqState {
+        return this._state
+    }
+    /** The proposal currently on the table, or null before the first offer. */
+    get standingProposal(): StandingProposal | null {
+        return this._standing
+    }
+    outcome(): RfqOutcome {
+        return this._outcome
+    }
+
+    /** Open a negotiation with the first proposal. */
+    async offer(terms: unknown): Promise<ChannelMessage> {
+        this.assertOpen("offer")
+        if (this._standing)
+            throw new Error(
+                "RfqSession: a proposal already stands; use counter()",
+            )
+        return this.proposeOutgoing("offer", terms)
+    }
+
+    /** Counter the standing proposal with new terms. */
+    async counter(terms: unknown): Promise<ChannelMessage> {
+        this.assertOpen("counter")
+        if (!this._standing)
+            throw new Error("RfqSession: nothing to counter — no standing offer")
+        return this.proposeOutgoing("counter", terms, this._standing.sequence)
+    }
+
+    /** Accept the standing proposal — terminal (CH-5). */
+    async accept(): Promise<ChannelMessage> {
+        this.assertOpen("accept")
+        if (!this._standing)
+            throw new Error("RfqSession: nothing to accept — no standing offer")
+        const accepted = this._standing
+        const body: RfqAcceptBody = { acceptedSequence: accepted.sequence }
+        const msg = await this.sendFn({
+            type: "accept",
+            body,
+            repliesTo: accepted.sequence,
+        })
+        this.settle({
+            state: "accepted",
+            agreedTerms: accepted.terms,
+            acceptedSequence: accepted.sequence,
+        })
+        return msg
+    }
+
+    /** Reject the negotiation — terminal (CH-5). */
+    async reject(reason?: string): Promise<ChannelMessage> {
+        this.assertOpen("reject")
+        const body: RfqEndBody = reason ? { reason } : {}
+        const msg = await this.sendFn({ type: "reject", body })
+        this.settle({ state: "rejected", reason })
+        return msg
+    }
+
+    /** Abort the negotiation — terminal (CH-5). */
+    async abort(reason?: string): Promise<ChannelMessage> {
+        this.assertOpen("abort")
+        const body: RfqEndBody = reason ? { reason } : {}
+        const msg = await this.sendFn({ type: "abort", body })
+        this.settle({ state: "aborted", reason })
+        return msg
+    }
+
+    /**
+     * Feed a verified inbound channel message. No-op for non-RFQ types or
+     * messages arriving after a terminal state (a late duplicate of an
+     * end message). Throws only on a protocol violation that the channel
+     * layer can't catch (e.g. accept referencing an unknown proposal).
+     */
+    onIncoming(msg: ChannelMessage): void {
+        if (!RFQ_TYPES.has(msg.type)) return
+        if (msg.sender === this.me) return // our own echo, already applied
+        if (this._state !== "open") return // terminal — ignore trailing traffic
+
+        switch (msg.type) {
+            case "offer":
+            case "counter": {
+                const terms = (msg.body as RfqProposalBody)?.terms
+                const proposal: StandingProposal = {
+                    sequence: msg.sequence,
+                    sender: msg.sender,
+                    terms,
+                }
+                this.proposals.set(msg.sequence, proposal)
+                this._standing = proposal
+                this.onProposal?.(proposal)
+                break
+            }
+            case "accept": {
+                const seq = (msg.body as RfqAcceptBody)?.acceptedSequence
+                const accepted = this.proposals.get(seq)
+                if (!accepted)
+                    throw new Error(
+                        `RfqSession: accept references unknown proposal sequence ${seq}`,
+                    )
+                this.settle({
+                    state: "accepted",
+                    agreedTerms: accepted.terms,
+                    acceptedSequence: seq,
+                })
+                break
+            }
+            case "reject": {
+                this.settle({
+                    state: "rejected",
+                    reason: (msg.body as RfqEndBody)?.reason,
+                })
+                break
+            }
+            case "abort": {
+                this.settle({
+                    state: "aborted",
+                    reason: (msg.body as RfqEndBody)?.reason,
+                })
+                break
+            }
+        }
+    }
+
+    private async proposeOutgoing(
+        type: "offer" | "counter",
+        terms: unknown,
+        repliesTo?: number,
+    ): Promise<ChannelMessage> {
+        const body: RfqProposalBody = { terms }
+        const msg = await this.sendFn({ type, body, repliesTo })
+        const proposal: StandingProposal = {
+            sequence: msg.sequence,
+            sender: this.me,
+            terms,
+        }
+        this.proposals.set(msg.sequence, proposal)
+        this._standing = proposal
+        this.onProposal?.(proposal)
+        return msg
+    }
+
+    private settle(outcome: RfqOutcome): void {
+        this._state = outcome.state
+        this._outcome = outcome
+        this.onStateChange?.(outcome)
+    }
+
+    private assertOpen(action: string): void {
+        if (this._state !== "open")
+            throw new Error(
+                `RfqSession: cannot ${action} — negotiation is ${this._state}`,
+            )
+    }
+}

--- a/src/tests/l2ps/negotiate.test.ts
+++ b/src/tests/l2ps/negotiate.test.ts
@@ -1,0 +1,151 @@
+import {
+    RfqSession,
+    type RfqAcceptBody,
+    type RfqProposalBody,
+} from "@/l2ps/channel/negotiate"
+import type { ChannelMessage, ChannelMessageType } from "@/l2ps/channel"
+import type { ClaimReference } from "@/identity/cci"
+
+const A = ("demos:0x" + "a".repeat(64)) as ClaimReference
+const B = ("demos:0x" + "b".repeat(64)) as ClaimReference
+
+/**
+ * A two-party RFQ harness: each side has an RfqSession whose `send`
+ * callback mints a ChannelMessage (monotonic shared sequence) and
+ * delivers it to the other side's `onIncoming`. No transport / crypto —
+ * the channel layer's verification is out of scope here; this tests the
+ * protocol state machine.
+ */
+function harness() {
+    let seq = 0
+    let aSes!: RfqSession
+    let bSes!: RfqSession
+
+    const mkSend =
+        (me: string, peer: () => RfqSession) =>
+        async (opts: {
+            type: ChannelMessageType
+            body: unknown
+            repliesTo?: number
+        }): Promise<ChannelMessage> => {
+            const msg = {
+                channelId: "ch",
+                sequence: ++seq,
+                sender: me,
+                sentAt: 1000 + seq,
+                type: opts.type,
+                body: opts.body,
+                ...(opts.repliesTo !== undefined && {
+                    refs: { repliesTo: opts.repliesTo },
+                }),
+                signature: { sigVersion: "1", signature: "0xsig" + seq },
+            } as ChannelMessage
+            // Deliver to the counterparty after the local state settles.
+            queueMicrotask(() => peer().onIncoming(msg))
+            return msg
+        }
+
+    aSes = new RfqSession({ me: A, send: mkSend(A, () => bSes) })
+    bSes = new RfqSession({ me: B, send: mkSend(B, () => aSes) })
+    return { aSes, bSes }
+}
+
+const tick = () => new Promise(r => setTimeout(r, 0))
+
+describe("RfqSession — negotiate-rfq state machine", () => {
+    it("offer → counter → accept settles agreedTerms on both sides", async () => {
+        const { aSes, bSes } = harness()
+
+        await aSes.offer({ price: 100 })
+        await tick()
+        expect(bSes.standingProposal?.terms).toEqual({ price: 100 })
+
+        await bSes.counter({ price: 90 })
+        await tick()
+        expect(aSes.standingProposal?.terms).toEqual({ price: 90 })
+
+        await aSes.accept()
+        await tick()
+
+        expect(aSes.state).toBe("accepted")
+        expect(bSes.state).toBe("accepted")
+        expect(aSes.outcome().agreedTerms).toEqual({ price: 90 })
+        expect(bSes.outcome().agreedTerms).toEqual({ price: 90 })
+        // accept referenced bob's counter (sequence 2)
+        expect(aSes.outcome().acceptedSequence).toBe(2)
+        expect(bSes.outcome().acceptedSequence).toBe(2)
+    })
+
+    it("reject terminates both sides", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 })
+        await tick()
+        await bSes.reject("too high")
+        await tick()
+        expect(bSes.state).toBe("rejected")
+        expect(aSes.state).toBe("rejected")
+        expect(aSes.outcome().reason).toBe("too high")
+    })
+
+    it("accept resolves the terms of the exact proposal it references", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 }) // seq 1
+        await tick()
+        await bSes.counter({ price: 80 }) // seq 2
+        await tick()
+        await aSes.counter({ price: 90 }) // seq 3 (standing)
+        await tick()
+        await bSes.accept() // accepts seq 3
+        await tick()
+        expect(aSes.outcome().agreedTerms).toEqual({ price: 90 })
+        expect(aSes.outcome().acceptedSequence).toBe(3)
+    })
+
+    it("rejects illegal transitions", async () => {
+        const { aSes } = harness()
+        // accept with nothing on the table
+        await expect(aSes.accept()).rejects.toThrow(/nothing to accept/)
+        // counter with nothing on the table
+        await expect(aSes.counter({ x: 1 })).rejects.toThrow(/nothing to counter/)
+
+        await aSes.offer({ price: 100 })
+        // second offer once one stands
+        await expect(aSes.offer({ price: 1 })).rejects.toThrow(
+            /already stands/,
+        )
+    })
+
+    it("refuses any action after a terminal state", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 })
+        await tick()
+        await aSes.accept()
+        await tick()
+        await expect(aSes.counter({ price: 1 })).rejects.toThrow(/accepted/)
+        await expect(aSes.reject()).rejects.toThrow(/accepted/)
+        await expect(bSes.offer({ price: 1 })).rejects.toThrow(/accepted/)
+    })
+
+    it("throws if an inbound accept references an unknown proposal", () => {
+        const { aSes } = harness()
+        const bogus = {
+            channelId: "ch",
+            sequence: 9,
+            sender: B,
+            sentAt: 9,
+            type: "accept" as ChannelMessageType,
+            body: { acceptedSequence: 42 } as RfqAcceptBody,
+            signature: { sigVersion: "1", signature: "0xsig9" },
+        } as ChannelMessage
+        expect(() => aSes.onIncoming(bogus)).toThrow(/unknown proposal/)
+    })
+
+    it("carries impl-defined terms opaquely (offer body shape)", async () => {
+        const { aSes, bSes } = harness()
+        const terms = { sku: "X", qty: 3, note: "rush" }
+        const msg = await aSes.offer(terms)
+        expect((msg.body as RfqProposalBody).terms).toEqual(terms)
+        await tick()
+        expect(bSes.standingProposal?.terms).toEqual(terms)
+    })
+})


### PR DESCRIPTION
Stacked on #95 (WI-A). The negotiate-rfq state machine on top of the SR-4 channel substrate.

## What

`RfqSession` (`src/l2ps/channel/negotiate.ts`) drives offer/counter → accept/reject/abort (CH-5 termination). RFQ bodies are **implementation-defined per the SR-4 brief** (only sealed-envelope bodies are spec-locked, §8.4.3), so this fixes a minimal schema — proposal carries opaque `terms`, accept references the accepted proposal's `sequence` — and the legal-transition rules, staying agnostic to the actual terms.

Pure protocol state machine, transport-agnostic like `ChannelSession`: wire `send` to `L2PSChannelTransport.send` (WI-A) and feed verified inbound envelopes to `onIncoming`. Channel-layer verification (signature / sender∈members / channelId / sequence) happens before `onIncoming`, so this only enforces protocol rules. Accepted terms resolve by the exact proposal sequence the accept points at, so a multi-round counter chain settles correctly on both sides.

## Tests — 7/7

offer→counter→accept settles agreedTerms on both sides; reject terminates both; accept resolves the referenced proposal across a counter chain; illegal transitions rejected; no action after terminal; inbound accept referencing an unknown proposal throws; impl-defined terms carried opaquely.

## Scope

`negotiate-sealed-envelope` (commit-then-reveal) remains gated on DACS-3 §8.4.3, which is not in the repo. WI-C (transcript anchor on terminal) + WI-D (AgreementDocument co-sign) + WI-E (devnet E2E) follow.

## Base

Stacked on #95 so the diff is WI-B only. Rebase onto main once #95 lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced RFQ (Request for Quote) negotiation capability within channel communications, enabling developers to implement structured bidirectional term proposals, counter-offer exchange, and negotiation completion workflows with full state tracking and proposal history management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->