### PR TITLE
feat(websdk): waitForNonce to avoid stale-nonce evictions (P1.5)

### DIFF
--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -1431,22 +1431,38 @@ export class Demos {
         target: number,
         opts?: { timeoutMs?: number; pollIntervalMs?: number },
     ): Promise<number> {
+        if (!Number.isInteger(target) || target < 0) {
+            throw new Error(
+                `waitForNonce: target must be a non-negative integer, got ${target}`,
+            )
+        }
         const timeoutMs = opts?.timeoutMs ?? 60_000
         const pollIntervalMs = opts?.pollIntervalMs ?? 500
         const deadline = Date.now() + timeoutMs
 
-        let observed = await this.getAddressNonce(address)
-        while (observed < target) {
+        let observed = -1
+        let lastError: unknown = null
+        while (true) {
+            try {
+                observed = await this.getAddressNonce(address)
+                if (observed >= target) return observed
+                lastError = null
+            } catch (error) {
+                // Tolerate transient node/transport errors — a single failed poll
+                // shouldn't abort the wait; keep polling until the deadline.
+                lastError = error
+            }
             if (Date.now() >= deadline) {
+                const detail = lastError
+                    ? `last error: ${lastError instanceof Error ? lastError.message : String(lastError)}`
+                    : `last observed ${observed}`
                 throw new Error(
                     `waitForNonce: nonce for ${address} did not reach ${target} ` +
-                        `within ${timeoutMs}ms (last observed ${observed})`,
+                        `within ${timeoutMs}ms (${detail})`,
                 )
             }
             await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
-            observed = await this.getAddressNonce(address)
         }
-        return observed
     }
 
     /**

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -1409,6 +1409,47 @@ export class Demos {
     }
 
     /**
+     * Poll the node until the nonce for `address` reaches (or exceeds) `target`.
+     *
+     * The node's `getAddressNonce` lags inclusion, so sending several transactions
+     * back-to-back can silently evict one: the next `pay`/`sign` reads a stale
+     * nonce and collides. When you must sequence dependent sends, wait for the
+     * nonce to advance past the last-sent one before signing the next.
+     *
+     * (For a single native transfer, prefer {@link payAndWait}, which already waits
+     * for on-chain inclusion.)
+     *
+     * @param address - The account address (hex).
+     * @param target - The nonce value to wait for (e.g. `lastSentNonce + 1`).
+     * @param opts.timeoutMs - Total time to wait. Defaults to 60_000.
+     * @param opts.pollIntervalMs - Delay between polls. Defaults to 500.
+     * @returns The observed nonce (>= `target`).
+     * @throws if `target` isn't reached before the timeout elapses.
+     */
+    async waitForNonce(
+        address: string,
+        target: number,
+        opts?: { timeoutMs?: number; pollIntervalMs?: number },
+    ): Promise<number> {
+        const timeoutMs = opts?.timeoutMs ?? 60_000
+        const pollIntervalMs = opts?.pollIntervalMs ?? 500
+        const deadline = Date.now() + timeoutMs
+
+        let observed = await this.getAddressNonce(address)
+        while (observed < target) {
+            if (Date.now() >= deadline) {
+                throw new Error(
+                    `waitForNonce: nonce for ${address} did not reach ${target} ` +
+                        `within ${timeoutMs}ms (last observed ${observed})`,
+                )
+            }
+            await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+            observed = await this.getAddressNonce(address)
+        }
+        return observed
+    }
+
+    /**
      * Get a validator's current record (stake, status, unstake timestamps).
      * Returns null if the address is not (and never was) a validator.
      */

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -1438,6 +1438,16 @@ export class Demos {
         }
         const timeoutMs = opts?.timeoutMs ?? 60_000
         const pollIntervalMs = opts?.pollIntervalMs ?? 500
+        if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+            throw new Error(
+                `waitForNonce: timeoutMs must be a non-negative number, got ${timeoutMs}`,
+            )
+        }
+        if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+            throw new Error(
+                `waitForNonce: pollIntervalMs must be a positive number, got ${pollIntervalMs}`,
+            )
+        }
         const deadline = Date.now() + timeoutMs
 
         let observed = -1


### PR DESCRIPTION
Part of DEM-781 (parent DEM-780 — DACS Directory SDK feedback).

## Problem

`getAddressNonce` lags inclusion, so sending several transactions back-to-back can **silently evict** one: a broadcast-accepted tx is dropped when the next `pay`/`sign` reads a stale nonce and collides. `broadcastAndWait` alone isn't enough because the *next* signer's nonce read can still lag. Consumers had to hand-roll a wait-for-nonce-advance.

## This PR (the helper half)

Adds **`waitForNonce(address, target, opts)`** — polls the node until the on-chain nonce reaches (or exceeds) `target`, or throws on timeout. Callers sequencing dependent sends wait for the nonce to advance past the last-sent one before signing the next.

Additive; nothing else changes. (For a single native transfer, `payAndWait()` already waits for inclusion.)

## Verification (runtime, Bun)

- Polls until the nonce reaches the target.
- Returns immediately when already satisfied.
- Times out with a clear error when the target is never reached.

## Scoped follow-up (still open on DEM-781)

**Transparent automatic nonce sequencing** in the hot signing path — so rapid sends never evict without the caller doing anything, and it's robust to failed/rejected txs (no nonce gaps) — is deliberately **not** in this PR. It changes the money-path nonce resolution and needs a **live testnet soak test** (fire N txs, assert none evicted, assert a failed tx doesn't corrupt the sequence), which can't be done in this environment. Filing as the remaining part of DEM-781.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper to wait until an account nonce reaches a desired value.
  * Supports configurable timeout and polling interval settings.
  * Validates the target nonce before starting and handles temporary polling issues gracefully.
* **Bug Fixes**
  * Improved error reporting when the wait period expires, including the last known nonce or error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->