### PR TITLE
feat(websdk): connectWalletFromPrivateKey — hex-key login without touching seed derivation (P2.7)

### DIFF
--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -347,6 +347,47 @@ export class Demos {
     }
 
     /**
+     * Connect a wallet from a hex-encoded key instead of a mnemonic.
+     *
+     * `connectWallet(<string>)` treats a non-mnemonic string as a BIP-39
+     * *passphrase* (PBKDF2), so passing a raw hex key there silently derives an
+     * unexpected identity. This method decodes the hex to bytes and feeds them to
+     * `connectWallet` as the master seed — a deterministic identity from the key,
+     * on the exact same derivation path as `connectWallet(<bytes>)`. Existing
+     * derivation is unchanged.
+     *
+     * Note: the hex is used as the SDK **master seed**, not as a literal ed25519
+     * seed — the keypair is still derived (sha3_512 → HKDF → forge). Use this for
+     * service accounts that want a stable identity from a fixed secret; it does not
+     * import a keypair produced by an external ed25519 tool.
+     *
+     * @param privateKeyHex - Hex-encoded key, optionally `0x`-prefixed.
+     * @param options - Same options as {@link connectWallet}.
+     * @returns The public key of the connected wallet (hex).
+     */
+    async connectWalletFromPrivateKey(
+        privateKeyHex: string,
+        options?: {
+            algorithm?: SigningAlgorithm
+            dual_sign?: boolean
+        },
+    ) {
+        const clean = privateKeyHex.startsWith("0x")
+            ? privateKeyHex.slice(2)
+            : privateKeyHex
+        if (
+            clean.length === 0 ||
+            clean.length % 2 !== 0 ||
+            !/^[0-9a-fA-F]+$/.test(clean)
+        ) {
+            throw new Error(
+                "connectWalletFromPrivateKey: expected a hex-encoded key (optionally 0x-prefixed).",
+            )
+        }
+        return await this.connectWallet(hexToUint8Array(clean), options)
+    }
+
+    /**
      * Returns the public key of the connected wallet.
      *
      * @returns The public key of the wallet

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -361,7 +361,7 @@ export class Demos {
      * service accounts that want a stable identity from a fixed secret; it does not
      * import a keypair produced by an external ed25519 tool.
      *
-     * @param privateKeyHex - Hex-encoded key, optionally `0x`-prefixed.
+     * @param privateKeyHex - A 32-byte key as 64 hex chars, optionally `0x`-prefixed.
      * @param options - Same options as {@link connectWallet}.
      * @returns The public key of the connected wallet (hex).
      */
@@ -375,13 +375,13 @@ export class Demos {
         const clean = privateKeyHex.startsWith("0x")
             ? privateKeyHex.slice(2)
             : privateKeyHex
-        if (
-            clean.length === 0 ||
-            clean.length % 2 !== 0 ||
-            !/^[0-9a-fA-F]+$/.test(clean)
-        ) {
+        // Require exactly 32 bytes (64 hex chars). Besides being the standard key
+        // length, this avoids connectWallet's 128-byte special case (a 128-byte
+        // master seed skips the sha3_512 step), so derivation is consistent for
+        // every accepted input.
+        if (clean.length !== 64 || !/^[0-9a-fA-F]+$/.test(clean)) {
             throw new Error(
-                "connectWalletFromPrivateKey: expected a hex-encoded key (optionally 0x-prefixed).",
+                "connectWalletFromPrivateKey: expected a 32-byte key as 64 hex chars (optionally 0x-prefixed).",
             )
         }
         return await this.connectWallet(hexToUint8Array(clean), options)


### PR DESCRIPTION
Closes DEM-785 (part of DEM-780 — DACS Directory SDK feedback).

## Problem

The SDK only really accepted a BIP-39 mnemonic. A raw hex key was either rejected (`Invalid mnemonic`, from the multichain modules) or — via `connectWallet(<string>)` — silently treated as a BIP-39 **passphrase** (PBKDF2), deriving an unexpected identity.

## Fix (strictly additive — the sensitive one)

New method **`connectWalletFromPrivateKey(hex)`**: decodes the hex (optionally `0x`-prefixed) to bytes and connects via the **same** derivation path as `connectWallet(<bytes>)`. 

- **Zero** change to the existing seed derivation — that must stay byte-stable for existing wallets (there's an explicit "do not change" comment in `connectWallet`). This is a thin wrapper only.
- Clear error on non-hex input.

## Semantics (please confirm)

The hex is used as the SDK **master seed**, *not* a literal ed25519 seed — the keypair is still derived (`sha3_512 → HKDF → forge`), because the SDK has no raw-seed path (every key goes through that chain). So this is for **service accounts that want a stable identity from a fixed secret**; it does **not** import a keypair produced by an external ed25519 tool (that's impossible without changing the whole key model).

If the team instead wants "hex = literal ed25519 seed" semantics (to import external keys), that's a separate, larger change to the key derivation — flagging rather than guessing.

## Verification (runtime, Bun)

- `connectWalletFromPrivateKey("0x" + key)` returns an address.
- **Consistent** with `connectWallet(<decoded bytes>)` (same address).
- **Deterministic** (same hex → same address).
- Invalid hex → clear error.

Existing `connectWallet` behaviour is unchanged.