### PR TITLE
fix(esm): resolve directory/extensionless imports so the build runs under Node ESM (P0.2)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,11 +3,18 @@ import { pathsToModuleNameMapper } from 'ts-jest';
 import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
-	moduleNameMapper: pathsToModuleNameMapper({
-		"@/*": ["src/*"]
-		// SEE: tsconfig.json > compilerOptions > paths
-		// '$lib/*': ['src/lib/*']
-	}),
+	moduleNameMapper: {
+		// The source now uses ESM-style ".js" specifiers on a few relative
+		// imports (required so the emitted build resolves under Node's strict
+		// ESM resolver). ts-jest runs the .ts source, so strip the ".js" and
+		// let it resolve to the .ts file.
+		"^(\\.{1,2}/.*)\\.js$": "$1",
+		...pathsToModuleNameMapper({
+			"@/*": ["src/*"]
+			// SEE: tsconfig.json > compilerOptions > paths
+			// '$lib/*': ['src/lib/*']
+		}),
+	},
 	preset: 'ts-jest',
 	roots: ['<rootDir>'],
 	modulePaths: ['./'],

--- a/src/demoswork/operations/conditional/index.ts
+++ b/src/demoswork/operations/conditional/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@/types"
 import { DemosWorkOutputKey } from "@/types/demoswork"
 import { Operand } from "@/types/demoswork/steps"
-import { DemosWorkOperation } from ".."
+import { DemosWorkOperation } from "../index.js"
 
 export class ConditionalOperation extends DemosWorkOperation {
     override type: OperationType = "conditional"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,7 +66,7 @@ export {
     NetworkUpgradePayload,
     NetworkUpgradeVoteTransaction,
     NetworkUpgradeVotePayload,
-} from "./blockchain/TransactionSubtypes"
+} from "./blockchain/TransactionSubtypes/index.js"
 
 // L2PSEncryptedPayload removed to avoid circular dependency - import directly from @/l2ps
 
@@ -297,4 +297,4 @@ export {
     validateTokenCreationParams,
     applyMutations,
     hasPermission,
-} from "./token"
+} from "./token/index.js"

--- a/src/types/token/index.ts
+++ b/src/types/token/index.ts
@@ -63,4 +63,4 @@ export {
     // Mutation helpers
     applyMutations,
     hasPermission,
-} from "./TokenUtils"
+} from "./TokenUtils.js"


### PR DESCRIPTION
## Problem

Reported by the DACS Directory team (reproduces on `latest` / 4.0.14): the package is pure ESM (`"type": "module"`), but a handful of relative specifiers in the main `types` barrel resolve to a **directory** (or a bare filename) with **no extension**. Node's strict ESM resolver then throws:

- `ERR_UNSUPPORTED_DIR_IMPORT` for `./blockchain/TransactionSubtypes`, `./token`, `..`
- `ERR_MODULE_NOT_FOUND` for `./TokenUtils`

So the SDK only runs under bundlers/tsx, and plain-Node ESM consumers (indexers, servers) break at import time. The build tool appends `.js` to most relative imports (634 of them) but leaves these directory / bare specifiers untouched.

## Fix

Point the four broken specifiers at the explicit index/file with a `.js` extension. tsc's `moduleResolution: bundler` maps the `.js` specifier back to the `.ts` source for type-checking, and emits it verbatim — so the build output is valid Node ESM.

| File | before | after |
| --- | --- | --- |
| `src/types/index.ts` | `./blockchain/TransactionSubtypes` | `…/index.js` |
| `src/types/index.ts` | `./token` | `./token/index.js` |
| `src/types/token/index.ts` | `./TokenUtils` | `./TokenUtils.js` |
| `src/demoswork/operations/conditional/index.ts` | `..` | `../index.js` |

## Verification

`npm run build`, then a strict resolve scan of `build/` (every relative import must resolve to a real file): **0** broken imports remain except the WIP `instant_messaging` placeholder (`./path/to/instant_messaging`), which is an unfinished, unexported module — out of scope here.

Part of the DACS-Directory SDK feedback (P0.2). Nonce issues (P1) are tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized module entry points by switching re-exports to explicit `.js` specifiers across shared type and demo operation exports.
  * Updated the test runner’s module mapping to correctly resolve ESM-style relative imports during tests.
  * Improves build/test compatibility while keeping public APIs and behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->