### PR TITLE
fix(websdk): harden auto-nonce manager (post-#108 review)

### DIFF
--- a/src/tests/nonceManager.spec.ts
+++ b/src/tests/nonceManager.spec.ts
@@ -81,4 +81,31 @@ describe("NonceManager", () => {
         expect(await m.reserve(ADDR, async () => 0)).toBe(77)
         expect(m.peek(ADDR)).toBe(78)
     })
+
+    it("rejects an invalid seed instead of poisoning later reservations", async () => {
+        const m = new NonceManager()
+        await expect(m.reserve(ADDR, async () => NaN)).rejects.toThrow()
+        await expect(m.reserve(ADDR, async () => -1)).rejects.toThrow()
+        await expect(m.reserve(ADDR, async () => 3.5)).rejects.toThrow()
+        // A valid seed still works afterwards (state not poisoned).
+        expect(await m.reserve(ADDR, async () => 9)).toBe(9)
+    })
+
+    it("a reset during an in-flight seed fetch forces the next reservation to reseed", async () => {
+        const m = new NonceManager()
+        let started: () => void
+        const startedP = new Promise<void>(r => (started = r))
+        let release: (v: number) => void
+        const slowSeed = () => {
+            started()
+            return new Promise<number>(r => (release = r))
+        }
+        const inflight = m.reserve(ADDR, slowSeed)
+        await startedP // seed fetch has started (epoch captured)
+        m.reset(ADDR) // reset lands mid-fetch
+        release!(10)
+        expect(await inflight).toBe(10) // caller still gets its value
+        // but state wasn't cached — the next reservation reseeds from the node.
+        expect(await m.reserve(ADDR, async () => 20)).toBe(20)
+    })
 })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -33,7 +33,7 @@ export async function resolveNonce(
     // sequences concurrent sends locally, seeded from the mempool-aware
     // pending nonce. Absent it, keep the historical confirmed-nonce read.
     if (reserve) {
-        return reserve()
+        return assertValidNonce(await reserve())
     }
     return (await fetchCurrent()) + 1
 }

--- a/src/websdk/NonceManager.ts
+++ b/src/websdk/NonceManager.ts
@@ -28,6 +28,12 @@ export class NonceManager {
     private readonly next = new Map<string, number>()
     /** Per-address serialization tail so concurrent reservations don't race. */
     private readonly tail = new Map<string, Promise<unknown>>()
+    /**
+     * Per-address reset generation. Bumped by {@link reset}/{@link resetAll}
+     * so a reservation whose seed fetch straddled a reset does not write its
+     * now-stale seed back into `next`.
+     */
+    private readonly epoch = new Map<string, number>()
 
     /**
      * Reserve the next nonce for `address`, serialized against other
@@ -45,10 +51,19 @@ export class NonceManager {
         const run = prior.then(async () => {
             let n = this.next.get(address)
             if (n === undefined) {
-                // Seed once. `fetchNext` already returns the next nonce to
-                // use; subsequent reservations increment locally so rapid
-                // sends don't re-read the lagging confirmed nonce.
-                n = await fetchNext()
+                // Seed once. `fetchNext` returns the first usable nonce;
+                // validate it so a bad node reply (NaN/negative/fractional)
+                // can't poison every later reservation. Subsequent
+                // reservations increment locally so rapid sends don't re-read
+                // the lagging confirmed nonce.
+                const startEpoch = this.epoch.get(address) ?? 0
+                n = assertValidNonce(await fetchNext())
+                if ((this.epoch.get(address) ?? 0) !== startEpoch) {
+                    // A reset() landed while we were fetching the seed. Honour
+                    // it: hand this value to the caller but don't cache it, so
+                    // the next reservation reseeds from the node afresh.
+                    return n
+                }
             }
             this.next.set(address, n + 1)
             return n
@@ -74,11 +89,17 @@ export class NonceManager {
      */
     reset(address: string): void {
         this.next.delete(address)
+        this.epoch.set(address, (this.epoch.get(address) ?? 0) + 1)
     }
 
     /** Drop local state for every address. */
     resetAll(): void {
         this.next.clear()
+        // Bump the epoch of every address seen so far (the tail retains them)
+        // so any in-flight reservation reseeds instead of writing stale state.
+        for (const address of this.tail.keys()) {
+            this.epoch.set(address, (this.epoch.get(address) ?? 0) + 1)
+        }
     }
 
     /**

--- a/src/websdk/demosclass.ts
+++ b/src/websdk/demosclass.ts
@@ -206,6 +206,10 @@ export class Demos {
                 this._cachedNetworkInfoRpcUrl = null
                 this._cachedNetworkInfoFailed = false
                 this._cachedNetworkInfoFailedAt = 0
+                // Local nonce counters are tied to the previous node's state;
+                // drop them so the next auto-nonce reservation reseeds from
+                // the new node.
+                this._nonceManager.resetAll()
             }
             this.rpc_url = rpc_url
         }
@@ -1750,6 +1754,9 @@ export class Demos {
         // remove rpc_url and wallet connection
         this.rpc_url = null
         this.dual_sign = false
+        // Drop local nonce counters — they belong to the node/wallet we're
+        // leaving; the next connect+reservation reseeds.
+        this._nonceManager.resetAll()
 
         this.connected = false
         // Clean up the per-instance crypto from the multiton map


### PR DESCRIPTION
Follow-up to #108, which was merged and shipped in **4.0.15** before these review fixes landed. Addresses the CodeRabbit findings on that PR.

## Two Major fixes

**1. `reset()` didn't invalidate an in-flight reservation.** If `reset()`/`resetAll()` ran while a `reserve()` was awaiting its seed fetch, the in-flight call would resume and write its now-stale seed into `next` — so the reset was silently lost and the following reservation did *not* reseed. Now `reset()` bumps a per-address epoch; a reservation whose seed fetch straddled a reset returns its value to the caller but does not cache it, so the next reservation reseeds from the node.

**2. Local nonce counters survived an RPC change.** `_nonceManager` is per-instance, but `connect()` can move the same instance to a different node/network. Counters are tied to a node's committed state, so they're now cleared when the RPC changes and on `disconnect()`.

## Three Minor fixes

- Validate the fetched seed with `assertValidNonce` — a bad node reply (`NaN` / negative / fractional) would otherwise be stored as `next` and poison every later reservation.
- Validate the reserver's return at the `resolveNonce` boundary, so the reserved path enforces the same contract as an explicit `options.nonce`.
- Doc/comment alignment.

## Tests

`nonceManager.spec.ts` — **8/8 green**, including two new cases:
- `rejects an invalid seed instead of poisoning later reservations`
- `a reset during an in-flight seed fetch forces the next reservation to reseed`

Clean `tsc` build from scratch.

## Behaviour

No API change; opt-in auto-nonce semantics unchanged. This only makes `reset`/reseed correct under concurrency and RPC switches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nonce handling so invalid reserved values are rejected safely, preventing state from getting stuck.
  * Fixed reconnect and reset behavior so pending nonce operations don’t leave behind stale values after a network change or disconnect.
  * Ensured concurrent nonce reservations stay consistent even when resets happen mid-request.

* **Tests**
  * Added coverage for invalid nonce inputs and reset/concurrency edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->