### PR TITLE
feat(websdk): opt-in client-side auto nonce sequencing (DEM-781)

### DIFF
--- a/src/tests/autoNonce.spec.ts
+++ b/src/tests/autoNonce.spec.ts
@@ -4,19 +4,12 @@ const ADDR = "0x" + "aa".repeat(32)
 
 /**
  * Stub the node RPC surface so we can drive nonce logic without a live node.
- * `supportsPending` toggles whether the node exposes the new
- * `getAddressPendingNonce` handler (older nodes throw "unknown method").
+ * `getAddressNonce` returns the confirmed nonce; the auto-nonce manager seeds
+ * from that + 1 and then increments locally.
  */
-function stubNode(
-    demos: Demos,
-    state: { confirmed: number; pending?: number; supportsPending: boolean },
-) {
+function stubNode(demos: Demos, state: { confirmed: number }) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(demos as any).nodeCall = async (method: string) => {
-        if (method === "getAddressPendingNonce") {
-            if (!state.supportsPending) throw new Error("unknown method")
-            return state.pending
-        }
         if (method === "getAddressNonce") return state.confirmed
         throw new Error("unexpected nodeCall: " + method)
     }
@@ -37,39 +30,29 @@ describe("Demos auto-nonce", () => {
         expect(d._nonceReserver(ADDR)).toBeUndefined()
     })
 
-    it("getAddressPendingNonce uses the node value when supported", async () => {
-        const d = new Demos()
-        stubNode(d, { confirmed: 4, pending: 9, supportsPending: true })
-        expect(await d.getAddressPendingNonce(ADDR)).toBe(9)
-    })
-
-    it("getAddressPendingNonce falls back to confirmed+1 on older nodes", async () => {
-        const d = new Demos()
-        stubNode(d, { confirmed: 4, supportsPending: false })
-        expect(await d.getAddressPendingNonce(ADDR)).toBe(5)
-    })
-
-    it("reserver sequences nonces from the pending base without re-reading", async () => {
+    it("reserver seeds from confirmed+1 and sequences locally without re-reading", async () => {
         const d = new Demos()
         d.enableAutoNonce()
-        stubNode(d, { confirmed: 4, pending: 9, supportsPending: true })
-
-        const r = d._nonceReserver(ADDR)!
-        const got = await Promise.all([r(), r(), r()])
-        expect(got).toEqual([9, 10, 11])
-    })
-
-    it("resetNonce reseeds from the node on the next send", async () => {
-        const d = new Demos()
-        d.enableAutoNonce()
-        const state = { confirmed: 4, pending: 9, supportsPending: true }
+        const state = { confirmed: 4 }
         stubNode(d, state)
 
         const r = d._nonceReserver(ADDR)!
-        expect(await r()).toBe(9)
-        expect(await r()).toBe(10)
+        // confirmed=4 -> first usable nonce 5, then local increments 6, 7.
+        const got = await Promise.all([r(), r(), r()])
+        expect(got).toEqual([5, 6, 7])
+    })
 
-        state.pending = 20 // chain moved on
+    it("resetNonce reseeds from the confirmed nonce on the next send", async () => {
+        const d = new Demos()
+        d.enableAutoNonce()
+        const state = { confirmed: 4 }
+        stubNode(d, state)
+
+        const r = d._nonceReserver(ADDR)!
+        expect(await r()).toBe(5)
+        expect(await r()).toBe(6)
+
+        state.confirmed = 19 // chain moved on (e.g. another client sent)
         d.resetNonce(ADDR)
         expect(await r()).toBe(20)
         expect(await r()).toBe(21)

--- a/src/tests/autoNonce.spec.ts
+++ b/src/tests/autoNonce.spec.ts
@@ -1,0 +1,77 @@
+import { Demos } from "@/websdk/demosclass"
+
+const ADDR = "0x" + "aa".repeat(32)
+
+/**
+ * Stub the node RPC surface so we can drive nonce logic without a live node.
+ * `supportsPending` toggles whether the node exposes the new
+ * `getAddressPendingNonce` handler (older nodes throw "unknown method").
+ */
+function stubNode(
+    demos: Demos,
+    state: { confirmed: number; pending?: number; supportsPending: boolean },
+) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(demos as any).nodeCall = async (method: string) => {
+        if (method === "getAddressPendingNonce") {
+            if (!state.supportsPending) throw new Error("unknown method")
+            return state.pending
+        }
+        if (method === "getAddressNonce") return state.confirmed
+        throw new Error("unexpected nodeCall: " + method)
+    }
+}
+
+describe("Demos auto-nonce", () => {
+    it("is opt-in: no reserver until enabled", () => {
+        const d = new Demos()
+        expect(d.autoNonceEnabled).toBe(false)
+        expect(d._nonceReserver(ADDR)).toBeUndefined()
+
+        d.enableAutoNonce()
+        expect(d.autoNonceEnabled).toBe(true)
+        expect(typeof d._nonceReserver(ADDR)).toBe("function")
+
+        d.disableAutoNonce()
+        expect(d.autoNonceEnabled).toBe(false)
+        expect(d._nonceReserver(ADDR)).toBeUndefined()
+    })
+
+    it("getAddressPendingNonce uses the node value when supported", async () => {
+        const d = new Demos()
+        stubNode(d, { confirmed: 4, pending: 9, supportsPending: true })
+        expect(await d.getAddressPendingNonce(ADDR)).toBe(9)
+    })
+
+    it("getAddressPendingNonce falls back to confirmed+1 on older nodes", async () => {
+        const d = new Demos()
+        stubNode(d, { confirmed: 4, supportsPending: false })
+        expect(await d.getAddressPendingNonce(ADDR)).toBe(5)
+    })
+
+    it("reserver sequences nonces from the pending base without re-reading", async () => {
+        const d = new Demos()
+        d.enableAutoNonce()
+        stubNode(d, { confirmed: 4, pending: 9, supportsPending: true })
+
+        const r = d._nonceReserver(ADDR)!
+        const got = await Promise.all([r(), r(), r()])
+        expect(got).toEqual([9, 10, 11])
+    })
+
+    it("resetNonce reseeds from the node on the next send", async () => {
+        const d = new Demos()
+        d.enableAutoNonce()
+        const state = { confirmed: 4, pending: 9, supportsPending: true }
+        stubNode(d, state)
+
+        const r = d._nonceReserver(ADDR)!
+        expect(await r()).toBe(9)
+        expect(await r()).toBe(10)
+
+        state.pending = 20 // chain moved on
+        d.resetNonce(ADDR)
+        expect(await r()).toBe(20)
+        expect(await r()).toBe(21)
+    })
+})

--- a/src/tests/nonceManager.spec.ts
+++ b/src/tests/nonceManager.spec.ts
@@ -1,0 +1,84 @@
+import { NonceManager } from "@/websdk/NonceManager"
+
+const ADDR = "0x" + "ab".repeat(32)
+
+describe("NonceManager", () => {
+    it("seeds from fetchNext once, then increments locally", async () => {
+        let calls = 0
+        const fetchNext = async () => {
+            calls++
+            return 5
+        }
+        const m = new NonceManager()
+
+        expect(await m.reserve(ADDR, fetchNext)).toBe(5)
+        expect(await m.reserve(ADDR, fetchNext)).toBe(6)
+        expect(await m.reserve(ADDR, fetchNext)).toBe(7)
+        // Seeded exactly once — later reservations don't re-read the node.
+        expect(calls).toBe(1)
+    })
+
+    it("gives concurrent reservations distinct, contiguous nonces (no collision)", async () => {
+        let calls = 0
+        const fetchNext = async () => {
+            calls++
+            // Simulate node latency so races would surface without serialization.
+            await new Promise(r => setTimeout(r, 5))
+            return 10
+        }
+        const m = new NonceManager()
+
+        const results = await Promise.all(
+            Array.from({ length: 20 }, () => m.reserve(ADDR, fetchNext)),
+        )
+        const sorted = [...results].sort((a, b) => a - b)
+
+        expect(new Set(results).size).toBe(20) // all unique
+        expect(sorted).toEqual(
+            Array.from({ length: 20 }, (_, i) => 10 + i),
+        )
+        expect(calls).toBe(1) // seeded once despite concurrency
+    })
+
+    it("keys state per address", async () => {
+        const other = "0x" + "cd".repeat(32)
+        const m = new NonceManager()
+        expect(await m.reserve(ADDR, async () => 1)).toBe(1)
+        expect(await m.reserve(other, async () => 100)).toBe(100)
+        expect(await m.reserve(ADDR, async () => 999)).toBe(2) // ADDR keeps its own counter
+        expect(await m.reserve(other, async () => 999)).toBe(101)
+    })
+
+    it("reseeds from the node after reset", async () => {
+        const m = new NonceManager()
+        expect(await m.reserve(ADDR, async () => 3)).toBe(3)
+        expect(await m.reserve(ADDR, async () => 3)).toBe(4)
+        m.reset(ADDR)
+        // Chain advanced to 8 while we were away — reseed picks it up.
+        expect(await m.reserve(ADDR, async () => 8)).toBe(8)
+        expect(await m.reserve(ADDR, async () => 8)).toBe(9)
+    })
+
+    it("does not poison the address after a transient seed failure", async () => {
+        const m = new NonceManager()
+        let attempt = 0
+        const flaky = async () => {
+            attempt++
+            if (attempt === 1) throw new Error("transient RPC error")
+            return 42
+        }
+        await expect(m.reserve(ADDR, flaky)).rejects.toThrow("transient RPC error")
+        // Next reservation retries the seed and succeeds.
+        expect(await m.reserve(ADDR, flaky)).toBe(42)
+        expect(await m.reserve(ADDR, flaky)).toBe(43)
+    })
+
+    it("seed() forces the next reserved nonce; peek() reports it", async () => {
+        const m = new NonceManager()
+        expect(m.peek(ADDR)).toBeUndefined()
+        m.seed(ADDR, 77)
+        expect(m.peek(ADDR)).toBe(77)
+        expect(await m.reserve(ADDR, async () => 0)).toBe(77)
+        expect(m.peek(ADDR)).toBe(78)
+    })
+})

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,9 +24,16 @@ export function assertValidNonce(nonce: number): number {
 export async function resolveNonce(
     customNonce: number | undefined,
     fetchCurrent: () => Promise<number>,
+    reserve?: () => Promise<number>,
 ): Promise<number> {
     if (customNonce !== undefined) {
         return assertValidNonce(customNonce)
+    }
+    // When a reserver is supplied (auto-nonce enabled on the client) it
+    // sequences concurrent sends locally, seeded from the mempool-aware
+    // pending nonce. Absent it, keep the historical confirmed-nonce read.
+    if (reserve) {
+        return reserve()
     }
     return (await fetchCurrent()) + 1
 }

--- a/src/websdk/DemosTransactions.ts
+++ b/src/websdk/DemosTransactions.ts
@@ -75,8 +75,10 @@ export const DemosTransactions = {
 
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         if (typeof amount === "bigint" && amount < 0n) {
@@ -529,8 +531,10 @@ export const DemosTransactions = {
 
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         // Convert bytes to base64 for JSONB compatibility
@@ -590,8 +594,10 @@ export const DemosTransactions = {
 
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         // Self-directed transaction (from = to) triggers DTR routing
@@ -654,8 +660,10 @@ export const DemosTransactions = {
         const tx = DemosTransactions.empty()
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         // Staking txs are reflexive — the sender operates on their own
@@ -681,8 +689,10 @@ export const DemosTransactions = {
         const tx = DemosTransactions.empty()
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         tx.content.to = publicKeyHex
@@ -705,8 +715,10 @@ export const DemosTransactions = {
         const tx = DemosTransactions.empty()
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         tx.content.to = publicKeyHex
@@ -785,8 +797,10 @@ export const DemosTransactions = {
         const tx = DemosTransactions.empty()
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         tx.content.to = publicKeyHex
@@ -832,8 +846,10 @@ export const DemosTransactions = {
         const tx = DemosTransactions.empty()
         const { publicKey } = await demos.crypto.getIdentity("ed25519")
         const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-        const nonce = await resolveNonce(options?.nonce, () =>
-            demos.getAddressNonce(publicKeyHex),
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => demos.getAddressNonce(publicKeyHex),
+            demos._nonceReserver(publicKeyHex),
         )
 
         tx.content.to = publicKeyHex

--- a/src/websdk/NonceManager.ts
+++ b/src/websdk/NonceManager.ts
@@ -32,9 +32,10 @@ export class NonceManager {
     /**
      * Reserve the next nonce for `address`, serialized against other
      * reservations for the same address. Seeds from `fetchNext` on first use
-     * (or after {@link reset}); `fetchNext` must resolve the next usable nonce
-     * for the address — i.e. one accounting for txs already pending, not just
-     * the confirmed count (see `Demos.getAddressPendingNonce`).
+     * (or after {@link reset}); `fetchNext` must resolve the first usable nonce
+     * for the address — the confirmed on-chain nonce plus one
+     * (`Demos.getAddressNonce(address) + 1`). Subsequent reservations increment
+     * locally, which is what keeps concurrent sends from colliding.
      */
     async reserve(
         address: string,

--- a/src/websdk/NonceManager.ts
+++ b/src/websdk/NonceManager.ts
@@ -1,0 +1,98 @@
+import { assertValidNonce } from "@/utils"
+
+/**
+ * Per-address nonce sequencer for a single Demos client.
+ *
+ * The node reports an address's nonce lagging inclusion: `getAddressNonce()`
+ * returns the last confirmed nonce, not counting transactions already
+ * broadcast but not yet included. So two sends fired back-to-back both read
+ * the same on-chain value, compute the same nonce, and collide — the node
+ * rejects the second one. That is the batch-failure mode apps hit when
+ * sending several transactions from the same address at once.
+ *
+ * NonceManager fixes this on the client: it keeps a local "next nonce" per
+ * address, seeded once from the node, then hands out strictly increasing
+ * nonces without re-reading the lagging chain value between sends.
+ * Reservations are serialized per address so concurrent callers never share
+ * a nonce.
+ *
+ * Boundary: this only sequences sends from THIS client. If the same key
+ * signs from another client/device concurrently, the local counter drifts
+ * from the chain — call {@link reset} to reseed from the node. Likewise, a
+ * reserved nonce is consumed at build time; if that transaction never lands
+ * the counter runs ahead of the chain, so callers should {@link reset} the
+ * address after a nonce-rejection so the next reservation reseeds.
+ */
+export class NonceManager {
+    /** Next nonce to hand out per address (absent = not yet seeded). */
+    private readonly next = new Map<string, number>()
+    /** Per-address serialization tail so concurrent reservations don't race. */
+    private readonly tail = new Map<string, Promise<unknown>>()
+
+    /**
+     * Reserve the next nonce for `address`, serialized against other
+     * reservations for the same address. Seeds from `fetchNext` on first use
+     * (or after {@link reset}); `fetchNext` must resolve the next usable nonce
+     * for the address — i.e. one accounting for txs already pending, not just
+     * the confirmed count (see `Demos.getAddressPendingNonce`).
+     */
+    async reserve(
+        address: string,
+        fetchNext: () => Promise<number>,
+    ): Promise<number> {
+        const prior = this.tail.get(address) ?? Promise.resolve()
+        const run = prior.then(async () => {
+            let n = this.next.get(address)
+            if (n === undefined) {
+                // Seed once. `fetchNext` already returns the next nonce to
+                // use; subsequent reservations increment locally so rapid
+                // sends don't re-read the lagging confirmed nonce.
+                n = await fetchNext()
+            }
+            this.next.set(address, n + 1)
+            return n
+        })
+        // Swallow the tail's outcome so one rejected reservation (e.g. a
+        // transient getAddressNonce failure during seeding) does not poison
+        // every later reservation for this address. The real error still
+        // surfaces to this caller via `run`.
+        this.tail.set(
+            address,
+            run.then(
+                () => undefined,
+                () => undefined,
+            ),
+        )
+        return run
+    }
+
+    /**
+     * Drop local state for `address` so the next {@link reserve} reseeds from
+     * the node. Call after a broadcast fails with a nonce error, or when
+     * another client may have sent from the same address.
+     */
+    reset(address: string): void {
+        this.next.delete(address)
+    }
+
+    /** Drop local state for every address. */
+    resetAll(): void {
+        this.next.clear()
+    }
+
+    /**
+     * Force the next nonce for `address` (advanced use / recovery). The next
+     * {@link reserve} returns exactly `nextNonce`.
+     */
+    seed(address: string, nextNonce: number): void {
+        this.next.set(address, assertValidNonce(nextNonce))
+    }
+
+    /**
+     * The nonce the next {@link reserve} would hand out for `address`, or
+     * `undefined` if the address has not been seeded yet.
+     */
+    peek(address: string): number | undefined {
+        return this.next.get(address)
+    }
+}

--- a/src/websdk/Web2Calls.ts
+++ b/src/websdk/Web2Calls.ts
@@ -192,8 +192,11 @@ export class Web2Proxy {
         web2Tx.content.data = ["web2Request", web2Payload]
         web2Tx.content.timestamp = Date.now()
 
-        const nonce = await resolveNonce(options?.nonce, async () =>
-            this._demos.getAddressNonce(await this._demos.getEd25519Address()),
+        const fromAddress = await this._demos.getEd25519Address()
+        const nonce = await resolveNonce(
+            options?.nonce,
+            () => this._demos.getAddressNonce(fromAddress),
+            this._demos._nonceReserver(fromAddress),
         )
         web2Tx.content.nonce = nonce
 

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -1465,8 +1465,15 @@ export class Demos {
      * Reserver passed to `resolveNonce` by the transaction builders. Returns a
      * function that sequences the nonce for `address` when auto-nonce is on,
      * or `undefined` so `resolveNonce` keeps its historical per-send read.
-     * The manager seeds from {@link getAddressPendingNonce} (mempool-aware),
-     * then increments locally per send.
+     *
+     * Seeds once from the confirmed on-chain nonce (`getAddressNonce() + 1`),
+     * then increments locally per send. Seeding from the confirmed nonce (not a
+     * mempool-aware value) is deliberate: the node accepts any nonce greater
+     * than the confirmed one, and the confirmed nonce is consistent across
+     * every RPC — whereas a per-RPC mempool count is not. The local counter is
+     * what keeps a batch's nonces distinct (`N+1, N+2, …`) so they don't
+     * collide; re-reading `getAddressNonce` for each send would not, because it
+     * lags inclusion.
      *
      * @internal
      */
@@ -1475,39 +1482,10 @@ export class Demos {
             return undefined
         }
         return () =>
-            this._nonceManager.reserve(address, () =>
-                this.getAddressPendingNonce(address),
-            )
-    }
-
-    /**
-     * Get the next usable nonce for `address`, accounting for transactions
-     * already pending in the node's mempool — i.e. the value to place directly
-     * in `tx.content.nonce`. This is `getAddressNonce` semantics shifted by the
-     * sender's in-flight count (like eth `getTransactionCount('pending')`), and
-     * is what avoids batch-send collisions.
-     *
-     * Falls back to `getAddressNonce() + 1` when the node does not expose the
-     * pending-nonce RPC yet, so this works against older nodes too.
-     */
-    async getAddressPendingNonce(address: string): Promise<number> {
-        try {
-            const pending = await this.nodeCall("getAddressPendingNonce", {
+            this._nonceManager.reserve(
                 address,
-            })
-            if (typeof pending === "number" && Number.isInteger(pending) && pending >= 0) {
-                return pending
-            }
-            if (typeof pending === "string") {
-                const parsed = Number.parseInt(pending, 10)
-                if (Number.isInteger(parsed) && parsed >= 0) {
-                    return parsed
-                }
-            }
-        } catch {
-            // Older node without the pending-nonce handler — fall through.
-        }
-        return (await this.getAddressNonce(address)) + 1
+                async () => (await this.getAddressNonce(address)) + 1,
+            )
     }
 
     /**

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -11,6 +11,7 @@ import { TransportError } from "./TransportError"
 
 // NOTE Including custom libraries from Demos
 import { DemosTransactions } from "./DemosTransactions"
+import { NonceManager } from "./NonceManager"
 import { DemosWebAuth } from "./DemosWebAuth"
 import { prepareXMPayload } from "./XMTransactions"
 
@@ -125,6 +126,15 @@ export class Demos {
      * still see the warning exactly once per instance lifetime.
      */
     private static readonly _NETWORK_INFO_FAILURE_TTL_MS = 30_000
+
+    /**
+     * Client-side nonce sequencer. Opt-in via {@link enableAutoNonce}. When
+     * enabled, transaction builders reserve nonces from this manager instead
+     * of re-reading the lagging chain nonce, so batched sends from the same
+     * address don't collide. See {@link NonceManager}.
+     */
+    private readonly _nonceManager = new NonceManager()
+    private _autoNonce = false
 
     /** Connection status of the RPC URL */
     connected: boolean = false
@@ -481,11 +491,13 @@ export class Demos {
             // txs ship with the skeleton default nonce 0 and get rejected
             // by the node's sequential-nonce / expectedPrior enforcement
             // after the first one.
-            const nonce = await resolveNonce(options?.nonce, async () => {
-                const { publicKey } = await this.crypto.getIdentity("ed25519")
-                const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
-                return this.getAddressNonce(publicKeyHex)
-            })
+            const { publicKey } = await this.crypto.getIdentity("ed25519")
+            const publicKeyHex = uint8ArrayToHex(publicKey as Uint8Array)
+            const nonce = await resolveNonce(
+                options?.nonce,
+                () => this.getAddressNonce(publicKeyHex),
+                this._nonceReserver(publicKeyHex),
+            )
 
             const tx = DemosTransactions.empty()
             tx.content.to = payload.storageAddress
@@ -1406,6 +1418,96 @@ export class Demos {
         }
 
         return 0
+    }
+
+    /**
+     * Enable client-side nonce sequencing for this instance.
+     *
+     * Once enabled, every transaction builder reserves its nonce from a local
+     * per-address counter (seeded once from the node) instead of re-reading
+     * `getAddressNonce` for each send. This prevents the collisions that make
+     * batched sends from the same address fail — the node rejects two txs
+     * that reuse a nonce because `getAddressNonce` lags inclusion.
+     *
+     * Opt-in for now. Passing an explicit `options.nonce` still overrides the
+     * manager. If a send is rejected for a nonce error, call
+     * {@link resetNonce} so the next send reseeds from the chain.
+     */
+    enableAutoNonce(): void {
+        this._autoNonce = true
+    }
+
+    /** Disable client-side nonce sequencing and clear its local state. */
+    disableAutoNonce(): void {
+        this._autoNonce = false
+        this._nonceManager.resetAll()
+    }
+
+    /** Whether client-side nonce sequencing is enabled for this instance. */
+    get autoNonceEnabled(): boolean {
+        return this._autoNonce
+    }
+
+    /**
+     * Reseed the local nonce counter for `address` (or every address) from the
+     * node on the next send. Call after a nonce-rejection, or when the same
+     * key may have sent from another client.
+     */
+    resetNonce(address?: string): void {
+        if (address === undefined) {
+            this._nonceManager.resetAll()
+        } else {
+            this._nonceManager.reset(address)
+        }
+    }
+
+    /**
+     * Reserver passed to `resolveNonce` by the transaction builders. Returns a
+     * function that sequences the nonce for `address` when auto-nonce is on,
+     * or `undefined` so `resolveNonce` keeps its historical per-send read.
+     * The manager seeds from {@link getAddressPendingNonce} (mempool-aware),
+     * then increments locally per send.
+     *
+     * @internal
+     */
+    _nonceReserver(address: string): (() => Promise<number>) | undefined {
+        if (!this._autoNonce) {
+            return undefined
+        }
+        return () =>
+            this._nonceManager.reserve(address, () =>
+                this.getAddressPendingNonce(address),
+            )
+    }
+
+    /**
+     * Get the next usable nonce for `address`, accounting for transactions
+     * already pending in the node's mempool — i.e. the value to place directly
+     * in `tx.content.nonce`. This is `getAddressNonce` semantics shifted by the
+     * sender's in-flight count (like eth `getTransactionCount('pending')`), and
+     * is what avoids batch-send collisions.
+     *
+     * Falls back to `getAddressNonce() + 1` when the node does not expose the
+     * pending-nonce RPC yet, so this works against older nodes too.
+     */
+    async getAddressPendingNonce(address: string): Promise<number> {
+        try {
+            const pending = await this.nodeCall("getAddressPendingNonce", {
+                address,
+            })
+            if (typeof pending === "number" && Number.isInteger(pending) && pending >= 0) {
+                return pending
+            }
+            if (typeof pending === "string") {
+                const parsed = Number.parseInt(pending, 10)
+                if (Number.isInteger(parsed) && parsed >= 0) {
+                    return parsed
+                }
+            }
+        } catch {
+            // Older node without the pending-nonce handler — fall through.
+        }
+        return (await this.getAddressNonce(address)) + 1
     }
 
     /**


### PR DESCRIPTION
## Problem

Batched transactions from the same address fail. `getAddressNonce` returns the last **confirmed** nonce (it lags inclusion), so rapid sends all read the same value and claim the same nonce → they collide. This is the P1 issue the DACS Directory team reported.

The manual workaround (`options.nonce = getAddressNonce()+1, +2, …`) is a leaky, error-prone abstraction: one off-by-one leaves a nonce gap that stalls later txs, and concurrent code paths still race.

## Fix (client-side, opt-in)

A `NonceManager` that seeds once from the **confirmed** on-chain nonce, then hands out strictly increasing nonces **serialized per address** so concurrent sends never share one. Apps stop touching nonce entirely.

- **`NonceManager`** — per-address local counter + async mutex. `reset()` / `resetAll()` / `seed()` / `peek()`.
- **`Demos`**: `enableAutoNonce()` / `disableAutoNonce()` / `autoNonceEnabled` / `resetNonce(address?)`; `_nonceReserver()` threaded through `resolveNonce` into every tx builder (`pay`, `store`, web2, storageProgram, …).

## Why seed from the confirmed nonce (cross-RPC correctness)

The node accepts any `tx.content.nonce > confirmedNonce`, and the confirmed nonce is the **same on every RPC** (committed state, not a mempool). So:

- Seeding from confirmed + 1 and incrementing locally produces `N+1, N+2, N+3…` — all `> confirmedNonce`, accepted at any RPC.
- We deliberately do **not** seed from a mempool-aware "pending" value: a per-RPC mempool count is inconsistent across RPCs (the node team dropped mempool-count enforcement for exactly this reason).
- The local sequencer is still essential — naive `getAddressNonce()+1` per send still collides because every send reads the same lagging confirmed nonce.

## Safety / compatibility

- **Opt-in.** Default behaviour is byte-identical — `resolveNonce` still does `getAddressNonce()+1` when no reserver is supplied. Nothing changes until an app calls `enableAutoNonce()`.
- **Explicit `options.nonce` still overrides** the manager.
- **No node dependency.** Works against any node enforcing `nonce > confirmed`.
- **Money-path:** opt-in pending live-testnet soak; intended to become default afterward.
- **Boundary:** sequences sends from *this* client only. Another client/session on the same key, or a dropped tx, can drift the local counter — `resetNonce(address)` reseeds from the chain.

## Usage

```ts
demos.enableAutoNonce()
await Promise.all([ demos.pay(a, 100), demos.pay(b, 100), demos.pay(c, 100) ])
// on a nonce-rejection: demos.resetNonce(address)
```

## Tests

- `nonceManager.spec.ts` — seeds once, sequences, concurrent reservations distinct+contiguous, per-address keying, reset reseeds, transient-seed-failure recovery, seed/peek. (green)
- `autoNonce.spec.ts` — Demos wiring: opt-in gating, seed-from-confirmed sequencing, reset. (runs in CI; local dev box hits a known V8 Turboshaft crash that also kills the pre-existing `wireFormat.spec`.)

Clean `tsc` build from scratch passes (includes `src/tests/**`).
