### PR TITLE
fix(identities): allow read-only getIdentities without a wallet (P2.6)

### DIFF
--- a/src/abstraction/Identities.ts
+++ b/src/abstraction/Identities.ts
@@ -753,6 +753,16 @@ export class Identities {
         address?: string,
     ) {
         if (!address) {
+            // Reading your own identities needs a connected wallet to know the
+            // address; reading someone else's only needs their address. Fail with
+            // a clear message instead of crashing on an undefined keypair.
+            if (!demos.walletConnected) {
+                throw new Error(
+                    "getIdentities: no address given and no wallet connected. " +
+                        "Pass an `address` to read a specific account's identities, " +
+                        "or connect a wallet to read your own.",
+                )
+            }
             const ed25519 = await demos.crypto.getIdentity("ed25519")
             address = uint8ArrayToHex(ed25519.publicKey as Uint8Array)
         }
@@ -767,7 +777,9 @@ export class Identities {
             ],
         }
 
-        return await demos.rpcCall(request, true)
+        // Identities for an address are public data — only authenticate when a
+        // wallet is connected, so indexers/verifiers can read without a keypair.
+        return await demos.rpcCall(request, demos.walletConnected)
     }
 
     /**


### PR DESCRIPTION
Closes DEM-784 (part of DEM-780 — DACS Directory SDK feedback).

## Problem

`Identities.getIdentities()` on a wallet-less `new Demos()` crashed with `Cannot read properties of undefined (reading 'publicKey')`. Two causes: with no `address` it derived the caller's own ed25519 key (undefined without a wallet), and it always called `rpcCall(request, true)` — forcing the keypair-auth path. Indexers/verifiers shouldn't need a keypair to read public identity data.

## Fix (additive)

- **No `address` + no wallet** → a clear error ("pass an `address`… or connect a wallet") instead of the undefined-keypair crash.
- **Authenticate only when a wallet is connected** — `rpcCall(request, demos.walletConnected)` — so a wallet-less read-by-address goes out **unauthenticated**.

Wallet-connected behaviour is unchanged (own or explicit address, authenticated). Covers `getXmIdentities` / `getWeb2Identities` / `getUDIdentities` / `getEthosIdentities` (all delegate to `getIdentities`).

## Verification (runtime, Bun)

- `new Demos()` (no wallet) + `getIdentities(demos, "getIdentities", "0x…")` → no crash, read goes out.
- `getIdentities(demos)` (no address, no wallet) → the clear error, not a `publicKey` crash.

Note: this makes the SDK *attempt* an unauthenticated read for wallet-less callers. If the node still requires auth on `gcr_routine` reads, relaxing that is a node-side gate (the same "reads shouldn't need a keypair" ask) — but the SDK no longer forces auth or crashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity loading by showing a clear error when no address is available and a wallet isn’t connected.
  * Updated network requests to use wallet-based authentication only when a wallet is connected, keeping public data access unchanged otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->