### PR TITLE
fix(identities): assign real nonce to identity txs instead of hardcoded 1

### DIFF
--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -136,6 +136,10 @@ export class Identities {
         const tx = DemosTransactions.empty()
         const ed25519 = await demos.crypto.getIdentity("ed25519")
         const address = uint8ArrayToHex(ed25519.publicKey as Uint8Array)
+        // Use the address' current nonce (+1) like every other native tx in
+        // this SDK — hardcoding nonce:1 only validated for a fresh account and
+        // broke the second identity op (e.g. remove after add).
+        const nonce = await demos.getAddressNonce(address)
 
         tx.content = {
             ...tx.content,
@@ -150,7 +154,7 @@ export class Identities {
                     payload: payload,
                 },
             ],
-            nonce: 1,
+            nonce: nonce + 1,
             timestamp: Date.now(),
         }
 
@@ -174,6 +178,10 @@ export class Identities {
 
         const ed25519 = await demos.crypto.getIdentity("ed25519")
         const address = uint8ArrayToHex(ed25519.publicKey as Uint8Array)
+        // Use the address' current nonce (+1) like every other native tx in
+        // this SDK — hardcoding nonce:1 broke removing an identity once the
+        // account had already done one identity op (e.g. the add).
+        const nonce = await demos.getAddressNonce(address)
 
         tx.content = {
             ...tx.content,
@@ -188,7 +196,7 @@ export class Identities {
                     payload: payload,
                 },
             ],
-            nonce: 1,
+            nonce: nonce + 1,
             timestamp: Date.now(),
         }
 


### PR DESCRIPTION
…ed 1

inferIdentity (add/link) and removeIdentity (remove) both hardcoded nonce:1. That only validates for a fresh account (nonce 0): the first identity op succeeds and bumps the on-chain nonce, so the second (e.g. removing an XM wallet right after adding it) is rejected with '[NONCE ERROR] Nonce not assigned'. Both now fetch demos.getAddressNonce(address) and use nonce+1, matching every other native tx in the SDK (DemosTransactions.pay, nativeBridge, ContractDeployer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identity actions so they use the correct transaction nonce instead of a fixed value.
  * Improved reliability for adding, assigning, and removing identities after earlier identity operations.
  * Added clearer handling to prevent failures caused by reusing an outdated nonce.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->