### PR TITLE
fix(encryption): lazy-load snarkjs so the websdk barrel is browser-safe (P0.3)

### DIFF
--- a/src/encryption/zK/identity/ProofGenerator.ts
+++ b/src/encryption/zK/identity/ProofGenerator.ts
@@ -10,7 +10,10 @@
  */
 
 // REVIEW: Phase 10.1 - Production cryptographic implementation
-import * as snarkjs from '@cryptkeeperzk/snarkjs'
+// snarkjs is loaded lazily (dynamic import inside the proof/verify functions):
+// a static import pulls snarkjs → node `fs` into the eager graph, which breaks
+// browser bundles that merely touch `encryption`/`websdk`. It's only needed when
+// a proof is actually generated/verified.
 
 export interface ZKProof {
     pi_a: string[]
@@ -83,6 +86,7 @@ export async function generateIdentityProof(
     const zkeyPath = 'https://files.demos.sh/zk-circuits/v1/identity_with_merkle_final.zkey'
 
     // REVIEW: Phase 10.1 - Production-ready proof generation using snarkjs
+    const snarkjs = await import('@cryptkeeperzk/snarkjs')
     const { proof, publicSignals } = await snarkjs.groth16.fullProve(
         circuitInputs,
         wasmPath,
@@ -148,6 +152,7 @@ export async function verifyProof(
             protocol: proof.protocol,
         }
 
+        const snarkjs = await import('@cryptkeeperzk/snarkjs')
         return await snarkjs.groth16.verify(vkey, publicSignals, snarkjsProof)
     } catch (error) {
         throw new Error(

--- a/src/encryption/zK/identity/ProofGenerator.ts
+++ b/src/encryption/zK/identity/ProofGenerator.ts
@@ -86,7 +86,16 @@ export async function generateIdentityProof(
     const zkeyPath = 'https://files.demos.sh/zk-circuits/v1/identity_with_merkle_final.zkey'
 
     // REVIEW: Phase 10.1 - Production-ready proof generation using snarkjs
-    const snarkjs = await import('@cryptkeeperzk/snarkjs')
+    let snarkjs: typeof import('@cryptkeeperzk/snarkjs')
+    try {
+        snarkjs = await import('@cryptkeeperzk/snarkjs')
+    } catch (error) {
+        throw new Error(
+            `ZK proof generation unavailable: could not load snarkjs (zK proofs ` +
+                `need a Node/WASM-capable environment). ` +
+                `${error instanceof Error ? error.message : String(error)}`,
+        )
+    }
     const { proof, publicSignals } = await snarkjs.groth16.fullProve(
         circuitInputs,
         wasmPath,


### PR DESCRIPTION
Closes DEM-783 (part of DEM-780 — DACS Directory SDK feedback).

## Problem

Any client bundle that touches `websdk` dragged `encryption` → zK (`ProofGenerator`) → `@cryptkeeperzk/snarkjs` → node `fs` into the **eager** import graph. snarkjs pulls `fs`, which hard-fails in the browser at bundle time. Chain: `websdk` → `DemosTransactions` (`import { Cryptography } from @/encryption`) → `encryption/index` (`export * as zK`) → `ProofGenerator` → `import * as snarkjs`.

## Fix (non-breaking)

`snarkjs` is only needed when a proof is actually generated/verified, so import it **lazily** — a dynamic `await import('@cryptkeeperzk/snarkjs')` inside `generateProof`/`verifyProof` — instead of a static top-level import. Merely importing `encryption`/`websdk` no longer loads snarkjs, so bundlers code-split it out of the main entry.

- zK public API is unchanged (both functions are already `async`; same signatures).
- Circuit artifacts were already loaded from HTTPS URLs (`files.demos.sh`), not `fs`, so nothing else in zK needs node built-ins.

## Verification

- `bun run build` passes (tsc, all of `src/**`).
- A transitive-import walk of `build/websdk/index.js` finds **NO eager `snarkjs`/`fs`** — only the dynamic `import()` inside ProofGenerator remains.

Follow-up (separate): the `browser` field already stubs `path`/`crypto` for the smaller node built-ins; this PR removes the one hard-fail (snarkjs→fs).

Note: local `npm test`/`tsc` intermittently crash on a V8 Turboshaft JIT bug under this Node (unrelated); the Bun build hook is clean.