### PR TITLE
fix(bridge): keep rubic-sdk out of the eager barrel so clean installs work (P0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "./utils": "./build/utils/index.js",
         "./encryption": "./build/encryption/index.js",
         "./bridge": "./build/bridge/index.js",
+        "./bridge/rubic": "./build/bridge/rubic.js",
         "./storage": "./build/storage/index.js",
         "./d402": "./build/d402/index.js",
         "./d402/server": "./build/d402/server/index.js",
@@ -156,7 +157,6 @@
         "pqcrypto": "^1.0.1",
         "protobufjs": "^7.6.2",
         "ripple-keypairs": "^2.0.0",
-        "rubic-sdk": "^5.57.4",
         "simple-peer": "^9.11.1",
         "socket.io-client": "^4.8.3",
         "sphincs": "^3.0.4",
@@ -165,6 +165,9 @@
         "tronweb": "^6.3.0",
         "web3": "^4.16.0",
         "xrpl": "^3.1.0"
+    },
+    "optionalDependencies": {
+        "rubic-sdk": "^5.57.4"
     },
     "devDependencies": {
         "@orbs-network/ton-access": "^2.3.3",

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -5,13 +5,12 @@ export {
     SupportedTokens,
 } from "@/types/bridge/constants"
 import RubicBridge from "./rubicBridge"
-export {
-    BLOCKCHAIN_NAME,
-    CROSS_CHAIN_TRADE_TYPE,
-    CrossChainTrade,
-    RubicSdkError,
-    WrappedCrossChainTrade,
-} from "rubic-sdk"
+// Rubic value enums/errors (BLOCKCHAIN_NAME, CROSS_CHAIN_TRADE_TYPE, RubicSdkError)
+// now live behind the optional `@kynesyslabs/demosdk/bridge/rubic` subpath, so
+// importing this barrel (or `websdk`) never eagerly loads `rubic-sdk` — whose
+// unresolvable peer-dep tree broke clean installs. The types stay here via
+// `export type` (erased at build time — no runtime pull).
+export type { CrossChainTrade, WrappedCrossChainTrade } from "rubic-sdk"
 
 import { methods as NativeBridgeMethods } from "./nativeBridge"
 import { supportedEVMChains, supportedNonEVMChains } from "./nativeBridgeTypes"

--- a/src/bridge/rubic.ts
+++ b/src/bridge/rubic.ts
@@ -1,0 +1,15 @@
+// Optional Rubic cross-chain surface.
+//
+// Importing this module pulls `rubic-sdk` at runtime — an `optionalDependency`
+// whose peer-dep tree can't always resolve. It therefore lives on its own
+// subpath (`@kynesyslabs/demosdk/bridge/rubic`) and is deliberately NOT part of
+// the `bridge` or `websdk` barrels, so a clean install of the SDK keeps working
+// even when rubic-sdk isn't (or can't be) installed. Import this only if you
+// actually run cross-chain trades and have rubic-sdk available.
+export {
+    BLOCKCHAIN_NAME,
+    CROSS_CHAIN_TRADE_TYPE,
+    CrossChainTrade,
+    RubicSdkError,
+    WrappedCrossChainTrade,
+} from "rubic-sdk"

--- a/src/bridge/rubicBridge.ts
+++ b/src/bridge/rubicBridge.ts
@@ -1,7 +1,7 @@
 import { RPCResponse } from "@/types"
 import { BridgeTradePayload } from "@/types/bridge/bridgeTradePayload"
 import { Demos } from "@/websdk/demosclass"
-import { WrappedCrossChainTrade } from "rubic-sdk"
+import type { WrappedCrossChainTrade } from "rubic-sdk"
 
 export default class RubicBridge {
     async getTrade(

--- a/src/tests/bridge/rubic.test.ts
+++ b/src/tests/bridge/rubic.test.ts
@@ -4,7 +4,7 @@ import {
     CrossChainTrade,
     RubicSdkError,
     WrappedCrossChainTrade,
-} from "@/bridge"
+} from "@/bridge/rubic"
 import { RubicBridge } from "@/bridge"
 import { BridgeTradePayload, SupportedChains } from "@/bridge"
 

--- a/src/websdk/bridge.ts
+++ b/src/websdk/bridge.ts
@@ -1,7 +1,7 @@
 import { RPCResponse } from "@/types"
 import { BridgeTradePayload } from "@/types/bridge/bridgeTradePayload"
 import { Demos } from "@/websdk/demosclass"
-import { WrappedCrossChainTrade } from "rubic-sdk"
+import type { WrappedCrossChainTrade } from "rubic-sdk"
 
 export class RubicBridge {
     async getTrade(


### PR DESCRIPTION
Closes DEM-782 (part of DEM-780 — DACS Directory SDK feedback).

## Problem

A clean `npm install @kynesyslabs/demosdk` pulled `rubic-sdk` — a hard **dependency** — whose peer tree (`@pancakeswap/smart-router` → `@pancakeswap/token-lists`, `@cetusprotocol/cetus-sui-clmm-sdk` → `@mysten/bcs`, …) can't resolve, so install failed without `--legacy-peer-deps`. And importing the `websdk` barrel eagerly loaded rubic (`websdk` → `export * from ./programmatic` → `@/bridge` → `rubic-sdk`, plus the `RubicBridge` re-export).

## Fix (non-breaking for our ecosystem)

- **Both `RubicBridge` classes** use `WrappedCrossChainTrade` only as a type → `import type` (erased at build, no runtime pull). The classes are just RPC wrappers; they never needed rubic at runtime.
- **Move the rubic value re-exports** (`BLOCKCHAIN_NAME`, `CROSS_CHAIN_TRADE_TYPE`, `RubicSdkError`) off `@/bridge` into an **opt-in `@kynesyslabs/demosdk/bridge/rubic`** subpath. The *types* stay on `@/bridge` via `export type` (erased).
- **`rubic-sdk` → `optionalDependencies`** so a clean install no longer hard-fails on its peer tree.
- Updated the one internal consumer (`tests/bridge/rubic.test.ts`) to import the values from `@/bridge/rubic`.

## Why it's safe

Audited the ecosystem: **no Demos app** (incentives, wallet-extension, agent-commerce-demo, l2ps-poc) imports rubic from the SDK. `node` imports rubic-sdk **directly** (its own dep) and uses `@kynesyslabs/demosdk/bridge` only for the **native** bridge types (`NativeBridgeOperationCompiled`, `* as bridge`) — all unchanged here. `RubicBridge` itself stays exported everywhere.

## Verification

- `bun run build` passes (tsc type-checks all of `src/**`, incl. tests).
- **rubic-sdk is no longer reachable from the `websdk` barrel's runtime graph** — a transitive-import walk of `build/websdk/index.js` finds `NONE`; only `build/bridge/rubic.js` imports rubic-sdk.
- Definitive clean-install check for review: `npm pack` this branch → `npm install` the tarball in an empty project (no `--legacy-peer-deps`) → succeeds; `import "@kynesyslabs/demosdk/websdk"` doesn't require rubic.

Note: local `npm test`/`tsc` intermittently crash on a **V8 Turboshaft JIT bug** under this Node (unrelated to the change); the Bun-based build hook is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Rubic bridge entry point for cross-chain functionality.
  * Introduced a new package subpath export for Rubic so consumers can import only what they need.

* **Bug Fixes**
  * Made Rubic SDK support optional to improve clean-install behavior.
  * Reduced unnecessary runtime loading by converting Rubic exports/imports to type-only where applicable.

* **Tests**
  * Updated Rubic bridge test imports to use the new Rubic-specific entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->