### PR TITLE
feat(websdk): add payAndWait/transferAndWait; document that pay/transfer only sign (P1.4)

### DIFF
--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -468,9 +468,14 @@ export class Demos {
      * @param to - The receiver address (0x-prefixed hex).
      * @param amount - DEM `number` (legacy) or OS `bigint` (preferred).
      * @param options.nonce - Optional explicit nonce.
-     * @param options.timeoutMs - Total time to wait. Defaults to 60_000.
-     * @param options.pollIntervalMs - Delay between polls. Defaults to 500.
-     * @returns The node's terminal broadcast response.
+     * @param options.timeoutMs - Max time to wait for on-chain inclusion (the
+     *   broadcast-and-poll phase). Defaults to 60_000. The preceding confirm
+     *   RPC is a single call and is not bounded by this.
+     * @param options.pollIntervalMs - Delay between inclusion polls. Defaults to 500.
+     * @param options.failFastOnBroadcastError - Reject immediately if the broadcast
+     *   RPC errors, instead of polling for a terminal status.
+     * @returns `{ broadcast, status }` — the broadcast RPC response and the
+     *   terminal on-chain status (`included` | `failed`, with optional `blockNumber`).
      */
     async payAndWait(
         to: string,
@@ -479,6 +484,7 @@ export class Demos {
             nonce?: number
             timeoutMs?: number
             pollIntervalMs?: number
+            failFastOnBroadcastError?: boolean
         },
     ) {
         const signed = await this.pay(to, amount, { nonce: options?.nonce })
@@ -486,6 +492,7 @@ export class Demos {
         return await this.broadcastAndWait(validityData, {
             timeoutMs: options?.timeoutMs,
             pollIntervalMs: options?.pollIntervalMs,
+            failFastOnBroadcastError: options?.failFastOnBroadcastError,
         })
     }
 
@@ -503,9 +510,14 @@ export class Demos {
      * @param to - The receiver address (0x-prefixed hex).
      * @param amount - DEM `number` (legacy) or OS `bigint` (preferred).
      * @param options.nonce - Optional explicit nonce.
-     * @param options.timeoutMs - Total time to wait. Defaults to 60_000.
-     * @param options.pollIntervalMs - Delay between polls. Defaults to 500.
-     * @returns The node's terminal broadcast response.
+     * @param options.timeoutMs - Max time to wait for on-chain inclusion (the
+     *   broadcast-and-poll phase). Defaults to 60_000. The preceding confirm
+     *   RPC is a single call and is not bounded by this.
+     * @param options.pollIntervalMs - Delay between inclusion polls. Defaults to 500.
+     * @param options.failFastOnBroadcastError - Reject immediately if the broadcast
+     *   RPC errors, instead of polling for a terminal status.
+     * @returns `{ broadcast, status }` — the broadcast RPC response and the
+     *   terminal on-chain status (`included` | `failed`, with optional `blockNumber`).
      */
     async transferAndWait(
         to: string,
@@ -514,6 +526,7 @@ export class Demos {
             nonce?: number
             timeoutMs?: number
             pollIntervalMs?: number
+            failFastOnBroadcastError?: boolean
         },
     ) {
         return this.payAndWait(to, amount, options)
@@ -639,10 +652,16 @@ export class Demos {
      * @param validationData - The validity data of the transaction
      * @param opts.timeoutMs - Total time to wait. Defaults to 60_000.
      * @param opts.pollIntervalMs - Delay between polls. Defaults to 500.
+     * @param opts.failFastOnBroadcastError - Reject immediately if the broadcast
+     *   RPC errors, instead of polling for a terminal status.
      */
     broadcastAndWait(
         validationData: RPCResponseWithValidityData,
-        opts?: { timeoutMs?: number; pollIntervalMs?: number },
+        opts?: {
+            timeoutMs?: number
+            pollIntervalMs?: number
+            failFastOnBroadcastError?: boolean
+        },
     ) {
         return DemosTransactions.broadcastAndWait(validationData, this, opts)
     }

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -403,9 +403,13 @@ export class Demos {
      * await demos.pay("0x...", 100)                          // legacy DEM number (deprecated)
      * ```
      *
+     * ⚠️ This only **signs** the transaction — it does NOT broadcast it, so
+     * on its own it moves no funds. Use {@link payAndWait} (or
+     * {@link transferAndWait}) to sign, broadcast, and wait for inclusion.
+     *
      * @param to - The receiver address (0x-prefixed hex).
      * @param amount - DEM `number` (legacy) or OS `bigint` (preferred).
-     * @returns The signed transaction.
+     * @returns The signed transaction (NOT broadcast).
      */
     async pay(
         to: string,
@@ -431,9 +435,12 @@ export class Demos {
      * await demos.transfer("0x...", 1_500_000_000n)                // raw OS
      * ```
      *
+     * ⚠️ Like {@link pay}, this only **signs** — it does NOT broadcast. Use
+     * {@link transferAndWait} to sign, broadcast, and wait for inclusion.
+     *
      * @param to - The receiver address (0x-prefixed hex).
      * @param amount - DEM `number` (legacy) or OS `bigint` (preferred).
-     * @returns The signed transaction.
+     * @returns The signed transaction (NOT broadcast).
      */
     async transfer(
         to: string,
@@ -441,6 +448,62 @@ export class Demos {
         options?: { nonce?: number },
     ) {
         return this.pay(to, amount, options)
+    }
+
+    /**
+     * Sign, broadcast, and wait for a native transfer to land on chain.
+     *
+     * The broadcasting counterpart to {@link pay}: it runs the full path
+     * (sign → confirm → broadcastAndWait), so the funds actually move. Prefer
+     * this over `pay`/`transfer` unless you deliberately want to handle
+     * broadcasting yourself. Throws `BroadcastTimeoutError` if the transaction
+     * doesn't reach a terminal state before the timeout.
+     *
+     * @example
+     * ```ts
+     * import { denomination } from "@kynesyslabs/demosdk"
+     * await demos.payAndWait("0x...", denomination.demToOs(100))  // sent & confirmed
+     * ```
+     *
+     * @param to - The receiver address (0x-prefixed hex).
+     * @param amount - DEM `number` (legacy) or OS `bigint` (preferred).
+     * @param options.nonce - Optional explicit nonce.
+     * @param options.timeoutMs - Total time to wait. Defaults to 60_000.
+     * @param options.pollIntervalMs - Delay between polls. Defaults to 500.
+     * @returns The node's terminal broadcast response.
+     */
+    async payAndWait(
+        to: string,
+        amount: number | bigint,
+        options?: {
+            nonce?: number
+            timeoutMs?: number
+            pollIntervalMs?: number
+        },
+    ) {
+        const signed = await this.pay(to, amount, { nonce: options?.nonce })
+        const validityData = await this.confirm(signed)
+        return this.broadcastAndWait(validityData, {
+            timeoutMs: options?.timeoutMs,
+            pollIntervalMs: options?.pollIntervalMs,
+        })
+    }
+
+    /**
+     * Alias of {@link payAndWait}: sign, broadcast, and wait for a native
+     * transfer. The broadcasting counterpart to {@link transfer} (which only
+     * signs).
+     */
+    async transferAndWait(
+        to: string,
+        amount: number | bigint,
+        options?: {
+            nonce?: number
+            timeoutMs?: number
+            pollIntervalMs?: number
+        },
+    ) {
+        return this.payAndWait(to, amount, options)
     }
 
     /**

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -483,7 +483,7 @@ export class Demos {
     ) {
         const signed = await this.pay(to, amount, { nonce: options?.nonce })
         const validityData = await this.confirm(signed)
-        return this.broadcastAndWait(validityData, {
+        return await this.broadcastAndWait(validityData, {
             timeoutMs: options?.timeoutMs,
             pollIntervalMs: options?.pollIntervalMs,
         })
@@ -493,6 +493,19 @@ export class Demos {
      * Alias of {@link payAndWait}: sign, broadcast, and wait for a native
      * transfer. The broadcasting counterpart to {@link transfer} (which only
      * signs).
+     *
+     * @example
+     * ```ts
+     * import { denomination } from "@kynesyslabs/demosdk"
+     * await demos.transferAndWait("0x...", denomination.demToOs(100))  // sent & confirmed
+     * ```
+     *
+     * @param to - The receiver address (0x-prefixed hex).
+     * @param amount - DEM `number` (legacy) or OS `bigint` (preferred).
+     * @param options.nonce - Optional explicit nonce.
+     * @param options.timeoutMs - Total time to wait. Defaults to 60_000.
+     * @param options.pollIntervalMs - Delay between polls. Defaults to 500.
+     * @returns The node's terminal broadcast response.
      */
     async transferAndWait(
         to: string,


### PR DESCRIPTION
## Problem

Reported by the DACS Directory team (they lost real transfers to this): `demos.pay()` / `demos.transfer()` **only sign** the transaction — they end in `return await demos.sign(tx)` and never broadcast. So a caller who does `await demos.transfer(to, amount)` and expects the funds to move gets a silent no-op; you must additionally `confirm()` + `broadcastAndWait()`. The verb-like naming (`pay`, `transfer`) invites exactly this bug.

## Fix (additive, non-breaking)

- Add **`payAndWait()`** and **`transferAndWait()`** — the broadcasting counterparts that run the full path (`sign → confirm → broadcastAndWait`), so the money actually moves and the call resolves once the tx lands (or throws `BroadcastTimeoutError`).
- Add a ⚠️ note to `pay()`/`transfer()` docs stating they only sign, pointing at the `*AndWait` variants, and change their `@returns` to "The signed transaction (NOT broadcast)".

Existing `pay`/`transfer` behaviour is unchanged.

```ts
// before (silent no-op — nothing broadcast):
await demos.transfer("0x...", denomination.demToOs(100))
// now:
await demos.transferAndWait("0x...", denomination.demToOs(100))  // signed, broadcast, confirmed
```

Part of the DACS-Directory SDK feedback (P1.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified transaction behavior: `pay()` and `transfer()` now clearly indicate they only sign transactions and do not broadcast them.
  * Improved the `payAndWait()` / `transferAndWait()` flow so broadcast errors can fail immediately when requested.
* **Documentation**
  * Updated method descriptions to explain the full sign, confirm, broadcast, and wait process.
  * Added clearer guidance on when to use the `*AndWait` variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->