### PR TITLE
feat(l2ps): SR-4 DACS negotiation stack (WI-A/B/C combined)

### DIFF
--- a/src/l2ps/channel/finalize.ts
+++ b/src/l2ps/channel/finalize.ts
@@ -84,14 +84,59 @@ export async function finalizeRfq(
         )
     }
 
+    // The signer must be a channel member — `exportTranscript` will sign
+    // with any demos claim, so a non-member signer produces a transcript
+    // that later fails `verifyTranscript` (signer ∉ members). Catch it
+    // here rather than emitting a transcript that cannot be verified.
+    if (!opts.session.members.includes(opts.signer)) {
+        throw new Error(
+            `finalizeRfq: signer "${opts.signer}" is not a channel member — ` +
+                "the transcript signature would fail verification",
+        )
+    }
+
+    // The transcript must actually contain the agreed exchange: the
+    // accepted proposal and the matching accept that `rfq.outcome()`
+    // points at. A stale or mismatched session would otherwise let us
+    // export/anchor a transcript that does not back the agreement.
+    const outcome = opts.rfq.outcome()
+    const acceptedSequence = outcome.acceptedSequence
+    if (acceptedSequence === undefined) {
+        throw new Error(
+            "finalizeRfq: accepted outcome has no acceptedSequence — cannot match transcript",
+        )
+    }
+    const messages = opts.session.messages()
+    const hasAcceptedProposal = messages.some(
+        m => m.sequence === acceptedSequence,
+    )
+    const hasAccept = messages.some(
+        m =>
+            m.type === "accept" &&
+            (m.body as { acceptedSequence?: number } | undefined)
+                ?.acceptedSequence === acceptedSequence,
+    )
+    if (!hasAcceptedProposal || !hasAccept) {
+        throw new Error(
+            `finalizeRfq: session transcript does not contain the accepted proposal ` +
+                `(seq ${acceptedSequence}) and its matching accept — session mismatch`,
+        )
+    }
+
     const transcript = await exportTranscript({
         channelId: opts.session.channelId,
         members: [...opts.session.members],
-        messages: opts.session.messages(),
+        messages,
         signers: [{ claim: opts.signer, demos: opts.demos }],
     })
 
-    if (opts.policy === "none") {
+    // §8.7 `none`: transcript stays local; nothing anchored.
+    // §8.7 `recommended` WITHOUT consent: also a no-anchor outcome — it
+    // must NOT require an L2PS instance just to take its null-ref branch.
+    const willAnchor =
+        opts.policy === "encrypted-anchored-required" ||
+        (opts.policy === "encrypted-anchored-recommended" && !!opts.consent)
+    if (!willAnchor) {
         return { transcript, channelTranscriptRef: null }
     }
 

--- a/src/l2ps/channel/finalize.ts
+++ b/src/l2ps/channel/finalize.ts
@@ -1,0 +1,123 @@
+/**
+ * SR-4 WI-C — finalise a negotiate-rfq session: on agreement, export the
+ * signed channel transcript and (per disclosure policy, DACS-3 §8.7)
+ * anchor an encrypted copy, returning the `channelTranscriptRef` that the
+ * negotiate-rfq output carries.
+ *
+ * This is the orchestration that ties WI-B's terminal state to WI-3's
+ * transcript anchor: `exportTranscript` (sign the ordered messages) →
+ * `anchorEncryptedTranscript` (encrypt-to-members + SR-2 anchor). Policy
+ * semantics (§8.7):
+ *   - `none` — transcript stays local; nothing anchored.
+ *   - `encrypted-anchored-recommended` — anchor only on explicit consent.
+ *   - `encrypted-anchored-required` — MUST anchor; a null result fails
+ *     the phase.
+ *
+ * The anchor call is injectable so the orchestration is unit-tested
+ * without a live node (the real anchor deploys an SR-2 storage program).
+ */
+
+import type { Demos } from "../../websdk"
+import type { ClaimReference } from "../../identity/cci"
+import type L2PS from "../l2ps"
+import type {
+    AnchorEncryptedTranscriptOpts,
+    AttestationRef,
+    TranscriptDisclosurePolicy,
+} from "../anchor"
+import { anchorEncryptedTranscript } from "../anchor"
+import { exportTranscript } from "./transcript"
+import type { ChannelMessage, ChannelTranscript } from "./types"
+import type { RfqOutcome, RfqState } from "./negotiate"
+
+/** Minimal RfqSession surface — structural for testability. */
+export interface RfqLike {
+    readonly state: RfqState
+    outcome(): RfqOutcome
+}
+
+/** Minimal ChannelSession surface — structural for testability. */
+export interface ChannelSessionView {
+    readonly channelId: string
+    readonly members: ReadonlyArray<ClaimReference>
+    messages(): ReadonlyArray<ChannelMessage>
+}
+
+export interface FinalizeRfqOpts {
+    rfq: RfqLike
+    session: ChannelSessionView
+    /** This party's CCI claim (signs the transcript); must be a member. */
+    signer: ClaimReference
+    demos: Demos
+    /** Required when the policy actually anchors (not for `none`). */
+    l2ps?: L2PS
+    policy: TranscriptDisclosurePolicy
+    /** Needed to anchor under `encrypted-anchored-recommended`. */
+    consent?: boolean
+    /**
+     * Injectable anchor implementation; defaults to the real
+     * `anchorEncryptedTranscript`. Tests pass a fake to avoid deploying
+     * a storage program.
+     */
+    anchor?: (
+        opts: AnchorEncryptedTranscriptOpts,
+    ) => Promise<AttestationRef | null>
+}
+
+export interface RfqFinalizeResult {
+    /** The signed, ordered transcript (always produced). */
+    transcript: ChannelTranscript
+    /**
+     * The anchored attestation reference, or null when the policy did not
+     * anchor (`none`, or `recommended` without consent).
+     */
+    channelTranscriptRef: AttestationRef | null
+}
+
+export async function finalizeRfq(
+    opts: FinalizeRfqOpts,
+): Promise<RfqFinalizeResult> {
+    if (opts.rfq.state !== "accepted") {
+        throw new Error(
+            `finalizeRfq: negotiation is "${opts.rfq.state}", not "accepted" — ` +
+                "only an agreed RFQ produces a transcript anchor",
+        )
+    }
+
+    const transcript = await exportTranscript({
+        channelId: opts.session.channelId,
+        members: [...opts.session.members],
+        messages: opts.session.messages(),
+        signers: [{ claim: opts.signer, demos: opts.demos }],
+    })
+
+    if (opts.policy === "none") {
+        return { transcript, channelTranscriptRef: null }
+    }
+
+    if (!opts.l2ps) {
+        throw new Error(
+            `finalizeRfq: policy "${opts.policy}" requires an L2PS instance to encrypt the transcript`,
+        )
+    }
+
+    const anchorFn = opts.anchor ?? anchorEncryptedTranscript
+    const ref = await anchorFn({
+        transcript,
+        l2ps: opts.l2ps,
+        demos: opts.demos,
+        signer: opts.signer,
+        policy: opts.policy,
+        consent: opts.consent,
+    })
+
+    // §8.7: under `required`, the absence of an anchor fails the phase.
+    if (opts.policy === "encrypted-anchored-required" && !ref) {
+        throw new Error(
+            "finalizeRfq: policy is 'encrypted-anchored-required' but anchoring " +
+                "produced no attestation — phase fails",
+        )
+    }
+
+    return { transcript, channelTranscriptRef: ref }
+}

--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -70,3 +70,11 @@ export {
     type RfqEndBody,
     type StandingProposal,
 } from "./negotiate"
+
+export {
+    finalizeRfq,
+    type FinalizeRfqOpts,
+    type RfqFinalizeResult,
+    type RfqLike,
+    type ChannelSessionView,
+} from "./finalize"

--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -50,3 +50,12 @@ export {
     verifyTranscript,
     type TranscriptVerificationResult,
 } from "./transcript"
+
+export {
+    L2PSChannelTransport,
+    type L2PSChannelTransportOpts,
+    type ChannelSessionLike,
+    type L2PSMessagingPeerLike,
+    type SerializedEncryptedMessage,
+    type IncomingMessagePayload,
+} from "./transport"

--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -59,3 +59,14 @@ export {
     type SerializedEncryptedMessage,
     type IncomingMessagePayload,
 } from "./transport"
+
+export {
+    RfqSession,
+    type RfqState,
+    type RfqOutcome,
+    type RfqSessionOpts,
+    type RfqProposalBody,
+    type RfqAcceptBody,
+    type RfqEndBody,
+    type StandingProposal,
+} from "./negotiate"

--- a/src/l2ps/channel/negotiate.ts
+++ b/src/l2ps/channel/negotiate.ts
@@ -134,6 +134,14 @@ export class RfqSession {
         this.assertOpen("accept")
         if (!this._standing)
             throw new Error("RfqSession: nothing to accept — no standing offer")
+        // You cannot accept your own proposal: acceptance is the
+        // counterparty agreeing to the terms on the table. Accepting a
+        // self-authored standing proposal would settle the negotiation
+        // (and produce a transcript) without the other side ever agreeing.
+        if (this._standing.sender === this.me)
+            throw new Error(
+                "RfqSession: cannot accept your own proposal — wait for the counterparty",
+            )
         const accepted = this._standing
         const body: RfqAcceptBody = { acceptedSequence: accepted.sequence }
         const msg = await this.sendFn({
@@ -179,17 +187,26 @@ export class RfqSession {
         if (this._state !== "open") return // terminal — ignore trailing traffic
 
         switch (msg.type) {
-            case "offer":
+            case "offer": {
+                // An offer opens a negotiation: it is only legal when no
+                // proposal stands yet. A second inbound offer must not
+                // overwrite the standing proposal — `offer()` rejects the
+                // same case outbound, so the inbound path enforces it too.
+                if (this._standing)
+                    throw new Error(
+                        `RfqSession: inbound offer (seq ${msg.sequence}) but a proposal already stands (seq ${this._standing.sequence})`,
+                    )
+                this.acceptProposal(msg)
+                break
+            }
             case "counter": {
-                const terms = (msg.body as RfqProposalBody)?.terms
-                const proposal: StandingProposal = {
-                    sequence: msg.sequence,
-                    sender: msg.sender,
-                    terms,
-                }
-                this.proposals.set(msg.sequence, proposal)
-                this._standing = proposal
-                this.onProposal?.(proposal)
+                // A counter replaces the standing proposal — illegal before
+                // any offer exists, mirroring `counter()` outbound.
+                if (!this._standing)
+                    throw new Error(
+                        `RfqSession: inbound counter (seq ${msg.sequence}) but no standing offer to counter`,
+                    )
+                this.acceptProposal(msg)
                 break
             }
             case "accept": {
@@ -198,6 +215,17 @@ export class RfqSession {
                 if (!accepted)
                     throw new Error(
                         `RfqSession: accept references unknown proposal sequence ${seq}`,
+                    )
+                // The accept must reference the proposal currently on the
+                // table. Once a counter supersedes an earlier offer, that
+                // older offer is off the table — accepting it would settle
+                // obsolete terms instead of what is currently being
+                // negotiated.
+                if (!this._standing || seq !== this._standing.sequence)
+                    throw new Error(
+                        `RfqSession: accept references stale proposal seq ${seq}; standing proposal is seq ${
+                            this._standing?.sequence ?? "none"
+                        }`,
                     )
                 this.settle({
                     state: "accepted",
@@ -221,6 +249,19 @@ export class RfqSession {
                 break
             }
         }
+    }
+
+    /** Record a verified inbound offer/counter as the standing proposal. */
+    private acceptProposal(msg: ChannelMessage): void {
+        const terms = (msg.body as RfqProposalBody)?.terms
+        const proposal: StandingProposal = {
+            sequence: msg.sequence,
+            sender: msg.sender,
+            terms,
+        }
+        this.proposals.set(msg.sequence, proposal)
+        this._standing = proposal
+        this.onProposal?.(proposal)
     }
 
     private async proposeOutgoing(

--- a/src/l2ps/channel/negotiate.ts
+++ b/src/l2ps/channel/negotiate.ts
@@ -1,0 +1,256 @@
+/**
+ * SR-4 WI-B — `negotiate-rfq` phase logic.
+ *
+ * A request-for-quote negotiation is a turn-based exchange of `offer` /
+ * `counter` proposals terminating in `accept`, `reject`, or `abort`
+ * (CH-5 termination; DACS-3 §8.3). Per the SR-4 brief the RFQ message
+ * *bodies* are implementation-defined (only sealed-envelope bodies are
+ * spec-locked, §8.4.3), so this layer fixes a minimal body schema and
+ * the state machine while staying agnostic to the actual `terms`.
+ *
+ * `RfqSession` is a pure protocol state machine. It does not move bytes:
+ * the caller wires its `send` callback to a transport (e.g.
+ * `L2PSChannelTransport.send`) and feeds verified inbound envelopes to
+ * `onIncoming`. By the time a message reaches `onIncoming` the channel
+ * layer has already verified the signature, `sender ∈ members`, the
+ * channelId, and monotonic sequence — so this layer only enforces
+ * protocol-level rules (legal transitions, body shape, referencing an
+ * existing offer).
+ */
+
+import type { ChannelMessage, ChannelMessageType } from "./types"
+import type { ClaimReference } from "../../identity/cci"
+
+/** Terminal + in-progress states (CH-5). */
+export type RfqState = "open" | "accepted" | "rejected" | "aborted"
+
+/** Body of an `offer` / `counter` — `terms` is opaque (impl-defined). */
+export interface RfqProposalBody {
+    terms: unknown
+}
+/** Body of an `accept` — references the proposal sequence being accepted. */
+export interface RfqAcceptBody {
+    acceptedSequence: number
+}
+/** Body of a `reject` / `abort`. */
+export interface RfqEndBody {
+    reason?: string
+}
+
+/** A standing proposal on the table. */
+export interface StandingProposal {
+    sequence: number
+    sender: ClaimReference
+    terms: unknown
+}
+
+export interface RfqOutcome {
+    state: RfqState
+    /** Set when `state === "accepted"`: the terms that were agreed. */
+    agreedTerms?: unknown
+    /** Sequence of the proposal that was accepted. */
+    acceptedSequence?: number
+    /** Reason for a reject / abort, if given. */
+    reason?: string
+}
+
+export interface RfqSessionOpts {
+    /** This party's CCI primary claim. */
+    me: ClaimReference
+    /**
+     * Delivers a signed channel message. Wire to the transport's send
+     * (e.g. `L2PSChannelTransport.send`). Returns the signed envelope so
+     * the session can track the sequence it produced.
+     */
+    send: (opts: {
+        type: ChannelMessageType
+        body: unknown
+        repliesTo?: number
+    }) => Promise<ChannelMessage>
+    /** Fired on every state transition (including the terminal one). */
+    onStateChange?: (outcome: RfqOutcome) => void
+    /** Fired when a fresh proposal (offer/counter) lands, ours or theirs. */
+    onProposal?: (proposal: StandingProposal) => void
+}
+
+const RFQ_TYPES: ReadonlySet<ChannelMessageType> = new Set<ChannelMessageType>([
+    "offer",
+    "counter",
+    "accept",
+    "reject",
+    "abort",
+])
+
+export class RfqSession {
+    private readonly me: ClaimReference
+    private readonly sendFn: RfqSessionOpts["send"]
+    private readonly onStateChange?: (o: RfqOutcome) => void
+    private readonly onProposal?: (p: StandingProposal) => void
+
+    private _state: RfqState = "open"
+    private _standing: StandingProposal | null = null
+    /** Every proposal seen, by sequence — so `accept` can resolve its terms. */
+    private readonly proposals = new Map<number, StandingProposal>()
+    private _outcome: RfqOutcome = { state: "open" }
+
+    constructor(opts: RfqSessionOpts) {
+        this.me = opts.me
+        this.sendFn = opts.send
+        this.onStateChange = opts.onStateChange
+        this.onProposal = opts.onProposal
+    }
+
+    get state(): RfqState {
+        return this._state
+    }
+    /** The proposal currently on the table, or null before the first offer. */
+    get standingProposal(): StandingProposal | null {
+        return this._standing
+    }
+    outcome(): RfqOutcome {
+        return this._outcome
+    }
+
+    /** Open a negotiation with the first proposal. */
+    async offer(terms: unknown): Promise<ChannelMessage> {
+        this.assertOpen("offer")
+        if (this._standing)
+            throw new Error(
+                "RfqSession: a proposal already stands; use counter()",
+            )
+        return this.proposeOutgoing("offer", terms)
+    }
+
+    /** Counter the standing proposal with new terms. */
+    async counter(terms: unknown): Promise<ChannelMessage> {
+        this.assertOpen("counter")
+        if (!this._standing)
+            throw new Error("RfqSession: nothing to counter — no standing offer")
+        return this.proposeOutgoing("counter", terms, this._standing.sequence)
+    }
+
+    /** Accept the standing proposal — terminal (CH-5). */
+    async accept(): Promise<ChannelMessage> {
+        this.assertOpen("accept")
+        if (!this._standing)
+            throw new Error("RfqSession: nothing to accept — no standing offer")
+        const accepted = this._standing
+        const body: RfqAcceptBody = { acceptedSequence: accepted.sequence }
+        const msg = await this.sendFn({
+            type: "accept",
+            body,
+            repliesTo: accepted.sequence,
+        })
+        this.settle({
+            state: "accepted",
+            agreedTerms: accepted.terms,
+            acceptedSequence: accepted.sequence,
+        })
+        return msg
+    }
+
+    /** Reject the negotiation — terminal (CH-5). */
+    async reject(reason?: string): Promise<ChannelMessage> {
+        this.assertOpen("reject")
+        const body: RfqEndBody = reason ? { reason } : {}
+        const msg = await this.sendFn({ type: "reject", body })
+        this.settle({ state: "rejected", reason })
+        return msg
+    }
+
+    /** Abort the negotiation — terminal (CH-5). */
+    async abort(reason?: string): Promise<ChannelMessage> {
+        this.assertOpen("abort")
+        const body: RfqEndBody = reason ? { reason } : {}
+        const msg = await this.sendFn({ type: "abort", body })
+        this.settle({ state: "aborted", reason })
+        return msg
+    }
+
+    /**
+     * Feed a verified inbound channel message. No-op for non-RFQ types or
+     * messages arriving after a terminal state (a late duplicate of an
+     * end message). Throws only on a protocol violation that the channel
+     * layer can't catch (e.g. accept referencing an unknown proposal).
+     */
+    onIncoming(msg: ChannelMessage): void {
+        if (!RFQ_TYPES.has(msg.type)) return
+        if (msg.sender === this.me) return // our own echo, already applied
+        if (this._state !== "open") return // terminal — ignore trailing traffic
+
+        switch (msg.type) {
+            case "offer":
+            case "counter": {
+                const terms = (msg.body as RfqProposalBody)?.terms
+                const proposal: StandingProposal = {
+                    sequence: msg.sequence,
+                    sender: msg.sender,
+                    terms,
+                }
+                this.proposals.set(msg.sequence, proposal)
+                this._standing = proposal
+                this.onProposal?.(proposal)
+                break
+            }
+            case "accept": {
+                const seq = (msg.body as RfqAcceptBody)?.acceptedSequence
+                const accepted = this.proposals.get(seq)
+                if (!accepted)
+                    throw new Error(
+                        `RfqSession: accept references unknown proposal sequence ${seq}`,
+                    )
+                this.settle({
+                    state: "accepted",
+                    agreedTerms: accepted.terms,
+                    acceptedSequence: seq,
+                })
+                break
+            }
+            case "reject": {
+                this.settle({
+                    state: "rejected",
+                    reason: (msg.body as RfqEndBody)?.reason,
+                })
+                break
+            }
+            case "abort": {
+                this.settle({
+                    state: "aborted",
+                    reason: (msg.body as RfqEndBody)?.reason,
+                })
+                break
+            }
+        }
+    }
+
+    private async proposeOutgoing(
+        type: "offer" | "counter",
+        terms: unknown,
+        repliesTo?: number,
+    ): Promise<ChannelMessage> {
+        const body: RfqProposalBody = { terms }
+        const msg = await this.sendFn({ type, body, repliesTo })
+        const proposal: StandingProposal = {
+            sequence: msg.sequence,
+            sender: this.me,
+            terms,
+        }
+        this.proposals.set(msg.sequence, proposal)
+        this._standing = proposal
+        this.onProposal?.(proposal)
+        return msg
+    }
+
+    private settle(outcome: RfqOutcome): void {
+        this._state = outcome.state
+        this._outcome = outcome
+        this.onStateChange?.(outcome)
+    }
+
+    private assertOpen(action: string): void {
+        if (this._state !== "open")
+            throw new Error(
+                `RfqSession: cannot ${action} — negotiation is ${this._state}`,
+            )
+    }
+}

--- a/src/l2ps/channel/transport.ts
+++ b/src/l2ps/channel/transport.ts
@@ -1,0 +1,246 @@
+/**
+ * SR-4 WI-A — Channel-over-L2PS transport adapter.
+ *
+ * The DACS channel layer (`ChannelSession`) is transport-agnostic: it
+ * produces signed `ChannelMessage` envelopes and verifies incoming ones,
+ * but does not move bytes. The L2PS instant-messaging layer
+ * (`L2PSMessagingPeer`) moves encrypted bytes between subnet members but
+ * knows nothing about channel envelopes. This adapter bridges the two:
+ * it serialises + encrypts an outgoing envelope onto the messaging
+ * transport, and on the receive side decrypts, deserialises, and feeds
+ * envelopes into the session **in strict sequence order**.
+ *
+ * Why a reorder buffer is mandatory:
+ * `ChannelSession.receiveIncoming` accepts any sequence strictly greater
+ * than the highest it has seen and then advances its counter to that
+ * value — so a *gap* (seq N+2 arriving before N+1) is not rejected, it
+ * permanently skips the missing messages. The L2PS transport delivers by
+ * timestamp and replays an offline queue, so out-of-order arrival is
+ * normal. This adapter therefore only hands the session the next
+ * contiguous sequence and buffers anything ahead of the gap until it
+ * fills.
+ *
+ * Scope / assumptions:
+ * - The shared per-channel sequence counter assumes turn-based messaging
+ *   (DACS negotiation is offer → counter → accept; a party waits for the
+ *   counter before replying). Two parties emitting the same sequence
+ *   concurrently is out of scope for SR-4 v1; such a colliding inbound
+ *   message (seq <= already-applied) is dropped as a duplicate.
+ * - Membership is the channel's `members`; the transport sends to every
+ *   member except self. Confidentiality is the subnet AES key (only
+ *   members hold it) — CH-2.
+ */
+
+import type { ChannelMessage, ChannelMessageType } from "./types"
+
+/**
+ * Minimal surface of `ChannelSession` the adapter depends on. Declared
+ * structurally so tests can inject a fake without real signing keys.
+ */
+export interface ChannelSessionLike {
+    readonly channelId: string
+    sendOutgoing(opts: {
+        type: ChannelMessageType
+        body: unknown
+        sentAt?: number
+        repliesTo?: number
+    }): Promise<ChannelMessage>
+    receiveIncoming(msg: ChannelMessage): Promise<void>
+}
+
+/** Wire shape the L2PS messaging transport carries (ciphertext + nonce, base64). */
+export interface SerializedEncryptedMessage {
+    ciphertext: string
+    nonce: string
+    ephemeralKey?: string
+}
+
+/** Incoming payload the messaging peer hands to an onMessage handler. */
+export interface IncomingMessagePayload {
+    from: string
+    encrypted: SerializedEncryptedMessage
+    messageHash: string
+    offline?: boolean
+}
+
+/**
+ * Minimal surface of `L2PSMessagingPeer` the adapter depends on.
+ * Declared structurally for the same reason as `ChannelSessionLike`.
+ */
+export interface L2PSMessagingPeerLike {
+    send(
+        to: string,
+        encrypted: SerializedEncryptedMessage,
+        messageHash: string,
+    ): Promise<unknown>
+    onMessage(handler: (payload: IncomingMessagePayload) => void): void
+}
+
+export interface L2PSChannelTransportOpts {
+    session: ChannelSessionLike
+    peer: L2PSMessagingPeerLike
+    /** Subnet AES-256 key (raw 32 bytes) — only members hold it (CH-2). */
+    sharedKey: Uint8Array
+    /**
+     * Recipient public keys to deliver to (every channel member except
+     * self), in the format the messaging peer routes on.
+     */
+    recipients: string[]
+    /** Called with each envelope once it has been applied in order. */
+    onMessage?: (msg: ChannelMessage) => void
+    /** Called on a decrypt / parse / verification failure. */
+    onError?: (err: Error) => void
+}
+
+export class L2PSChannelTransport {
+    private readonly session: ChannelSessionLike
+    private readonly peer: L2PSMessagingPeerLike
+    private readonly sharedKey: Uint8Array
+    private readonly recipients: string[]
+    private readonly onMessage?: (msg: ChannelMessage) => void
+    private readonly onError?: (err: Error) => void
+
+    /** Sequences seen ahead of the gap, awaiting contiguous application. */
+    private readonly buffer = new Map<number, ChannelMessage>()
+    /** Highest contiguous sequence applied locally (sent or received). */
+    private appliedSeq = 0
+    /** Serialises drain() so concurrent inbound frames can't interleave. */
+    private draining: Promise<void> = Promise.resolve()
+    private started = false
+
+    constructor(opts: L2PSChannelTransportOpts) {
+        this.session = opts.session
+        this.peer = opts.peer
+        this.sharedKey = opts.sharedKey
+        this.recipients = opts.recipients
+        this.onMessage = opts.onMessage
+        this.onError = opts.onError
+    }
+
+    /** Wire the peer's inbound handler. Call once. */
+    start(): void {
+        if (this.started) throw new Error("L2PSChannelTransport: already started")
+        this.started = true
+        this.peer.onMessage(payload => {
+            // Chain onto `draining` so frames are processed one at a time
+            // in arrival order; each appends to the buffer then drains.
+            this.draining = this.draining
+                .then(() => this.ingest(payload))
+                .catch(err => this.onError?.(err as Error))
+        })
+    }
+
+    /**
+     * Build + sign the next outgoing envelope via the session, encrypt
+     * it under the subnet key, and deliver to every recipient.
+     */
+    async send(opts: {
+        type: ChannelMessageType
+        body: unknown
+        repliesTo?: number
+    }): Promise<ChannelMessage> {
+        const signed = await this.session.sendOutgoing(opts)
+        // Our own send advances the shared per-channel counter; record it
+        // so we expect the peer's reply at appliedSeq + 1.
+        if (signed.sequence > this.appliedSeq) this.appliedSeq = signed.sequence
+
+        const encrypted = await this.encrypt(JSON.stringify(signed))
+        const messageHash = signed.signature.signature // unique per signed envelope
+        for (const to of this.recipients) {
+            await this.peer.send(to, encrypted, messageHash)
+        }
+        return signed
+    }
+
+    private async ingest(payload: IncomingMessagePayload): Promise<void> {
+        let msg: ChannelMessage
+        try {
+            const json = await this.decrypt(payload.encrypted)
+            msg = JSON.parse(json) as ChannelMessage
+        } catch (e) {
+            throw new Error(
+                `L2PSChannelTransport: failed to decrypt/parse inbound frame from ${payload.from}: ${
+                    (e as Error).message
+                }`,
+            )
+        }
+
+        // Ignore traffic for other channels sharing the same subnet.
+        if (msg.channelId !== this.session.channelId) return
+        // Duplicate / already-applied (or a colliding concurrent send): drop.
+        if (msg.sequence <= this.appliedSeq) return
+        // Buffer; a later sequence with the same value would be a protocol
+        // error — keep the first seen.
+        if (!this.buffer.has(msg.sequence)) this.buffer.set(msg.sequence, msg)
+
+        await this.drain()
+    }
+
+    /** Apply every buffered message that is now contiguous with appliedSeq. */
+    private async drain(): Promise<void> {
+        // Sequence counter is shared across both directions, so the next
+        // expected inbound is appliedSeq + 1.
+        let next = this.buffer.get(this.appliedSeq + 1)
+        while (next) {
+            this.buffer.delete(next.sequence)
+            // Throws on tamper (bad signature, wrong sender, channelId
+            // mismatch) — propagate as channel-fatal per §8.12.
+            await this.session.receiveIncoming(next)
+            this.appliedSeq = next.sequence
+            this.onMessage?.(next)
+            next = this.buffer.get(this.appliedSeq + 1)
+        }
+    }
+
+    /** Count of out-of-order messages currently held awaiting the gap. */
+    get bufferedCount(): number {
+        return this.buffer.size
+    }
+
+    // ── AES-256-GCM (Web Crypto) — matches the messaging wire format:
+    //    ciphertext (with auth tag) + 12-byte nonce, both base64. ──
+
+    private async encrypt(plaintext: string): Promise<SerializedEncryptedMessage> {
+        const nonce = crypto.getRandomValues(new Uint8Array(12))
+        const key = await crypto.subtle.importKey(
+            "raw",
+            this.sharedKey.buffer as ArrayBuffer,
+            "AES-GCM",
+            false,
+            ["encrypt"],
+        )
+        const cipher = await crypto.subtle.encrypt(
+            { name: "AES-GCM", iv: nonce },
+            key,
+            new TextEncoder().encode(plaintext),
+        )
+        return {
+            ciphertext: bytesToBase64(new Uint8Array(cipher)),
+            nonce: bytesToBase64(nonce),
+        }
+    }
+
+    private async decrypt(enc: SerializedEncryptedMessage): Promise<string> {
+        const key = await crypto.subtle.importKey(
+            "raw",
+            this.sharedKey.buffer as ArrayBuffer,
+            "AES-GCM",
+            false,
+            ["decrypt"],
+        )
+        const plain = await crypto.subtle.decrypt(
+            { name: "AES-GCM", iv: base64ToBytes(enc.nonce) as BufferSource },
+            key,
+            base64ToBytes(enc.ciphertext) as BufferSource,
+        )
+        return new TextDecoder().decode(plain)
+    }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+    return Buffer.from(bytes).toString("base64")
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+    return new Uint8Array(Buffer.from(b64, "base64"))
+}

--- a/src/l2ps/channel/transport.ts
+++ b/src/l2ps/channel/transport.ts
@@ -34,6 +34,13 @@
 import type { ChannelMessage, ChannelMessageType } from "./types"
 
 /**
+ * Max number of sequences a buffered inbound frame may sit ahead of the
+ * current contiguous point before it is dropped, bounding reorder-buffer
+ * memory. Turn-based negotiation never legitimately exceeds this.
+ */
+const MAX_REORDER_AHEAD = 256
+
+/**
  * Minimal surface of `ChannelSession` the adapter depends on. Declared
  * structurally so tests can inject a fake without real signing keys.
  */
@@ -140,15 +147,22 @@ export class L2PSChannelTransport {
         repliesTo?: number
     }): Promise<ChannelMessage> {
         const signed = await this.session.sendOutgoing(opts)
-        // Our own send advances the shared per-channel counter; record it
-        // so we expect the peer's reply at appliedSeq + 1.
-        if (signed.sequence > this.appliedSeq) this.appliedSeq = signed.sequence
 
         const encrypted = await this.encrypt(JSON.stringify(signed))
         const messageHash = signed.signature.signature // unique per signed envelope
+        // Deliver to every recipient BEFORE committing the sequence locally.
+        // If any send rejects, the throw propagates here and appliedSeq is
+        // left untouched, so a retry re-emits the same sequence rather than
+        // skipping ahead and stranding peers behind a reorder gap. (Recipients
+        // that did receive it will drop the duplicate on resend — seq <=
+        // appliedSeq — so at-least-once delivery is safe.)
         for (const to of this.recipients) {
             await this.peer.send(to, encrypted, messageHash)
         }
+
+        // Our own send advances the shared per-channel counter; record it
+        // so we expect the peer's reply at appliedSeq + 1.
+        if (signed.sequence > this.appliedSeq) this.appliedSeq = signed.sequence
         return signed
     }
 
@@ -169,6 +183,22 @@ export class L2PSChannelTransport {
         if (msg.channelId !== this.session.channelId) return
         // Duplicate / already-applied (or a colliding concurrent send): drop.
         if (msg.sequence <= this.appliedSeq) return
+        // Bound the reorder window: a member could otherwise stream many
+        // validly-encrypted frames at far-future sequences without ever
+        // filling the gap, growing `buffer` without limit. Drop anything
+        // beyond MAX_REORDER_AHEAD of the current contiguous point — a
+        // legitimate turn-based negotiation never runs that far ahead, and
+        // a dropped frame is re-deliverable (the offline queue replays it
+        // once the gap closes and appliedSeq advances).
+        if (msg.sequence > this.appliedSeq + MAX_REORDER_AHEAD) {
+            this.onError?.(
+                new Error(
+                    `L2PSChannelTransport: dropping seq ${msg.sequence} — ` +
+                        `more than ${MAX_REORDER_AHEAD} ahead of applied ${this.appliedSeq}`,
+                ),
+            )
+            return
+        }
         // Buffer; a later sequence with the same value would be a protocol
         // error — keep the first seen.
         if (!this.buffer.has(msg.sequence)) this.buffer.set(msg.sequence, msg)
@@ -204,7 +234,7 @@ export class L2PSChannelTransport {
         const nonce = crypto.getRandomValues(new Uint8Array(12))
         const key = await crypto.subtle.importKey(
             "raw",
-            this.sharedKey.buffer as ArrayBuffer,
+            keyBytes(this.sharedKey),
             "AES-GCM",
             false,
             ["encrypt"],
@@ -223,7 +253,7 @@ export class L2PSChannelTransport {
     private async decrypt(enc: SerializedEncryptedMessage): Promise<string> {
         const key = await crypto.subtle.importKey(
             "raw",
-            this.sharedKey.buffer as ArrayBuffer,
+            keyBytes(this.sharedKey),
             "AES-GCM",
             false,
             ["decrypt"],
@@ -235,6 +265,22 @@ export class L2PSChannelTransport {
         )
         return new TextDecoder().decode(plain)
     }
+}
+
+/**
+ * Return a standalone `ArrayBuffer` holding exactly the bytes of `view`.
+ * `view.buffer` exposes the whole backing buffer, which for a `subarray`
+ * (e.g. a 32-byte key sliced out of a larger buffer) is longer than the
+ * view — Web Crypto would then see the wrong length / wrong bytes and
+ * reject or mis-key the AES import. Copying the exact `[byteOffset,
+ * byteOffset+byteLength)` window guarantees the key import sees only the
+ * intended bytes.
+ */
+function keyBytes(view: Uint8Array): ArrayBuffer {
+    return view.buffer.slice(
+        view.byteOffset,
+        view.byteOffset + view.byteLength,
+    ) as ArrayBuffer
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/src/tests/l2ps/finalize.test.ts
+++ b/src/tests/l2ps/finalize.test.ts
@@ -1,0 +1,186 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
+import {
+    ChannelSession,
+    RfqSession,
+    finalizeRfq,
+    type ChannelMessage,
+} from "@/l2ps/channel"
+import type {
+    AnchorEncryptedTranscriptOpts,
+    AttestationRef,
+} from "@/l2ps/anchor"
+
+const CHANNEL = "ch-finalize-1"
+
+async function newConnectedDemos(): Promise<{
+    demos: Demos
+    claim: ClaimReference
+}> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return {
+        demos,
+        claim: demosClaimRefForAddress(await demos.getEd25519Address()),
+    }
+}
+
+/** Run a real signed offer→accept so the session holds a verifiable transcript. */
+async function agreedSession() {
+    const alice = await newConnectedDemos()
+    const bob = await newConnectedDemos()
+    const members = [alice.claim, bob.claim]
+    const aSes = new ChannelSession({
+        channelId: CHANNEL,
+        members,
+        me: alice.claim,
+        demos: alice.demos,
+    })
+    const bSes = new ChannelSession({
+        channelId: CHANNEL,
+        members,
+        me: bob.claim,
+        demos: bob.demos,
+    })
+    await aSes.open()
+    await bSes.open()
+
+    const aRfq = new RfqSession({
+        me: alice.claim,
+        send: async opts => {
+            const m = await aSes.sendOutgoing(opts)
+            await bSes.receiveIncoming(m)
+            bRfq.onIncoming(m)
+            return m
+        },
+    })
+    const bRfq = new RfqSession({
+        me: bob.claim,
+        send: async opts => {
+            const m = await bSes.sendOutgoing(opts)
+            await aSes.receiveIncoming(m)
+            aRfq.onIncoming(m)
+            return m
+        },
+    })
+
+    await aRfq.offer({ price: 100 })
+    await bRfq.counter({ price: 90 })
+    await aRfq.accept()
+    return { alice, aSes, aRfq }
+}
+
+const okAnchor =
+    (captured: AnchorEncryptedTranscriptOpts[]) =>
+    async (o: AnchorEncryptedTranscriptOpts): Promise<AttestationRef> => {
+        captured.push(o)
+        return { anchor: "0xsp-addr", contentHash: "0xhash" }
+    }
+
+describe("finalizeRfq — WI-C transcript anchor on terminal", () => {
+    it("exports a signed transcript and anchors under `required`", async () => {
+        const { alice, aSes, aRfq } = await agreedSession()
+        const captured: AnchorEncryptedTranscriptOpts[] = []
+        const res = await finalizeRfq({
+            rfq: aRfq,
+            session: aSes,
+            signer: alice.claim,
+            demos: alice.demos,
+            l2ps: {} as never, // anchor is faked; l2ps only needs to be present
+            policy: "encrypted-anchored-required",
+            anchor: okAnchor(captured),
+        })
+        expect(res.transcript.messages.map(m => m.sequence)).toEqual([1, 2, 3])
+        expect(res.transcript.signatures.length).toBe(1) // signed by alice
+        expect(res.channelTranscriptRef).toEqual({
+            anchor: "0xsp-addr",
+            contentHash: "0xhash",
+        })
+        expect(captured[0].policy).toBe("encrypted-anchored-required")
+    })
+
+    it("policy `none` exports the transcript but does not anchor", async () => {
+        const { alice, aSes, aRfq } = await agreedSession()
+        let anchored = false
+        const res = await finalizeRfq({
+            rfq: aRfq,
+            session: aSes,
+            signer: alice.claim,
+            demos: alice.demos,
+            policy: "none",
+            anchor: async () => {
+                anchored = true
+                return null
+            },
+        })
+        expect(res.channelTranscriptRef).toBeNull()
+        expect(anchored).toBe(false)
+        expect(res.transcript.messages.length).toBe(3)
+    })
+
+    it("`recommended` without consent does not anchor (ref null)", async () => {
+        const { alice, aSes, aRfq } = await agreedSession()
+        const res = await finalizeRfq({
+            rfq: aRfq,
+            session: aSes,
+            signer: alice.claim,
+            demos: alice.demos,
+            l2ps: {} as never,
+            policy: "encrypted-anchored-recommended",
+            consent: false,
+            // mimic the real helper: recommended + no consent → null
+            anchor: async o => (o.consent === true ? { anchor: "a", contentHash: "h" } : null),
+        })
+        expect(res.channelTranscriptRef).toBeNull()
+    })
+
+    it("`required` fails the phase when anchoring returns null", async () => {
+        const { alice, aSes, aRfq } = await agreedSession()
+        await expect(
+            finalizeRfq({
+                rfq: aRfq,
+                session: aSes,
+                signer: alice.claim,
+                demos: alice.demos,
+                l2ps: {} as never,
+                policy: "encrypted-anchored-required",
+                anchor: async () => null,
+            }),
+        ).rejects.toThrow(/phase fails/)
+    })
+
+    it("refuses to finalize a non-accepted negotiation", async () => {
+        const alice = await newConnectedDemos()
+        const fakeRfq = { state: "open" as const, outcome: () => ({ state: "open" as const }) }
+        const fakeSession = {
+            channelId: CHANNEL,
+            members: [alice.claim],
+            messages: () => [] as ChannelMessage[],
+        }
+        await expect(
+            finalizeRfq({
+                rfq: fakeRfq,
+                session: fakeSession,
+                signer: alice.claim,
+                demos: alice.demos,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/not "accepted"/)
+    })
+
+    it("requires an L2PS instance when the policy anchors", async () => {
+        const { alice, aSes, aRfq } = await agreedSession()
+        await expect(
+            finalizeRfq({
+                rfq: aRfq,
+                session: aSes,
+                signer: alice.claim,
+                demos: alice.demos,
+                policy: "encrypted-anchored-required",
+                // no l2ps, no anchor override
+            }),
+        ).rejects.toThrow(/requires an L2PS instance/)
+    })
+})

--- a/src/tests/l2ps/finalize.test.ts
+++ b/src/tests/l2ps/finalize.test.ts
@@ -183,4 +183,63 @@ describe("finalizeRfq — WI-C transcript anchor on terminal", () => {
             }),
         ).rejects.toThrow(/requires an L2PS instance/)
     })
+
+    it("`recommended` without consent succeeds without an L2PS instance", async () => {
+        // No-anchor outcome must not require l2ps just to take the null
+        // branch (regression: the l2ps check used to run first).
+        const { alice, aSes, aRfq } = await agreedSession()
+        const res = await finalizeRfq({
+            rfq: aRfq,
+            session: aSes,
+            signer: alice.claim,
+            demos: alice.demos,
+            policy: "encrypted-anchored-recommended",
+            consent: false,
+            // no l2ps, no anchor override
+        })
+        expect(res.channelTranscriptRef).toBeNull()
+        expect(res.transcript.messages.length).toBe(3)
+    })
+
+    it("rejects a signer who is not a channel member", async () => {
+        const { aSes, aRfq } = await agreedSession()
+        const stranger = await newConnectedDemos()
+        await expect(
+            finalizeRfq({
+                rfq: aRfq,
+                session: aSes,
+                signer: stranger.claim, // not in members
+                demos: stranger.demos,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/not a channel member/)
+    })
+
+    it("rejects a session whose transcript lacks the accepted exchange", async () => {
+        const { alice } = await agreedSession()
+        // An accepted RFQ outcome pointing at seq 2, but a session whose
+        // messages don't contain that proposal/accept → mismatch.
+        const mismatchedRfq = {
+            state: "accepted" as const,
+            outcome: () => ({
+                state: "accepted" as const,
+                agreedTerms: { price: 90 },
+                acceptedSequence: 2,
+            }),
+        }
+        const emptySession = {
+            channelId: CHANNEL,
+            members: [alice.claim],
+            messages: () => [] as ChannelMessage[],
+        }
+        await expect(
+            finalizeRfq({
+                rfq: mismatchedRfq,
+                session: emptySession,
+                signer: alice.claim,
+                demos: alice.demos,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/session mismatch/)
+    })
 })

--- a/src/tests/l2ps/negotiate.test.ts
+++ b/src/tests/l2ps/negotiate.test.ts
@@ -1,0 +1,151 @@
+import {
+    RfqSession,
+    type RfqAcceptBody,
+    type RfqProposalBody,
+} from "@/l2ps/channel/negotiate"
+import type { ChannelMessage, ChannelMessageType } from "@/l2ps/channel"
+import type { ClaimReference } from "@/identity/cci"
+
+const A = ("demos:0x" + "a".repeat(64)) as ClaimReference
+const B = ("demos:0x" + "b".repeat(64)) as ClaimReference
+
+/**
+ * A two-party RFQ harness: each side has an RfqSession whose `send`
+ * callback mints a ChannelMessage (monotonic shared sequence) and
+ * delivers it to the other side's `onIncoming`. No transport / crypto —
+ * the channel layer's verification is out of scope here; this tests the
+ * protocol state machine.
+ */
+function harness() {
+    let seq = 0
+    let aSes!: RfqSession
+    let bSes!: RfqSession
+
+    const mkSend =
+        (me: string, peer: () => RfqSession) =>
+        async (opts: {
+            type: ChannelMessageType
+            body: unknown
+            repliesTo?: number
+        }): Promise<ChannelMessage> => {
+            const msg = {
+                channelId: "ch",
+                sequence: ++seq,
+                sender: me,
+                sentAt: 1000 + seq,
+                type: opts.type,
+                body: opts.body,
+                ...(opts.repliesTo !== undefined && {
+                    refs: { repliesTo: opts.repliesTo },
+                }),
+                signature: { sigVersion: "1", signature: "0xsig" + seq },
+            } as ChannelMessage
+            // Deliver to the counterparty after the local state settles.
+            queueMicrotask(() => peer().onIncoming(msg))
+            return msg
+        }
+
+    aSes = new RfqSession({ me: A, send: mkSend(A, () => bSes) })
+    bSes = new RfqSession({ me: B, send: mkSend(B, () => aSes) })
+    return { aSes, bSes }
+}
+
+const tick = () => new Promise(r => setTimeout(r, 0))
+
+describe("RfqSession — negotiate-rfq state machine", () => {
+    it("offer → counter → accept settles agreedTerms on both sides", async () => {
+        const { aSes, bSes } = harness()
+
+        await aSes.offer({ price: 100 })
+        await tick()
+        expect(bSes.standingProposal?.terms).toEqual({ price: 100 })
+
+        await bSes.counter({ price: 90 })
+        await tick()
+        expect(aSes.standingProposal?.terms).toEqual({ price: 90 })
+
+        await aSes.accept()
+        await tick()
+
+        expect(aSes.state).toBe("accepted")
+        expect(bSes.state).toBe("accepted")
+        expect(aSes.outcome().agreedTerms).toEqual({ price: 90 })
+        expect(bSes.outcome().agreedTerms).toEqual({ price: 90 })
+        // accept referenced bob's counter (sequence 2)
+        expect(aSes.outcome().acceptedSequence).toBe(2)
+        expect(bSes.outcome().acceptedSequence).toBe(2)
+    })
+
+    it("reject terminates both sides", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 })
+        await tick()
+        await bSes.reject("too high")
+        await tick()
+        expect(bSes.state).toBe("rejected")
+        expect(aSes.state).toBe("rejected")
+        expect(aSes.outcome().reason).toBe("too high")
+    })
+
+    it("accept resolves the terms of the exact proposal it references", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 }) // seq 1
+        await tick()
+        await bSes.counter({ price: 80 }) // seq 2
+        await tick()
+        await aSes.counter({ price: 90 }) // seq 3 (standing)
+        await tick()
+        await bSes.accept() // accepts seq 3
+        await tick()
+        expect(aSes.outcome().agreedTerms).toEqual({ price: 90 })
+        expect(aSes.outcome().acceptedSequence).toBe(3)
+    })
+
+    it("rejects illegal transitions", async () => {
+        const { aSes } = harness()
+        // accept with nothing on the table
+        await expect(aSes.accept()).rejects.toThrow(/nothing to accept/)
+        // counter with nothing on the table
+        await expect(aSes.counter({ x: 1 })).rejects.toThrow(/nothing to counter/)
+
+        await aSes.offer({ price: 100 })
+        // second offer once one stands
+        await expect(aSes.offer({ price: 1 })).rejects.toThrow(
+            /already stands/,
+        )
+    })
+
+    it("refuses any action after a terminal state", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 })
+        await tick()
+        await aSes.accept()
+        await tick()
+        await expect(aSes.counter({ price: 1 })).rejects.toThrow(/accepted/)
+        await expect(aSes.reject()).rejects.toThrow(/accepted/)
+        await expect(bSes.offer({ price: 1 })).rejects.toThrow(/accepted/)
+    })
+
+    it("throws if an inbound accept references an unknown proposal", () => {
+        const { aSes } = harness()
+        const bogus = {
+            channelId: "ch",
+            sequence: 9,
+            sender: B,
+            sentAt: 9,
+            type: "accept" as ChannelMessageType,
+            body: { acceptedSequence: 42 } as RfqAcceptBody,
+            signature: { sigVersion: "1", signature: "0xsig9" },
+        } as ChannelMessage
+        expect(() => aSes.onIncoming(bogus)).toThrow(/unknown proposal/)
+    })
+
+    it("carries impl-defined terms opaquely (offer body shape)", async () => {
+        const { aSes, bSes } = harness()
+        const terms = { sku: "X", qty: 3, note: "rush" }
+        const msg = await aSes.offer(terms)
+        expect((msg.body as RfqProposalBody).terms).toEqual(terms)
+        await tick()
+        expect(bSes.standingProposal?.terms).toEqual(terms)
+    })
+})

--- a/src/tests/l2ps/negotiate.test.ts
+++ b/src/tests/l2ps/negotiate.test.ts
@@ -119,7 +119,9 @@ describe("RfqSession — negotiate-rfq state machine", () => {
         const { aSes, bSes } = harness()
         await aSes.offer({ price: 100 })
         await tick()
-        await aSes.accept()
+        // The counterparty (B) accepts A's offer — reaching the terminal
+        // state legitimately (a party cannot accept its own proposal).
+        await bSes.accept()
         await tick()
         await expect(aSes.counter({ price: 1 })).rejects.toThrow(/accepted/)
         await expect(aSes.reject()).rejects.toThrow(/accepted/)
@@ -138,6 +140,63 @@ describe("RfqSession — negotiate-rfq state machine", () => {
             signature: { sigVersion: "1", signature: "0xsig9" },
         } as ChannelMessage
         expect(() => aSes.onIncoming(bogus)).toThrow(/unknown proposal/)
+    })
+
+    it("refuses to accept your own standing proposal", async () => {
+        const { aSes } = harness()
+        await aSes.offer({ price: 100 })
+        await tick()
+        // A's own offer stands locally; A must not accept it.
+        await expect(aSes.accept()).rejects.toThrow(/your own proposal/)
+    })
+
+    it("rejects an inbound counter before any offer stands", () => {
+        const { aSes } = harness()
+        const counter = {
+            channelId: "ch",
+            sequence: 1,
+            sender: B,
+            sentAt: 1,
+            type: "counter" as ChannelMessageType,
+            body: { terms: { price: 1 } } as RfqProposalBody,
+            signature: { sigVersion: "1", signature: "0xsig1" },
+        } as ChannelMessage
+        expect(() => aSes.onIncoming(counter)).toThrow(/no standing offer to counter/)
+    })
+
+    it("rejects a second inbound offer once a proposal stands", async () => {
+        const { aSes } = harness()
+        await aSes.offer({ price: 100 }) // A's offer stands (seq 1)
+        await tick()
+        const secondOffer = {
+            channelId: "ch",
+            sequence: 2,
+            sender: B,
+            sentAt: 2,
+            type: "offer" as ChannelMessageType,
+            body: { terms: { price: 5 } } as RfqProposalBody,
+            signature: { sigVersion: "1", signature: "0xsig2" },
+        } as ChannelMessage
+        expect(() => aSes.onIncoming(secondOffer)).toThrow(/already stands/)
+    })
+
+    it("rejects an inbound accept that references a stale (superseded) proposal", async () => {
+        const { aSes, bSes } = harness()
+        await aSes.offer({ price: 100 }) // seq 1
+        await tick()
+        await bSes.counter({ price: 80 }) // seq 2 — supersedes seq 1
+        await tick()
+        // A receives an accept that points at the now-stale seq 1.
+        const staleAccept = {
+            channelId: "ch",
+            sequence: 3,
+            sender: B,
+            sentAt: 3,
+            type: "accept" as ChannelMessageType,
+            body: { acceptedSequence: 1 } as RfqAcceptBody,
+            signature: { sigVersion: "1", signature: "0xsig3" },
+        } as ChannelMessage
+        expect(() => aSes.onIncoming(staleAccept)).toThrow(/stale proposal/)
     })
 
     it("carries impl-defined terms opaquely (offer body shape)", async () => {

--- a/src/tests/l2ps/transport.e2e.test.ts
+++ b/src/tests/l2ps/transport.e2e.test.ts
@@ -1,0 +1,214 @@
+/**
+ * WI-A end-to-end: two REAL Demos identities, two REAL ChannelSessions,
+ * two L2PSChannelTransports, talking over an in-process relay that
+ * stands in for the L2PS messaging server. Unlike transport.test.ts
+ * (which mocks the session to isolate the reorder buffer), this exercises
+ * the full stack: real CCI-key signing, real cross-party verification
+ * (signature + sender∈members + channelId), real AES-256-GCM under a
+ * shared subnet key, and the reorder buffer under realistic out-of-order
+ * delivery.
+ */
+
+import { Demos, DemosWebAuth } from "@/websdk"
+import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
+import { ChannelSession } from "@/l2ps/channel"
+import {
+    L2PSChannelTransport,
+    type IncomingMessagePayload,
+    type L2PSMessagingPeerLike,
+    type SerializedEncryptedMessage,
+} from "@/l2ps/channel/transport"
+
+const CHANNEL = "ch-e2e-1"
+const SUBNET_KEY = new Uint8Array(32).fill(11)
+
+async function newConnectedDemos(): Promise<{
+    demos: Demos
+    claim: ClaimReference
+}> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return {
+        demos,
+        claim: demosClaimRefForAddress(await demos.getEd25519Address()),
+    }
+}
+
+/**
+ * In-process two-endpoint relay simulating the messaging transport.
+ * `deliver` routes a send to the *other* endpoint's handler. When
+ * `hold` is true, frames are queued instead of delivered so a test can
+ * flush them in an arbitrary order (offline-queue replay / reorder).
+ */
+class Relay {
+    private handlers = new Map<string, (p: IncomingMessagePayload) => void>()
+    private held: { to: string; payload: IncomingMessagePayload }[] = []
+    hold = false
+
+    endpoint(selfId: string): L2PSMessagingPeerLike {
+        return {
+            send: async (
+                to: string,
+                encrypted: SerializedEncryptedMessage,
+                messageHash: string,
+            ) => {
+                const payload: IncomingMessagePayload = {
+                    from: selfId,
+                    encrypted,
+                    messageHash,
+                }
+                if (this.hold) this.held.push({ to, payload })
+                else this.dispatch(to, payload)
+                return { messageHash, l2psStatus: "submitted" as const }
+            },
+            onMessage: handler => this.handlers.set(selfId, handler),
+        }
+    }
+
+    private dispatch(to: string, payload: IncomingMessagePayload): void {
+        const h = this.handlers.get(to)
+        if (h) h(payload)
+    }
+
+    /** Flush held frames in the given index order (to simulate reordering). */
+    flush(order: number[]): void {
+        const frames = this.held
+        this.held = []
+        for (const i of order) this.dispatch(frames[i].to, frames[i].payload)
+    }
+
+    /** Tamper the most recently held frame's signature, then flush in order. */
+    flushTampered(): void {
+        for (const f of this.held) {
+            // Corrupt the ciphertext so decrypt fails (cheapest tamper that
+            // still drives the transport's error path).
+            f.payload.encrypted = {
+                ...f.payload.encrypted,
+                ciphertext: f.payload.encrypted.ciphertext.slice(0, -4) + "AAAA",
+            }
+        }
+        const frames = this.held
+        this.held = []
+        for (const f of frames) this.dispatch(f.to, f.payload)
+    }
+}
+
+async function flush(): Promise<void> {
+    for (let i = 0; i < 4; i++) await new Promise(r => setTimeout(r, 0))
+}
+
+describe("L2PSChannelTransport — E2E with real identities", () => {
+    let alice: { demos: Demos; claim: ClaimReference }
+    let bob: { demos: Demos; claim: ClaimReference }
+
+    beforeEach(async () => {
+        alice = await newConnectedDemos()
+        bob = await newConnectedDemos()
+    })
+
+    function wire(relay: Relay) {
+        const members = [alice.claim, bob.claim]
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: alice.claim,
+            demos: alice.demos,
+        })
+        const bSes = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        const aRecv: number[] = []
+        const bRecv: number[] = []
+        const aErr: Error[] = []
+        const bErr: Error[] = []
+        const aTx = new L2PSChannelTransport({
+            session: aSes,
+            peer: relay.endpoint("alice"),
+            sharedKey: SUBNET_KEY,
+            recipients: ["bob"],
+            onMessage: m => aRecv.push(m.sequence),
+            onError: e => aErr.push(e),
+        })
+        const bTx = new L2PSChannelTransport({
+            session: bSes,
+            peer: relay.endpoint("bob"),
+            sharedKey: SUBNET_KEY,
+            recipients: ["alice"],
+            onMessage: m => bRecv.push(m.sequence),
+            onError: e => bErr.push(e),
+        })
+        return { aSes, bSes, aTx, bTx, aRecv, bRecv, aErr, bErr }
+    }
+
+    it("full offer → counter → accept round verifies on both ends", async () => {
+        const relay = new Relay()
+        const { aSes, bSes, aTx, bTx, aRecv, bRecv, aErr, bErr } = wire(relay)
+        await aSes.open()
+        await bSes.open()
+        aTx.start()
+        bTx.start()
+
+        await aTx.send({ type: "offer", body: { price: 100 } }) // seq 1
+        await flush()
+        await bTx.send({ type: "counter", body: { price: 90 }, repliesTo: 1 }) // seq 2
+        await flush()
+        await aTx.send({ type: "accept", body: { price: 90 }, repliesTo: 2 }) // seq 3
+        await flush()
+
+        // bob received alice's offer(1) + accept(3); alice received bob's counter(2)
+        expect(bRecv).toEqual([1, 3])
+        expect(aRecv).toEqual([2])
+        // Real signature verification passed throughout — no errors.
+        expect(aErr).toEqual([])
+        expect(bErr).toEqual([])
+        // Both transcripts agree on the three messages in sequence.
+        expect(aSes.messages().map(m => m.sequence)).toEqual([1, 2, 3])
+        expect(bSes.messages().map(m => m.sequence)).toEqual([1, 2, 3])
+    })
+
+    it("reorders a burst delivered out of order (offline-queue replay)", async () => {
+        const relay = new Relay()
+        const { aSes, bSes, aTx, bTx, bRecv, bErr } = wire(relay)
+        await aSes.open()
+        await bSes.open()
+        aTx.start()
+        bTx.start()
+
+        // Alice bursts two messages without waiting; the relay holds them.
+        relay.hold = true
+        await aTx.send({ type: "offer", body: { n: 1 } }) // seq 1
+        await aTx.send({ type: "counter", body: { n: 2 } }) // seq 2
+        // Deliver REVERSED: seq2 arrives before seq1.
+        relay.flush([1, 0])
+        await flush()
+
+        // Despite reversed arrival, bob applied them in sequence order.
+        expect(bRecv).toEqual([1, 2])
+        expect(bErr).toEqual([])
+        expect(bSes.messages().map(m => m.sequence)).toEqual([1, 2])
+    })
+
+    it("surfaces a tampered frame via onError without advancing", async () => {
+        const relay = new Relay()
+        const { aSes, bSes, aTx, bTx, bRecv, bErr } = wire(relay)
+        await aSes.open()
+        await bSes.open()
+        aTx.start()
+        bTx.start()
+
+        relay.hold = true
+        await aTx.send({ type: "offer", body: { n: 1 } }) // seq 1
+        relay.flushTampered()
+        await flush()
+
+        // Corrupted ciphertext → decrypt fails → onError, nothing applied.
+        expect(bRecv).toEqual([])
+        expect(bErr.length).toBe(1)
+        expect(bSes.messages()).toEqual([])
+    })
+})

--- a/src/tests/l2ps/transport.test.ts
+++ b/src/tests/l2ps/transport.test.ts
@@ -1,0 +1,201 @@
+import {
+    L2PSChannelTransport,
+    type ChannelSessionLike,
+    type IncomingMessagePayload,
+    type L2PSMessagingPeerLike,
+    type SerializedEncryptedMessage,
+} from "@/l2ps/channel/transport"
+import type { ChannelMessage, ChannelMessageType } from "@/l2ps/channel"
+
+const CHANNEL = "ch-test-1"
+const KEY = new Uint8Array(32).fill(7)
+
+/**
+ * Fake session: enforces the same monotonic rule as the real
+ * ChannelSession (`sequence` must be strictly greater than the highest
+ * seen) and records the order it accepted messages, but without real
+ * signatures so the reorder logic can be tested in isolation.
+ */
+class FakeSession implements ChannelSessionLike {
+    readonly channelId = CHANNEL
+    highestSeen = 0
+    applied: number[] = []
+    private outSeq = 0
+
+    async sendOutgoing(opts: {
+        type: ChannelMessageType
+        body: unknown
+    }): Promise<ChannelMessage> {
+        const sequence = ++this.highestSeen
+        this.outSeq = sequence
+        return makeMsg(sequence, opts.type, opts.body)
+    }
+
+    async receiveIncoming(msg: ChannelMessage): Promise<void> {
+        if (msg.sequence <= this.highestSeen) {
+            throw new Error(
+                `non-monotonic ${msg.sequence} <= ${this.highestSeen}`,
+            )
+        }
+        this.highestSeen = msg.sequence
+        this.applied.push(msg.sequence)
+    }
+}
+
+/** Fake peer: lets the test capture sends and inject inbound frames. */
+class FakePeer implements L2PSMessagingPeerLike {
+    sent: { to: string; messageHash: string }[] = []
+    private handler: ((p: IncomingMessagePayload) => void) | null = null
+
+    async send(to: string, _e: SerializedEncryptedMessage, messageHash: string) {
+        this.sent.push({ to, messageHash })
+        return { messageHash, l2psStatus: "submitted" as const }
+    }
+    onMessage(handler: (p: IncomingMessagePayload) => void): void {
+        this.handler = handler
+    }
+    inject(p: IncomingMessagePayload): void {
+        if (!this.handler) throw new Error("no handler registered")
+        this.handler(p)
+    }
+}
+
+function makeMsg(
+    sequence: number,
+    type: ChannelMessageType = "offer",
+    body: unknown = {},
+): ChannelMessage {
+    return {
+        channelId: CHANNEL,
+        sequence,
+        sender: "demos:0x" + "a".repeat(64),
+        sentAt: 1000 + sequence,
+        type,
+        body,
+        signature: { sigVersion: "1", signature: "0xsig" + sequence },
+    } as ChannelMessage
+}
+
+/**
+ * AES-256-GCM encrypt to the SerializedEncryptedMessage wire shape using
+ * the same scheme the adapter decrypts with, so an injected frame
+ * round-trips. (The adapter's own encrypt() is private; this mirrors it.)
+ */
+async function encryptEnvelope(
+    msg: ChannelMessage,
+): Promise<SerializedEncryptedMessage> {
+    const nonce = crypto.getRandomValues(new Uint8Array(12))
+    const key = await crypto.subtle.importKey(
+        "raw",
+        KEY.buffer as ArrayBuffer,
+        "AES-GCM",
+        false,
+        ["encrypt"],
+    )
+    const cipher = await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: nonce },
+        key,
+        new TextEncoder().encode(JSON.stringify(msg)),
+    )
+    return {
+        ciphertext: Buffer.from(new Uint8Array(cipher)).toString("base64"),
+        nonce: Buffer.from(nonce).toString("base64"),
+    }
+}
+
+async function inject(
+    peer: FakePeer,
+    msg: ChannelMessage,
+    from = "0xpeer",
+): Promise<void> {
+    peer.inject({
+        from,
+        encrypted: await encryptEnvelope(msg),
+        messageHash: msg.signature.signature,
+    })
+}
+
+/** Wait for the adapter's internal drain chain to settle. */
+async function flush(): Promise<void> {
+    await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
+}
+
+describe("L2PSChannelTransport — reorder buffer", () => {
+    function setup() {
+        const session = new FakeSession()
+        const peer = new FakePeer()
+        const applied: number[] = []
+        const transport = new L2PSChannelTransport({
+            session,
+            peer,
+            sharedKey: KEY,
+            recipients: ["0xpeer"],
+            onMessage: m => applied.push(m.sequence),
+        })
+        transport.start()
+        return { session, peer, transport, applied }
+    }
+
+    it("applies in-order arrivals immediately", async () => {
+        const { peer, transport, applied } = setup()
+        await inject(peer, makeMsg(1))
+        await flush()
+        await inject(peer, makeMsg(2))
+        await flush()
+        expect(applied).toEqual([1, 2])
+        expect(transport.bufferedCount).toBe(0)
+    })
+
+    it("buffers a gap and applies in order once it fills", async () => {
+        const { peer, transport, applied } = setup()
+        // seq 3 and 2 arrive before 1 (offline-queue replay / reorder)
+        await inject(peer, makeMsg(3))
+        await flush()
+        expect(applied).toEqual([]) // held — gap at 1,2
+        expect(transport.bufferedCount).toBe(1)
+
+        await inject(peer, makeMsg(2))
+        await flush()
+        expect(applied).toEqual([]) // still held — gap at 1
+        expect(transport.bufferedCount).toBe(2)
+
+        await inject(peer, makeMsg(1))
+        await flush()
+        // 1 fills the gap → 1,2,3 drain contiguously, in order
+        expect(applied).toEqual([1, 2, 3])
+        expect(transport.bufferedCount).toBe(0)
+    })
+
+    it("drops duplicates / already-applied sequences", async () => {
+        const { peer, applied } = setup()
+        await inject(peer, makeMsg(1))
+        await flush()
+        await inject(peer, makeMsg(1)) // replay
+        await flush()
+        expect(applied).toEqual([1])
+    })
+
+    it("ignores envelopes for a different channel on the same subnet", async () => {
+        const { peer, applied } = setup()
+        const other = makeMsg(1)
+        ;(other as { channelId: string }).channelId = "ch-other"
+        await inject(peer, other)
+        await flush()
+        expect(applied).toEqual([])
+    })
+
+    it("interleaves our sends with peer replies on the shared counter", async () => {
+        const { peer, transport, applied } = setup()
+        // We send seq 1; peer replies seq 2; we send seq 3; peer seq 4.
+        await transport.send({ type: "offer", body: {} }) // seq 1 (outgoing)
+        await inject(peer, makeMsg(2, "counter"))
+        await flush()
+        await transport.send({ type: "counter", body: {} }) // seq 3 (outgoing)
+        await inject(peer, makeMsg(4, "accept"))
+        await flush()
+        // Only inbound (2,4) go through onMessage; sends are returned directly.
+        expect(applied).toEqual([2, 4])
+        expect(peer.sent.length).toBe(2) // one delivery per send to the single recipient
+    })
+})

--- a/src/tests/l2ps/transport.test.ts
+++ b/src/tests/l2ps/transport.test.ts
@@ -198,4 +198,87 @@ describe("L2PSChannelTransport — reorder buffer", () => {
         expect(applied).toEqual([2, 4])
         expect(peer.sent.length).toBe(2) // one delivery per send to the single recipient
     })
+
+    it("does not commit appliedSeq when a recipient send fails", async () => {
+        // A session whose sendOutgoing mints a sequence but, unlike the
+        // monotonic FakeSession, does not raise highestSeen — so we can
+        // observe purely the transport's appliedSeq behaviour on a send
+        // that fails downstream at peer.send.
+        const recvApplied: number[] = []
+        const session: ChannelSessionLike = {
+            channelId: CHANNEL,
+            async sendOutgoing(opts) {
+                return makeMsg(1, opts.type, opts.body)
+            },
+            async receiveIncoming(msg) {
+                recvApplied.push(msg.sequence)
+            },
+        }
+        const peer = new FakePeer()
+        // Make the (only) send reject.
+        peer.send = async () => {
+            throw new Error("transport down")
+        }
+        const transport = new L2PSChannelTransport({
+            session,
+            peer,
+            sharedKey: KEY,
+            recipients: ["0xpeer"],
+        })
+        transport.start()
+
+        // sendOutgoing mints seq 1; peer.send rejects → send() throws and
+        // appliedSeq must stay 0 (never advanced past the failed send).
+        await expect(
+            transport.send({ type: "offer", body: {} }),
+        ).rejects.toThrow(/transport down/)
+
+        // appliedSeq still 0, so an inbound seq 1 is fresh and is applied —
+        // proving the failed send did not consume the channel sequence.
+        await inject(peer, makeMsg(1))
+        await flush()
+        expect(recvApplied).toEqual([1])
+    })
+
+    it("accepts a 32-byte key that is a subarray of a larger buffer", async () => {
+        // A 32-byte key view backed by a 64-byte ArrayBuffer. `key.buffer`
+        // would expose all 64 bytes and break Web Crypto's AES-256 import;
+        // the adapter must slice the exact view bytes.
+        const backing = new Uint8Array(64).fill(9)
+        const keyView = backing.subarray(0, 32)
+        const session = new FakeSession()
+        const peer = new FakePeer()
+        const transport = new L2PSChannelTransport({
+            session,
+            peer,
+            sharedKey: keyView,
+            recipients: ["0xpeer"],
+        })
+        transport.start()
+        // If the key import used the 64-byte backing buffer, encrypt would
+        // throw a DataError here.
+        await expect(
+            transport.send({ type: "offer", body: { ok: true } }),
+        ).resolves.toBeDefined()
+        expect(peer.sent.length).toBe(1)
+    })
+
+    it("drops inbound frames more than the reorder window ahead", async () => {
+        const errors: Error[] = []
+        const session = new FakeSession()
+        const peer = new FakePeer()
+        const transport = new L2PSChannelTransport({
+            session,
+            peer,
+            sharedKey: KEY,
+            recipients: ["0xpeer"],
+            onError: e => errors.push(e),
+        })
+        transport.start()
+        // appliedSeq is 0; a frame at seq 1000 is far beyond MAX_REORDER_AHEAD.
+        await inject(peer, makeMsg(1000))
+        await flush()
+        expect(transport.bufferedCount).toBe(0) // not buffered
+        expect(errors.some(e => /ahead of applied/.test(e.message))).toBe(true)
+    })
 })

--- a/src/websdk/BroadcastFailedError.ts
+++ b/src/websdk/BroadcastFailedError.ts
@@ -13,7 +13,9 @@
  */
 export class BroadcastFailedError extends Error {
     public readonly txHash: string
-    public override readonly cause: unknown
+    // No `override`: the configured lib (es2021) predates ES2022's
+    // `Error.cause`, so the base class has no `cause` to override (TS4113).
+    public readonly cause: unknown
 
     constructor(opts: { txHash: string; cause: unknown; message?: string }) {
         const causeMessage =

--- a/src/websdk/TransportError.ts
+++ b/src/websdk/TransportError.ts
@@ -9,7 +9,9 @@
  */
 export class TransportError extends Error {
     public readonly attempts: number
-    public override readonly cause: unknown
+    // No `override`: the configured lib (es2021) predates ES2022's
+    // `Error.cause`, so the base class has no `cause` to override (TS4113).
+    public readonly cause: unknown
 
     constructor(message: string, opts: { cause: unknown; attempts: number }) {
         super(message)


### PR DESCRIPTION
Combines the three stacked SR-4 DACS negotiation slices (#95 WI-A, #96 WI-B, #97 WI-C) into a single PR off `main`, rebased past `v4.0.11`.

## What your code does (plain English)

L2PS lets two parties hold a private, encrypted conversation over the Demos messaging layer. This PR builds the negotiation layer on top of that: two parties can make an offer, send counter-offers back and forth, and finally accept or reject — then optionally record a tamper-proof receipt of the whole exchange on-chain. Three pieces:

1. **Transport (WI-A)** — carries channel messages over the L2PS instant-messaging socket. Encrypts each message, sends it to every channel member, and on receipt decrypts, drops duplicates/foreign messages, and hands them to the session **in strict order** (the network can deliver out of order, so a reorder buffer fills gaps before delivery).
2. **Negotiation (WI-B)** — the offer → counter → accept/reject state machine. Enforces which transitions are legal, settles the agreed terms by the exact proposal that the accept points at (so a multi-round counter chain resolves correctly on both sides), and stays agnostic to the actual term contents.
3. **Finalize (WI-C)** — on a terminal (accepted) negotiation, exports the transcript and anchors an encrypted copy per the DACS-3 §8.7 disclosure policy (`none` / `recommended` / `required`).

## What's in the diff

| Area | File |
|---|---|
| Transport adapter | `src/l2ps/channel/transport.ts` |
| RFQ state machine | `src/l2ps/channel/negotiate.ts` |
| Finalize + anchor | `src/l2ps/channel/finalize.ts` |
| Public exports | `src/l2ps/channel/index.ts` |
| Tests | `src/tests/l2ps/{transport,negotiate,finalize,transport.e2e}.test.ts` |

## Conflict resolution

`#95` conflicted with `main` because `v4.0.11` independently landed the same TS4113 fix (`BroadcastFailedError` / `TransportError`: drop invalid `override` on `Error.cause`). Resolved by taking the chain's version — functionally identical to main (`public readonly cause: unknown`) but keeps the explanatory comment. The standalone build-fix commit from the chain is now redundant and folded away.

## Verification

- `bun run build` — green.
- `bun test transport.test.ts negotiate.test.ts` — 12/12 pure unit tests pass.
- `finalize.test.ts` / `transport.e2e.test.ts` fail to load with a **pre-existing** `export 'ValidityData' not found in './blockchain/ValidityData'` module error — reproduced identically on the original `feat/sr4-wi-c-finalize-anchor` branch, so not introduced here. Unblocking those is out of scope for this merge.

## Scope / follow-ups (unchanged from the slices)

- `negotiate-sealed-envelope` (commit-then-reveal) gated on DACS-3 §8.4.3 (not in repo).
- WI-D (AgreementDocument co-sign) needs DACS-3 §8.5.1.
- WI-E (devnet E2E) needs a node running the messaging server.

Closes #95, closes #96, closes #97.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RFQ session negotiation support, including offer/counter/accept/reject/abort flows and session state tracking.
  * Added RFQ finalization with transcript export and optional anchoring based on policy.
  * Added a channel transport adapter for encrypted message delivery, ordering, buffering, and error handling.
  * Expanded public channel exports to include the new session, transport, and finalization APIs.

* **Tests**
  * Added integration and end-to-end coverage for negotiation, finalization, message ordering, and encryption/decryption behavior.

* **Documentation**
  * Added inline clarifications to error classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->