### PR TITLE
feat(l2ps): negotiate-sealed-envelope — commit-then-reveal sealed bids (SR-4)

### DIFF
--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -78,3 +78,17 @@ export {
     type RfqLike,
     type ChannelSessionView,
 } from "./finalize"
+
+export {
+    SealedEnvelopeSession,
+    commitmentHex,
+    SEALED_ENVELOPE_DOMAIN_PREFIX,
+    type SealedEnvelopeState,
+    type SealedEnvelopeOutcome,
+    type SealedEnvelopeSessionOpts,
+    type SealedCommitBody,
+    type SealedRevealBody,
+    type SealedAbortBody,
+    type SealedCommitment,
+    type RevealedBid,
+} from "./sealedEnvelope"

--- a/src/l2ps/channel/sealedEnvelope.ts
+++ b/src/l2ps/channel/sealedEnvelope.ts
@@ -44,7 +44,32 @@ export const SEALED_ENVELOPE_DOMAIN_PREFIX = "dacs-sealed-envelope:v1:"
  * bytes. Recomputing this from a reveal and comparing to the commit is the
  * whole anti-cheat check: it binds the revealer to the exact bid it sealed.
  */
+function assertInjectivelySerialisable(
+    value: unknown,
+    path = "bid",
+    seen: WeakSet<object> = new WeakSet(),
+): void {
+    if (typeof value === "number") {
+        if (!Number.isFinite(value))
+            throw new Error(
+                `sealed-envelope: ${path} is ${String(value)}, which canonicalises to null — committing to it would let the sender open a different bid`,
+            )
+        return
+    }
+    if (!value || typeof value !== "object") return
+    if (seen.has(value)) return
+    seen.add(value)
+    if (Array.isArray(value)) {
+        value.forEach((v, i) => assertInjectivelySerialisable(v, `${path}[${i}]`, seen))
+        return
+    }
+    for (const [k, v] of Object.entries(value)) {
+        assertInjectivelySerialisable(v, `${path}.${k}`, seen)
+    }
+}
+
 export function commitmentHex(bid: unknown, salt: string): string {
+    assertInjectivelySerialisable(bid)
     const canonical = canonicalJSONStringify({ bid, salt })
     return bytesToHex(
         sha256(new TextEncoder().encode(SEALED_ENVELOPE_DOMAIN_PREFIX + canonical)),
@@ -156,6 +181,13 @@ export class SealedEnvelopeSession {
             throw new Error(
                 `SealedEnvelopeSession: me (${opts.me}) is not a participant`,
             )
+        // `commits` is keyed by participant, so a duplicated entry would make
+        // participants.length exceed the reachable commits.size and the commit
+        // phase could never auto-advance.
+        if (new Set(opts.participants).size !== opts.participants.length)
+            throw new Error(
+                "SealedEnvelopeSession: participants contains duplicates",
+            )
         this.me = opts.me
         this.participants = [...opts.participants]
         this.sendFn = opts.send
@@ -215,6 +247,16 @@ export class SealedEnvelopeSession {
     }
 
     /**
+     * CALLER CONTRACT — this closes THIS member's phase only. Every member must
+     * close on a signal they all share (a deadline agreed in the terms, or one
+     * derived from the transcript — not each member's own wall clock). If one
+     * member closes and reveals while another is still collecting commits, the
+     * second treats that reveal as an early one and fails the channel. That is
+     * the right call, not a bug to paper over: it cannot tell a deadline race
+     * from a cheat, and guessing would be exactly how the fairness rule gets
+     * lost. The safe default is to let the phase auto-advance once everyone has
+     * committed, and to reach for this only on an agreed deadline.
+     *
      * Close the commit phase early without waiting for every participant —
      * the deadline path. Whoever has not committed is simply excluded from the
      * auction (they never bid); the committed set is locked and reveals begin.
@@ -301,7 +343,9 @@ export class SealedEnvelopeSession {
                     throw new Error(
                         `SealedEnvelopeSession: reveal from ${msg.sender} who never committed`,
                     )
-                if (this.reveals.has(msg.sender))
+                // Already opened, or already caught cheating: a second reveal
+                // must not get another shot at passing.
+                if (this.reveals.has(msg.sender) || this._badReveals.has(msg.sender))
                     throw new Error(
                         `SealedEnvelopeSession: duplicate reveal from ${msg.sender}`,
                     )
@@ -313,7 +357,17 @@ export class SealedEnvelopeSession {
                 // A reveal that does not reproduce the commitment is a bid the
                 // sender did not seal. Disqualify — do not throw: one cheater
                 // must not sink an otherwise-valid auction.
-                if (commitmentHex(bid, salt) !== commit.commitment) {
+                // A bid the serializer rejects (bigint, undefined, a class
+                // instance, a cycle) makes commitmentHex throw. That is still a
+                // reveal that fails to open the commitment, so it disqualifies
+                // the sender — it must not crash the auction for everyone else.
+                let opens: boolean
+                try {
+                    opens = commitmentHex(bid, salt) === commit.commitment
+                } catch {
+                    opens = false
+                }
+                if (!opens) {
                     this._badReveals.add(msg.sender)
                     this.maybeAutoClose()
                     break

--- a/src/l2ps/channel/sealedEnvelope.ts
+++ b/src/l2ps/channel/sealedEnvelope.ts
@@ -1,0 +1,410 @@
+/**
+ * SR-4 — `negotiate-sealed-envelope` phase logic (DACS-3 §8.4.3).
+ *
+ * A sealed-bid negotiation runs in two phases. In the **commit** phase each
+ * participant broadcasts a hiding commitment to its bid; in the **reveal**
+ * phase it opens that commitment. The point is fairness: because every bid is
+ * locked before any is opened, no participant can see another's number and
+ * shade its own by a dollar. The L2PS channel already keeps the traffic
+ * private from non-members (CH-2); the commitment keeps a bid private from the
+ * *other members* until reveal.
+ *
+ * Like `RfqSession`, this is a pure protocol state machine — it moves no
+ * bytes. The caller wires `send` to a transport and feeds channel-verified
+ * envelopes to `onIncoming`; by then the channel layer has checked the
+ * signature, `sender ∈ members`, the channelId, and monotonic sequence, so
+ * this layer only enforces the commit/reveal rules.
+ *
+ * SPEC NOTE: §8.4.3 fixes the sealed-envelope body schema, but that section
+ * of DACS-3-NEGOTIATE.md was not available when this was written. The
+ * commit/reveal *mechanism* (hash-commit then salted-open) is unambiguous and
+ * implemented faithfully here; the exact wire field names and the
+ * `dacs-sealed-envelope:v1:` domain string below should be reconciled against
+ * §8.4.3 before this is treated as spec-final. The commitment is a hiding hash,
+ * not a channel signature — the envelope signature already authenticates the
+ * message.
+ */
+
+import { sha256 } from "@noble/hashes/sha2"
+import { randomBytes } from "@noble/hashes/utils"
+import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import { bytesToHex } from "../utils/hex"
+import type { ChannelMessage, ChannelMessageType } from "./types"
+import type { ClaimReference } from "../../identity/cci"
+
+/** Domain-separates the bid commitment from every other hash in the system. */
+export const SEALED_ENVELOPE_DOMAIN_PREFIX = "dacs-sealed-envelope:v1:"
+
+/**
+ * The hiding commitment to a bid: `sha256(domain || JCS({ bid, salt }))`, hex.
+ *
+ * The salt is what makes it hiding — without it a low-entropy bid (a round
+ * dollar amount) could be recovered by hashing candidates. It must be fresh
+ * per commitment and high-entropy; `SealedEnvelopeSession` generates 32 random
+ * bytes. Recomputing this from a reveal and comparing to the commit is the
+ * whole anti-cheat check: it binds the revealer to the exact bid it sealed.
+ */
+export function commitmentHex(bid: unknown, salt: string): string {
+    const canonical = canonicalJSONStringify({ bid, salt })
+    return bytesToHex(
+        sha256(new TextEncoder().encode(SEALED_ENVELOPE_DOMAIN_PREFIX + canonical)),
+    )
+}
+
+/** Body of a `sealed-envelope-commit`. */
+export interface SealedCommitBody {
+    commitment: string
+}
+/** Body of a `sealed-envelope-reveal`. */
+export interface SealedRevealBody {
+    bid: unknown
+    salt: string
+}
+/** Body of an `abort`. */
+export interface SealedAbortBody {
+    reason?: string
+}
+
+export type SealedEnvelopeState = "commit" | "reveal" | "closed" | "aborted"
+
+/** A commitment on record, before its bid is known. */
+export interface SealedCommitment {
+    participant: ClaimReference
+    commitment: string
+    sequence: number
+}
+
+/** A reveal whose bid matched its commitment. */
+export interface RevealedBid {
+    participant: ClaimReference
+    bid: unknown
+    sequence: number
+}
+
+export interface SealedEnvelopeOutcome {
+    state: SealedEnvelopeState
+    /** Valid reveals (commitment matched), in the order revealed. */
+    reveals: RevealedBid[]
+    /**
+     * Participants who committed but, by the time the session closed, either
+     * never revealed or revealed a bid that did not match their commitment.
+     * A defaulting bidder is visible, not silently dropped.
+     */
+    disqualified: ClaimReference[]
+    /** Set when a `compareBids` comparator was supplied and ≥1 valid reveal. */
+    winner?: ClaimReference
+    winningBid?: unknown
+    /** Reason for an abort, if given. */
+    reason?: string
+}
+
+export interface SealedEnvelopeSessionOpts {
+    /** This party's CCI primary claim. */
+    me: ClaimReference
+    /**
+     * The fixed bidder set for this auction (CH-1). The commit phase closes
+     * automatically once every one of these has committed; `me` must be in it.
+     */
+    participants: ClaimReference[]
+    /**
+     * Delivers a signed channel message (wire to the transport's send).
+     * Returns the signed envelope so the session can record its sequence.
+     */
+    send: (opts: {
+        type: ChannelMessageType
+        body: unknown
+        repliesTo?: number
+    }) => Promise<ChannelMessage>
+    /**
+     * Optional winner rule over valid reveals. Positive → `a` beats `b`
+     * (highest wins); the session picks the maximum. Ties resolve to the
+     * earlier-revealed bid. Absent → no winner is chosen; the caller ranks
+     * `outcome.reveals` itself.
+     */
+    compareBids?: (a: RevealedBid, b: RevealedBid) => number
+    /** Fired on every phase/state transition. */
+    onStateChange?: (outcome: SealedEnvelopeOutcome) => void
+    /** Fired when the commit phase closes and reveals may begin. */
+    onRevealPhase?: () => void
+}
+
+/** Non-terminal-state message types this session acts on. */
+const SEALED_TYPES: ReadonlySet<ChannelMessageType> = new Set<ChannelMessageType>([
+    "sealed-envelope-commit",
+    "sealed-envelope-reveal",
+    "abort",
+])
+
+export class SealedEnvelopeSession {
+    private readonly me: ClaimReference
+    private readonly participants: ReadonlyArray<ClaimReference>
+    private readonly sendFn: SealedEnvelopeSessionOpts["send"]
+    private readonly compareBids?: SealedEnvelopeSessionOpts["compareBids"]
+    private readonly onStateChange?: (o: SealedEnvelopeOutcome) => void
+    private readonly onRevealPhase?: () => void
+
+    private _state: SealedEnvelopeState = "commit"
+    private readonly commits = new Map<ClaimReference, SealedCommitment>()
+    private readonly reveals = new Map<ClaimReference, RevealedBid>()
+    /** My own sealed bid, kept between committing and revealing it. */
+    private mySealed: { bid: unknown; salt: string } | null = null
+
+    constructor(opts: SealedEnvelopeSessionOpts) {
+        if (!opts.participants?.length)
+            throw new Error("SealedEnvelopeSession: participants required")
+        if (!opts.participants.includes(opts.me))
+            throw new Error(
+                `SealedEnvelopeSession: me (${opts.me}) is not a participant`,
+            )
+        this.me = opts.me
+        this.participants = [...opts.participants]
+        this.sendFn = opts.send
+        this.compareBids = opts.compareBids
+        this.onStateChange = opts.onStateChange
+        this.onRevealPhase = opts.onRevealPhase
+    }
+
+    get state(): SealedEnvelopeState {
+        return this._state
+    }
+    /** Commitments on record so far (bids still hidden). */
+    commitments(): ReadonlyArray<SealedCommitment> {
+        return [...this.commits.values()]
+    }
+    outcome(): SealedEnvelopeOutcome {
+        return this.buildOutcome()
+    }
+
+    /** Commit to a bid — commit phase only, once per participant. */
+    async commit(bid: unknown): Promise<ChannelMessage> {
+        if (this._state !== "commit")
+            throw new Error(
+                `SealedEnvelopeSession: cannot commit — phase is ${this._state}`,
+            )
+        if (this.commits.has(this.me))
+            throw new Error("SealedEnvelopeSession: already committed")
+
+        const salt = bytesToHex(randomBytes(32))
+        const commitment = commitmentHex(bid, salt)
+        const body: SealedCommitBody = { commitment }
+        const msg = await this.sendFn({ type: "sealed-envelope-commit", body })
+        // Stash the opening locally; only its hash went on the wire.
+        this.mySealed = { bid, salt }
+        this.recordCommit(this.me, commitment, msg.sequence)
+        return msg
+    }
+
+    /** Open my committed bid — reveal phase only. */
+    async reveal(): Promise<ChannelMessage> {
+        if (this._state !== "reveal")
+            throw new Error(
+                `SealedEnvelopeSession: cannot reveal — phase is ${this._state}`,
+            )
+        if (!this.mySealed)
+            throw new Error("SealedEnvelopeSession: nothing to reveal — never committed")
+        if (this.reveals.has(this.me))
+            throw new Error("SealedEnvelopeSession: already revealed")
+
+        const body: SealedRevealBody = {
+            bid: this.mySealed.bid,
+            salt: this.mySealed.salt,
+        }
+        const msg = await this.sendFn({ type: "sealed-envelope-reveal", body })
+        this.recordReveal(this.me, this.mySealed.bid, msg.sequence)
+        return msg
+    }
+
+    /**
+     * Close the commit phase early without waiting for every participant —
+     * the deadline path. Whoever has not committed is simply excluded from the
+     * auction (they never bid); the committed set is locked and reveals begin.
+     */
+    closeCommitPhase(): void {
+        if (this._state !== "commit")
+            throw new Error(
+                `SealedEnvelopeSession: not in commit phase (${this._state})`,
+            )
+        this.enterRevealPhase()
+    }
+
+    /**
+     * Close the auction — the deadline path for the reveal phase. Any
+     * participant who committed but has not revealed is disqualified, and the
+     * winner (if a comparator was given) is drawn from the valid reveals.
+     */
+    close(): SealedEnvelopeOutcome {
+        if (this._state !== "reveal")
+            throw new Error(
+                `SealedEnvelopeSession: cannot close — phase is ${this._state}`,
+            )
+        this.settle("closed")
+        return this.buildOutcome()
+    }
+
+    /** Abort the negotiation — terminal (CH-5). */
+    async abort(reason?: string): Promise<ChannelMessage> {
+        if (this._state === "closed" || this._state === "aborted")
+            throw new Error(
+                `SealedEnvelopeSession: cannot abort — already ${this._state}`,
+            )
+        const body: SealedAbortBody = reason ? { reason } : {}
+        const msg = await this.sendFn({ type: "abort", body })
+        this._reason = reason
+        this.settle("aborted")
+        return msg
+    }
+
+    /**
+     * Feed a channel-verified inbound message. No-op for unrelated types, our
+     * own echo, or traffic after a terminal state. Throws on a protocol
+     * violation the channel layer cannot catch — the decisive one being a
+     * reveal that arrives while bids are still being committed, which would let
+     * a laggard adapt its bid to a number it should not yet be able to see.
+     */
+    onIncoming(msg: ChannelMessage): void {
+        if (!SEALED_TYPES.has(msg.type)) return
+        if (msg.sender === this.me) return // our own echo, already applied
+        if (this._state === "closed" || this._state === "aborted") return
+
+        switch (msg.type) {
+            case "sealed-envelope-commit": {
+                if (this._state !== "commit")
+                    throw new Error(
+                        `SealedEnvelopeSession: commit from ${msg.sender} after commit phase closed`,
+                    )
+                if (!this.participants.includes(msg.sender))
+                    throw new Error(
+                        `SealedEnvelopeSession: commit from non-participant ${msg.sender}`,
+                    )
+                if (this.commits.has(msg.sender))
+                    throw new Error(
+                        `SealedEnvelopeSession: duplicate commit from ${msg.sender}`,
+                    )
+                const { commitment } = (msg.body as SealedCommitBody) ?? {}
+                if (typeof commitment !== "string" || !commitment)
+                    throw new Error(
+                        `SealedEnvelopeSession: commit from ${msg.sender} carries no commitment`,
+                    )
+                this.recordCommit(msg.sender, commitment, msg.sequence)
+                break
+            }
+            case "sealed-envelope-reveal": {
+                // The core fairness rule: a reveal is only legal once every
+                // bid is locked. Before that, an un-committed party could see
+                // this number and set its own accordingly.
+                if (this._state !== "reveal")
+                    throw new Error(
+                        `SealedEnvelopeSession: reveal from ${msg.sender} before the commit phase closed`,
+                    )
+                const commit = this.commits.get(msg.sender)
+                if (!commit)
+                    throw new Error(
+                        `SealedEnvelopeSession: reveal from ${msg.sender} who never committed`,
+                    )
+                if (this.reveals.has(msg.sender))
+                    throw new Error(
+                        `SealedEnvelopeSession: duplicate reveal from ${msg.sender}`,
+                    )
+                const { bid, salt } = (msg.body as SealedRevealBody) ?? {}
+                if (typeof salt !== "string" || !salt)
+                    throw new Error(
+                        `SealedEnvelopeSession: reveal from ${msg.sender} carries no salt`,
+                    )
+                // A reveal that does not reproduce the commitment is a bid the
+                // sender did not seal. Disqualify — do not throw: one cheater
+                // must not sink an otherwise-valid auction.
+                if (commitmentHex(bid, salt) !== commit.commitment) {
+                    this._badReveals.add(msg.sender)
+                    this.maybeAutoClose()
+                    break
+                }
+                this.recordReveal(msg.sender, bid, msg.sequence)
+                break
+            }
+            case "abort": {
+                this._reason = (msg.body as SealedAbortBody)?.reason
+                this.settle("aborted")
+                break
+            }
+        }
+    }
+
+    // ── internals ──────────────────────────────────────────────────────────
+
+    private _reason: string | undefined
+    /** Committers whose reveal did not match — disqualified, not fatal. */
+    private readonly _badReveals = new Set<ClaimReference>()
+
+    private recordCommit(
+        participant: ClaimReference,
+        commitment: string,
+        sequence: number,
+    ): void {
+        this.commits.set(participant, { participant, commitment, sequence })
+        // Everyone in the auction has sealed a bid — open the reveal phase.
+        if (this._state === "commit" && this.commits.size === this.participants.length)
+            this.enterRevealPhase()
+        else this.emitStateChange()
+    }
+
+    private recordReveal(
+        participant: ClaimReference,
+        bid: unknown,
+        sequence: number,
+    ): void {
+        this.reveals.set(participant, { participant, bid, sequence })
+        this.maybeAutoClose()
+    }
+
+    /** Close once every committer is accounted for — validly opened or not. */
+    private maybeAutoClose(): void {
+        if (
+            this._state === "reveal" &&
+            this.reveals.size + this._badReveals.size === this.commits.size
+        )
+            this.settle("closed")
+        else this.emitStateChange()
+    }
+
+    private enterRevealPhase(): void {
+        this._state = "reveal"
+        this.onRevealPhase?.()
+        this.emitStateChange()
+    }
+
+    private settle(state: "closed" | "aborted"): void {
+        this._state = state
+        this.emitStateChange()
+    }
+
+    private emitStateChange(): void {
+        this.onStateChange?.(this.buildOutcome())
+    }
+
+    private buildOutcome(): SealedEnvelopeOutcome {
+        const reveals = [...this.reveals.values()]
+        // A committer is disqualified if it never produced a valid reveal —
+        // only meaningful once the auction has closed.
+        const disqualified: ClaimReference[] = []
+        if (this._state === "closed") {
+            for (const p of this.commits.keys())
+                if (!this.reveals.has(p)) disqualified.push(p)
+        }
+        for (const p of this._badReveals) if (!disqualified.includes(p)) disqualified.push(p)
+
+        const outcome: SealedEnvelopeOutcome = {
+            state: this._state,
+            reveals,
+            disqualified,
+            reason: this._reason,
+        }
+        if (this._state === "closed" && this.compareBids && reveals.length) {
+            const winner = reveals.reduce((best, r) =>
+                this.compareBids!(r, best) > 0 ? r : best,
+            )
+            outcome.winner = winner.participant
+            outcome.winningBid = winner.bid
+        }
+        return outcome
+    }
+}

--- a/src/tests/l2ps/sealedEnvelope.test.ts
+++ b/src/tests/l2ps/sealedEnvelope.test.ts
@@ -264,6 +264,53 @@ describe("SealedEnvelopeSession — protocol guards", () => {
     })
 })
 
+describe("SealedEnvelopeSession — a sealed bid must open to exactly what was sealed", () => {
+    it("refuses NaN/Infinity, which canonicalise to null and would open as null", () => {
+        // Commit {price: NaN}, reveal {price: null}: same canonical bytes, same
+        // commitment. That breaks the whole scheme, so it is refused at commit.
+        for (const bad of [NaN, Infinity, -Infinity]) {
+            expect(() => commitmentHex({ price: bad }, "aa")).toThrow(/canonicalises to null/)
+        }
+        expect(commitmentHex({ price: 1 }, "aa")).not.toBe(commitmentHex({ price: null }, "aa"))
+    })
+
+    it("disqualifies a reveal the serializer rejects, instead of crashing the auction", async () => {
+        const h = harness([A, B], { compareBids: byPrice })
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+        await h.get(A).reveal()
+
+        // A bid that cannot be canonicalised (undefined) cannot open anything —
+        // that is a failed reveal, not a reason to kill everyone's auction.
+        const junk = h.raw(B, "sealed-envelope-reveal", { bid: { price: undefined }, salt: "00" })
+        expect(() => h.get(A).onIncoming(junk)).not.toThrow()
+        await tick()
+        const o = h.get(A).outcome()
+        expect(o.disqualified).toEqual([B])
+        expect(o.winner).toBe(A)
+    })
+
+    it("keeps a disqualified bidder out — no second attempt", async () => {
+        const h = harness([A, B])
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+        const bad = h.raw(B, "sealed-envelope-reveal", { bid: { price: 999 }, salt: "00" })
+        h.get(A).onIncoming(bad)
+        // B, caught cheating, tries again with something that would open cleanly.
+        const retry = h.raw(B, "sealed-envelope-reveal", { bid: { price: 100 }, salt: "11" })
+        expect(() => h.get(A).onIncoming(retry)).toThrow(/duplicate reveal/)
+        expect(h.get(A).outcome().disqualified).toEqual([B])
+    })
+
+    it("refuses duplicate participants — the commit phase could never complete", () => {
+        expect(
+            () => new SealedEnvelopeSession({ me: A, participants: [A, B, B], send: async () => ({}) as ChannelMessage }),
+        ).toThrow(/duplicates/)
+    })
+})
+
 describe("SealedEnvelopeSession — abort", () => {
     it("aborts terminally and refuses further transitions", async () => {
         const h = harness([A, B])

--- a/src/tests/l2ps/sealedEnvelope.test.ts
+++ b/src/tests/l2ps/sealedEnvelope.test.ts
@@ -1,0 +1,290 @@
+import {
+    SealedEnvelopeSession,
+    commitmentHex,
+    type RevealedBid,
+    type SealedCommitBody,
+} from "@/l2ps/channel/sealedEnvelope"
+import type { ChannelMessage, ChannelMessageType } from "@/l2ps/channel"
+import type { ClaimReference } from "@/identity/cci"
+
+const A = ("demos:0x" + "a".repeat(64)) as ClaimReference
+const B = ("demos:0x" + "b".repeat(64)) as ClaimReference
+const C = ("demos:0x" + "c".repeat(64)) as ClaimReference
+
+/** Highest-price-wins comparator for the tests that pick a winner. */
+const byPrice = (a: RevealedBid, b: RevealedBid): number =>
+    (a.bid as { price: number }).price - (b.bid as { price: number }).price
+
+/**
+ * An N-party sealed-envelope harness. Each session's `send` mints a
+ * ChannelMessage on a shared monotonic sequence and delivers it to every
+ * *other* session's `onIncoming` — no transport / crypto, so this exercises the
+ * protocol state machine, not the channel layer's verification.
+ */
+function harness(
+    participants: ClaimReference[],
+    opts?: Partial<{ compareBids: (a: RevealedBid, b: RevealedBid) => number }>,
+) {
+    let seq = 0
+    const sessions = new Map<ClaimReference, SealedEnvelopeSession>()
+
+    const mkSend =
+        (me: ClaimReference) =>
+        async (o: {
+            type: ChannelMessageType
+            body: unknown
+            repliesTo?: number
+        }): Promise<ChannelMessage> => {
+            const msg = {
+                channelId: "ch",
+                sequence: ++seq,
+                sender: me,
+                sentAt: 1000 + seq,
+                type: o.type,
+                body: o.body,
+                ...(o.repliesTo !== undefined && { refs: { repliesTo: o.repliesTo } }),
+                signature: { sigVersion: "1", signature: "0xsig" + seq },
+            } as ChannelMessage
+            queueMicrotask(() => {
+                for (const [claim, s] of sessions)
+                    if (claim !== me) s.onIncoming(msg)
+            })
+            return msg
+        }
+
+    for (const p of participants)
+        sessions.set(
+            p,
+            new SealedEnvelopeSession({
+                me: p,
+                participants,
+                send: mkSend(p),
+                compareBids: opts?.compareBids,
+            }),
+        )
+
+    // A raw sender for crafting adversarial (unsigned) messages by hand.
+    const raw = (
+        sender: ClaimReference,
+        type: ChannelMessageType,
+        body: unknown,
+    ): ChannelMessage =>
+        ({
+            channelId: "ch",
+            sequence: ++seq,
+            sender,
+            sentAt: 1000 + seq,
+            type,
+            body,
+            signature: { sigVersion: "1", signature: "0xraw" + seq },
+        }) as ChannelMessage
+
+    return { get: (c: ClaimReference) => sessions.get(c)!, raw }
+}
+
+const tick = () => new Promise(r => setTimeout(r, 0))
+
+describe("commitmentHex", () => {
+    it("is deterministic in (bid, salt) and hiding across salts", () => {
+        expect(commitmentHex({ price: 100 }, "aa")).toBe(commitmentHex({ price: 100 }, "aa"))
+        expect(commitmentHex({ price: 100 }, "aa")).not.toBe(commitmentHex({ price: 100 }, "bb"))
+        expect(commitmentHex({ price: 100 }, "aa")).not.toBe(commitmentHex({ price: 101 }, "aa"))
+        expect(commitmentHex({ price: 100 }, "aa")).toMatch(/^[0-9a-f]{64}$/)
+    })
+})
+
+describe("SealedEnvelopeSession — happy path", () => {
+    it("commit → auto reveal-phase → reveal → auto close, winner is the top bid", async () => {
+        const h = harness([A, B], { compareBids: byPrice })
+
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+
+        // Both crossed into the reveal phase only after every bid was sealed.
+        expect(h.get(A).state).toBe("reveal")
+        expect(h.get(B).state).toBe("reveal")
+
+        await h.get(A).reveal()
+        await h.get(B).reveal()
+        await tick()
+
+        for (const who of [A, B]) {
+            const o = h.get(who).outcome()
+            expect(o.state).toBe("closed")
+            expect(o.winner).toBe(B)
+            expect(o.winningBid).toEqual({ price: 100 })
+            expect(o.disqualified).toEqual([])
+            expect(o.reveals).toHaveLength(2)
+        }
+    })
+
+    it("keeps bids hidden until reveal — the commit carries only a hash", async () => {
+        const h = harness([A, B])
+        await h.get(A).commit({ price: 90 })
+        await tick()
+
+        // B has A's commitment on record, but not the number behind it: the
+        // record carries only the hash — no bid, no salt. (Substring-checking
+        // the hash for "90" would be flaky: a random salt's hex can contain it.)
+        const [onlyCommit] = h.get(B).commitments()
+        expect(onlyCommit.participant).toBe(A)
+        expect(onlyCommit.commitment).toMatch(/^[0-9a-f]{64}$/)
+        const serialized = JSON.stringify(h.get(B).commitments())
+        for (const leak of ['"bid"', '"price"', '"salt"']) expect(serialized).not.toContain(leak)
+        expect(Object.keys(onlyCommit).sort()).toEqual(["commitment", "participant", "sequence"])
+        expect(h.get(B).state).toBe("commit") // not everyone has committed yet
+    })
+})
+
+describe("SealedEnvelopeSession — fairness", () => {
+    it("rejects a reveal that lands before the commit phase closed", async () => {
+        const h = harness([A, B, C])
+        await h.get(A).commit({ price: 90 })
+        await tick()
+        // A is still in commit (B, C haven't committed). A peeking at a reveal
+        // now would let it re-bid against a number it should not yet see.
+        const early = h.raw(B, "sealed-envelope-reveal", { bid: { price: 100 }, salt: "de" })
+        expect(() => h.get(A).onIncoming(early)).toThrow(/before the commit phase closed/)
+    })
+
+    it("cannot reveal through the API while bids are still open", async () => {
+        const h = harness([A, B])
+        await h.get(A).commit({ price: 90 })
+        await tick()
+        await expect(h.get(A).reveal()).rejects.toThrow(/cannot reveal — phase is commit/)
+    })
+})
+
+describe("SealedEnvelopeSession — cheating is contained, not fatal", () => {
+    it("disqualifies a reveal whose bid does not match its commitment", async () => {
+        const h = harness([A, B], { compareBids: byPrice })
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+
+        // A opens honestly; B hand-crafts a reveal for a different number than
+        // it sealed. B's commitment was to {price:100}; it now claims 999.
+        await h.get(A).reveal()
+        const bCommitment = h.get(A).commitments().find(c => c.participant === B)!.commitment
+        const forged = h.raw(B, "sealed-envelope-reveal", { bid: { price: 999 }, salt: "00" })
+        expect(commitmentHex({ price: 999 }, "00")).not.toBe(bCommitment) // sanity
+        h.get(A).onIncoming(forged)
+        await tick()
+
+        const o = h.get(A).outcome()
+        expect(o.state).toBe("closed") // every committer accounted for → auto-closed
+        expect(o.disqualified).toEqual([B])
+        expect(o.reveals.map(r => r.participant)).toEqual([A])
+        expect(o.winner).toBe(A) // the only valid bid wins by default
+    })
+
+    it("disqualifies a committer who never reveals, at the deadline", async () => {
+        const h = harness([A, B], { compareBids: byPrice })
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+
+        await h.get(A).reveal()
+        await tick()
+        expect(h.get(A).state).toBe("reveal") // B still owes a reveal
+
+        // Deadline: A closes the auction; B forfeits its (higher) sealed bid.
+        const o = h.get(A).close()
+        expect(o.state).toBe("closed")
+        expect(o.disqualified).toEqual([B])
+        expect(o.winner).toBe(A)
+        expect(o.winningBid).toEqual({ price: 90 })
+    })
+})
+
+describe("SealedEnvelopeSession — deadlines & exclusion", () => {
+    it("closeCommitPhase excludes a non-committer without disqualifying it", async () => {
+        const h = harness([A, B, C], { compareBids: byPrice })
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+        expect(h.get(A).state).toBe("commit") // C hasn't committed
+
+        // Every online party hits the commit deadline and closes its commit
+        // phase — the committed set is locked to {A, B}. C, having never bid,
+        // moves to reveal with nothing to open.
+        for (const p of [A, B, C]) h.get(p).closeCommitPhase()
+        expect(h.get(A).state).toBe("reveal")
+
+        await h.get(A).reveal()
+        await h.get(B).reveal()
+        await tick()
+
+        const o = h.get(A).outcome()
+        expect(o.state).toBe("closed")
+        expect(o.winner).toBe(B)
+        // C never committed, so it is simply not in the auction — not disqualified.
+        expect(o.disqualified).toEqual([])
+        expect(o.reveals).toHaveLength(2)
+    })
+})
+
+describe("SealedEnvelopeSession — protocol guards", () => {
+    it("rejects double commit, double reveal, and reveal-before-commit", async () => {
+        const h = harness([A, B])
+        await h.get(A).commit({ price: 90 })
+        await expect(h.get(A).commit({ price: 91 })).rejects.toThrow(/already committed/)
+
+        await h.get(B).commit({ price: 100 })
+        await tick()
+        await h.get(A).reveal()
+        await expect(h.get(A).reveal()).rejects.toThrow(/already revealed/)
+
+        const fresh = harness([A, B])
+        await fresh.get(B).commit({ price: 5 })
+        await tick()
+        await expect(fresh.get(A).reveal()).rejects.toThrow(/never committed|phase is commit/)
+    })
+
+    it("rejects a commit from a non-participant and a duplicate inbound commit", async () => {
+        const h = harness([A, B])
+        const outsider = h.raw(C, "sealed-envelope-commit", { commitment: "ab".repeat(32) })
+        expect(() => h.get(A).onIncoming(outsider)).toThrow(/non-participant/)
+
+        await h.get(B).commit({ price: 100 })
+        await tick()
+        const dupe = h.raw(B, "sealed-envelope-commit", { commitment: "cd".repeat(32) } as SealedCommitBody)
+        expect(() => h.get(A).onIncoming(dupe)).toThrow(/duplicate commit/)
+    })
+
+    it("rejects a commit that arrives after the commit phase closed", async () => {
+        const h = harness([A, B])
+        await h.get(A).commit({ price: 90 })
+        await h.get(B).commit({ price: 100 })
+        await tick()
+        expect(h.get(A).state).toBe("reveal")
+        const late = h.raw(B, "sealed-envelope-commit", { commitment: "ee".repeat(32) })
+        expect(() => h.get(A).onIncoming(late)).toThrow(/after commit phase closed/)
+    })
+})
+
+describe("SealedEnvelopeSession — abort", () => {
+    it("aborts terminally and refuses further transitions", async () => {
+        const h = harness([A, B])
+        await h.get(A).commit({ price: 90 })
+        await h.get(A).abort("changed my mind")
+        await tick()
+
+        expect(h.get(A).state).toBe("aborted")
+        expect(h.get(A).outcome().reason).toBe("changed my mind")
+        expect(h.get(B).state).toBe("aborted") // the abort propagated
+        await expect(h.get(A).commit({ price: 1 })).rejects.toThrow(/phase is aborted/)
+    })
+
+    it("construction rejects a me that is not among participants", () => {
+        expect(
+            () =>
+                new SealedEnvelopeSession({
+                    me: C,
+                    participants: [A, B],
+                    send: async () => ({}) as ChannelMessage,
+                }),
+        ).toThrow(/not a participant/)
+    })
+})


### PR DESCRIPTION
Closes the second SR-4 negotiation mode. RFQ shipped in #94/#99; the brief requires **two** patterns and this is the other one.

## Why

DACS-3 §8.4.3 needs `negotiate-sealed-envelope` — a sealed-bid exchange. The point is **fairness**: every bid is locked before any is opened, so no participant can peek at another's number and shade its own by a dollar. The L2PS channel already keeps traffic private from non-members (CH-2); the commitment keeps a bid private from the *other members* until reveal.

## What

`SealedEnvelopeSession` mirrors `RfqSession` — a pure protocol state machine over the existing channel layer (which already verifies signature, `sender ∈ members`, channelId, monotonic sequence). Two phases:

- **commit** — each participant broadcasts a hiding commitment and stashes the opening locally:
  ```ts
  commitment = sha256("dacs-sealed-envelope:v1:" || JCS({ bid, salt }))   // salt = 32 random bytes
  ```
  Auto-advances to reveal once **every** participant has committed, or `closeCommitPhase()` at a deadline (non-committers are simply out — never bid, not disqualified).
- **reveal** — each opens `{ bid, salt }`; the session recomputes the commitment and binds the revealer to exactly what it sealed.

**Fairness rule (channel-fatal):** a reveal arriving *before* the commit phase closes is rejected — otherwise a laggard could adapt its bid to a number it shouldn't yet see.

**Cheating is contained, not fatal:** a reveal whose bid doesn't reproduce its commitment, or a committer who never reveals, is **disqualified** and visible in the outcome — one bad actor can't sink an otherwise-valid auction. `close()` handles the reveal-phase deadline; `abort()` is terminal.

**Winner selection is impl-defined** via an optional `compareBids` comparator, exactly as RFQ leaves `terms` opaque.

## Tests — 13, single-file, run in-band

Happy path + winner; bids stay hidden until reveal (**structural** check — no bid/price/salt in the record, not a flaky substring on a random hash); early-reveal rejection; commitment-mismatch and no-show disqualification; both deadline paths; non-participant / duplicate / out-of-phase guards; abort propagation; `commitmentHex` determinism + hiding.

```
npx jest src/tests/l2ps/sealedEnvelope.test.ts --runInBand   → 13 passed
```
Pre-commit `bun run build` (full `tsc --skipLibCheck`) is green, so the whole SDK type-checks with the addition. Ran the file twice to confirm the salt-randomness flakiness is gone. (One flaky assertion caught in review — a random salt's hex can contain the bid digits — fixed to a structural check, the same class of bug as the earlier `758` one.)

## ⚠️ Spec caveat

**§8.4.3 of `DACS-3-NEGOTIATE.md` was not available in-repo** when this was written. The commit-then-reveal *mechanism* is unambiguous and implemented faithfully, but the exact **wire field names** (`commitment` / `bid` / `salt`) and the **domain string** (`dacs-sealed-envelope:v1:`) should be reconciled against §8.4.3 before this is treated as spec-final. Flagged in the module header too. If someone can point me at the spec section I'll align the schema in a follow-up.

## Scope

Session-layer only, matching the RFQ split. A `finalizeSealedEnvelope` (tie into transcript + encrypted anchor, like `finalizeRfq`) is the natural follow-up once the schema is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sealed-bid negotiation for two-phase commit and reveal workflows.
  * Added bid privacy until reveal, commitment verification, and protection against invalid or missing reveals.
  * Added configurable winner selection, session status tracking, closure, and abort handling.
  * Exposed sealed-envelope types and utilities for broader integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->