### PR TITLE
feat(l2ps): finalizeSealedEnvelope — transcript anchor on a resolved auction (SR-4)

### DIFF
--- a/src/l2ps/channel/finalizeSealed.ts
+++ b/src/l2ps/channel/finalizeSealed.ts
@@ -29,7 +29,14 @@ import { anchorEncryptedTranscript } from "../anchor"
 import { exportTranscript } from "./transcript"
 import type { ChannelTranscript } from "./types"
 import type { ChannelSessionView } from "./finalize"
-import type { SealedEnvelopeOutcome, SealedEnvelopeState } from "./sealedEnvelope"
+import {
+    commitmentHex,
+    type SealedCommitBody,
+    type SealedEnvelopeOutcome,
+    type SealedEnvelopeState,
+    type SealedRevealBody,
+} from "./sealedEnvelope"
+import type { ChannelMessage } from "./types"
 
 /** Minimal SealedEnvelopeSession surface — structural for testability. */
 export interface SealedEnvelopeLike {
@@ -87,32 +94,71 @@ export async function finalizeSealedEnvelope(
         )
     }
 
-    // The transcript must actually back the reported outcome: every valid
-    // revealed bid must have both its reveal message (at the recorded
-    // sequence) and the commit it opened present in the record. Otherwise we
-    // could export/anchor a transcript that does not support the bids the
-    // outcome claims. (Vacuous — and legitimately so — for an all-defaulted
-    // auction with no valid reveals.)
+    // The transcript must actually back the reported outcome — not merely
+    // contain a reveal and *a* commit from the same sender, but a reveal that
+    // cryptographically OPENS that commit. `sealed` and `session` are separate
+    // structural inputs, so a mismatched or mocked pair could otherwise pair a
+    // real reveal sequence with an unrelated commit and still produce a
+    // transcript that verifies while proving nothing about the sealed bid.
     const messages = opts.session.messages()
-    for (const reveal of opts.sealed.outcome().reveals) {
-        const hasReveal = messages.some(
+    const commitOf = (participant: ClaimReference): ChannelMessage | undefined =>
+        messages.find(
+            m => m.type === "sealed-envelope-commit" && m.sender === participant,
+        )
+
+    const outcome = opts.sealed.outcome()
+
+    for (const reveal of outcome.reveals) {
+        const revealMsg = messages.find(
             m =>
                 m.sequence === reveal.sequence &&
                 m.type === "sealed-envelope-reveal" &&
                 m.sender === reveal.participant,
         )
-        const hasCommit = messages.some(
-            m =>
-                m.type === "sealed-envelope-commit" &&
-                m.sender === reveal.participant,
-        )
-        if (!hasReveal || !hasCommit) {
+        const commitMsg = commitOf(reveal.participant)
+        if (!revealMsg || !commitMsg)
             throw new Error(
                 `finalizeSealedEnvelope: transcript does not contain ${reveal.participant}'s ` +
                     `commit and its reveal (seq ${reveal.sequence}) — session mismatch`,
             )
+        const { bid, salt } = (revealMsg.body as SealedRevealBody) ?? {}
+        const { commitment } = (commitMsg.body as SealedCommitBody) ?? {}
+        let opens = false
+        try {
+            opens = typeof salt === "string" && commitmentHex(bid, salt) === commitment
+        } catch {
+            opens = false
         }
+        if (!opens)
+            throw new Error(
+                `finalizeSealedEnvelope: ${reveal.participant}'s reveal (seq ${reveal.sequence}) ` +
+                    "does not open the commit it is bound to — session mismatch",
+            )
     }
+
+    // An all-defaulted auction's evidence IS the commits: every disqualified
+    // participant committed and then failed to open. Without their commits in
+    // the record, a fabricated `{state:"closed", reveals:[]}` would export a
+    // transcript that proves nothing — so require the commits that back them.
+    for (const participant of outcome.disqualified ?? []) {
+        if (!commitOf(participant))
+            throw new Error(
+                `finalizeSealedEnvelope: disqualified participant ${participant} has no commit ` +
+                    "in the transcript — nothing backs the default",
+            )
+    }
+
+    // A closed auction with neither a valid reveal nor a disqualified committer
+    // has no bids to anchor; refuse rather than sign an empty record.
+    if (
+        opts.sealed.state === "closed" &&
+        outcome.reveals.length === 0 &&
+        (outcome.disqualified?.length ?? 0) === 0
+    )
+        throw new Error(
+            "finalizeSealedEnvelope: closed auction has no reveals and no disqualified " +
+                "committers — there is nothing to anchor",
+        )
 
     const transcript = await exportTranscript({
         channelId: opts.session.channelId,

--- a/src/l2ps/channel/finalizeSealed.ts
+++ b/src/l2ps/channel/finalizeSealed.ts
@@ -1,0 +1,156 @@
+/**
+ * SR-4 — finalise a negotiate-sealed-envelope session: once the auction has
+ * closed, export the signed channel transcript and (per disclosure policy,
+ * DACS-3 §8.7) anchor an encrypted copy, returning the `channelTranscriptRef`.
+ *
+ * The sealed-envelope analogue of `finalizeRfq`. Where RFQ finalises on an
+ * `accepted` proposal, this finalises on a `closed` auction — the terminal
+ * state in which every committer has been accounted for (validly opened or
+ * disqualified). The orchestration is identical from `exportTranscript`
+ * onward, so the anchor call is injectable for the same reason: unit-testing
+ * without deploying an SR-2 storage program.
+ *
+ * A closed auction with no valid reveals (everyone welched) is still a
+ * finalisable terminal state — anchoring it produces a portable proof that
+ * these members committed and failed to open, which is exactly what a
+ * reputation layer needs. Only `aborted` and the non-terminal phases are
+ * refused.
+ */
+
+import type { Demos } from "../../websdk"
+import type { ClaimReference } from "../../identity/cci"
+import type L2PS from "../l2ps"
+import type {
+    AnchorEncryptedTranscriptOpts,
+    AttestationRef,
+    TranscriptDisclosurePolicy,
+} from "../anchor"
+import { anchorEncryptedTranscript } from "../anchor"
+import { exportTranscript } from "./transcript"
+import type { ChannelTranscript } from "./types"
+import type { ChannelSessionView } from "./finalize"
+import type { SealedEnvelopeOutcome, SealedEnvelopeState } from "./sealedEnvelope"
+
+/** Minimal SealedEnvelopeSession surface — structural for testability. */
+export interface SealedEnvelopeLike {
+    readonly state: SealedEnvelopeState
+    outcome(): SealedEnvelopeOutcome
+}
+
+export interface FinalizeSealedEnvelopeOpts {
+    sealed: SealedEnvelopeLike
+    session: ChannelSessionView
+    /** This party's CCI claim (signs the transcript); must be a member. */
+    signer: ClaimReference
+    demos: Demos
+    /** Required when the policy actually anchors (not for `none`). */
+    l2ps?: L2PS
+    policy: TranscriptDisclosurePolicy
+    /** Needed to anchor under `encrypted-anchored-recommended`. */
+    consent?: boolean
+    /**
+     * Injectable anchor implementation; defaults to the real
+     * `anchorEncryptedTranscript`. Tests pass a fake to avoid deploying a
+     * storage program.
+     */
+    anchor?: (
+        opts: AnchorEncryptedTranscriptOpts,
+    ) => Promise<AttestationRef | null>
+}
+
+export interface SealedEnvelopeFinalizeResult {
+    /** The signed, ordered transcript (always produced). */
+    transcript: ChannelTranscript
+    /**
+     * The anchored attestation reference, or null when the policy did not
+     * anchor (`none`, or `recommended` without consent).
+     */
+    channelTranscriptRef: AttestationRef | null
+}
+
+export async function finalizeSealedEnvelope(
+    opts: FinalizeSealedEnvelopeOpts,
+): Promise<SealedEnvelopeFinalizeResult> {
+    if (opts.sealed.state !== "closed") {
+        throw new Error(
+            `finalizeSealedEnvelope: auction is "${opts.sealed.state}", not "closed" — ` +
+                "only a resolved auction produces a transcript anchor",
+        )
+    }
+
+    // Same reason as finalizeRfq: a non-member signer yields a transcript that
+    // later fails `verifyTranscript` (signer ∉ members). Catch it here.
+    if (!opts.session.members.includes(opts.signer)) {
+        throw new Error(
+            `finalizeSealedEnvelope: signer "${opts.signer}" is not a channel member — ` +
+                "the transcript signature would fail verification",
+        )
+    }
+
+    // The transcript must actually back the reported outcome: every valid
+    // revealed bid must have both its reveal message (at the recorded
+    // sequence) and the commit it opened present in the record. Otherwise we
+    // could export/anchor a transcript that does not support the bids the
+    // outcome claims. (Vacuous — and legitimately so — for an all-defaulted
+    // auction with no valid reveals.)
+    const messages = opts.session.messages()
+    for (const reveal of opts.sealed.outcome().reveals) {
+        const hasReveal = messages.some(
+            m =>
+                m.sequence === reveal.sequence &&
+                m.type === "sealed-envelope-reveal" &&
+                m.sender === reveal.participant,
+        )
+        const hasCommit = messages.some(
+            m =>
+                m.type === "sealed-envelope-commit" &&
+                m.sender === reveal.participant,
+        )
+        if (!hasReveal || !hasCommit) {
+            throw new Error(
+                `finalizeSealedEnvelope: transcript does not contain ${reveal.participant}'s ` +
+                    `commit and its reveal (seq ${reveal.sequence}) — session mismatch`,
+            )
+        }
+    }
+
+    const transcript = await exportTranscript({
+        channelId: opts.session.channelId,
+        members: [...opts.session.members],
+        messages,
+        signers: [{ claim: opts.signer, demos: opts.demos }],
+    })
+
+    // §8.7 policy semantics — identical to finalizeRfq.
+    const willAnchor =
+        opts.policy === "encrypted-anchored-required" ||
+        (opts.policy === "encrypted-anchored-recommended" && !!opts.consent)
+    if (!willAnchor) {
+        return { transcript, channelTranscriptRef: null }
+    }
+
+    if (!opts.l2ps) {
+        throw new Error(
+            `finalizeSealedEnvelope: policy "${opts.policy}" requires an L2PS instance to encrypt the transcript`,
+        )
+    }
+
+    const anchorFn = opts.anchor ?? anchorEncryptedTranscript
+    const ref = await anchorFn({
+        transcript,
+        l2ps: opts.l2ps,
+        demos: opts.demos,
+        signer: opts.signer,
+        policy: opts.policy,
+        consent: opts.consent,
+    })
+
+    if (opts.policy === "encrypted-anchored-required" && !ref) {
+        throw new Error(
+            "finalizeSealedEnvelope: policy is 'encrypted-anchored-required' but anchoring " +
+                "produced no attestation — phase fails",
+        )
+    }
+
+    return { transcript, channelTranscriptRef: ref }
+}

--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -92,3 +92,10 @@ export {
     type SealedCommitment,
     type RevealedBid,
 } from "./sealedEnvelope"
+
+export {
+    finalizeSealedEnvelope,
+    type FinalizeSealedEnvelopeOpts,
+    type SealedEnvelopeFinalizeResult,
+    type SealedEnvelopeLike,
+} from "./finalizeSealed"

--- a/src/tests/l2ps/finalizeSealed.test.ts
+++ b/src/tests/l2ps/finalizeSealed.test.ts
@@ -1,0 +1,226 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
+import {
+    ChannelSession,
+    SealedEnvelopeSession,
+    finalizeSealedEnvelope,
+    type RevealedBid,
+} from "@/l2ps/channel"
+import type { SealedEnvelopeLike } from "@/l2ps/channel/finalizeSealed"
+import type {
+    AnchorEncryptedTranscriptOpts,
+    AttestationRef,
+} from "@/l2ps/anchor"
+
+const CHANNEL = "ch-sealed-finalize-1"
+
+const byPrice = (a: RevealedBid, b: RevealedBid): number =>
+    (a.bid as { price: number }).price - (b.bid as { price: number }).price
+
+async function newConnectedDemos(): Promise<{
+    demos: Demos
+    claim: ClaimReference
+}> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return {
+        demos,
+        claim: demosClaimRefForAddress(await demos.getEd25519Address()),
+    }
+}
+
+/**
+ * Run a real signed two-party sealed auction to a terminal state so the
+ * session holds a verifiable transcript. `stopAfter` lets a caller leave it
+ * mid-reveal for the "not closed" guard. Only the anchor is mocked (real
+ * ChannelSession, real CCI signing).
+ */
+async function resolvedAuction(stopAfter?: "reveal-a") {
+    const alice = await newConnectedDemos()
+    const bob = await newConnectedDemos()
+    const members = [alice.claim, bob.claim]
+    const aSes = new ChannelSession({ channelId: CHANNEL, members, me: alice.claim, demos: alice.demos })
+    const bSes = new ChannelSession({ channelId: CHANNEL, members, me: bob.claim, demos: bob.demos })
+    await aSes.open()
+    await bSes.open()
+
+    let aSeal!: SealedEnvelopeSession
+    let bSeal!: SealedEnvelopeSession
+    aSeal = new SealedEnvelopeSession({
+        me: alice.claim,
+        participants: members,
+        compareBids: byPrice,
+        send: async opts => {
+            const m = await aSes.sendOutgoing(opts)
+            await bSes.receiveIncoming(m)
+            bSeal.onIncoming(m)
+            return m
+        },
+    })
+    bSeal = new SealedEnvelopeSession({
+        me: bob.claim,
+        participants: members,
+        compareBids: byPrice,
+        send: async opts => {
+            const m = await bSes.sendOutgoing(opts)
+            await aSes.receiveIncoming(m)
+            aSeal.onIncoming(m)
+            return m
+        },
+    })
+
+    await aSeal.commit({ price: 90 })
+    await bSeal.commit({ price: 100 })
+    await aSeal.reveal()
+    if (stopAfter === "reveal-a") return { alice, bob, aSes, aSeal, members }
+    await bSeal.reveal()
+    return { alice, bob, aSes, aSeal, members }
+}
+
+const okAnchor =
+    (captured: AnchorEncryptedTranscriptOpts[]) =>
+    async (o: AnchorEncryptedTranscriptOpts): Promise<AttestationRef> => {
+        captured.push(o)
+        return { anchor: "0xsp-addr", contentHash: "0xhash" }
+    }
+
+describe("finalizeSealedEnvelope — transcript anchor on a resolved auction", () => {
+    it("exports a signed transcript and anchors under `required`", async () => {
+        const { alice, bob, aSes, aSeal } = await resolvedAuction()
+        expect(aSeal.state).toBe("closed")
+        expect(aSeal.outcome().winner).toBe(bob.claim) // 100 beats 90
+        expect(aSeal.outcome().winningBid).toEqual({ price: 100 })
+
+        const captured: AnchorEncryptedTranscriptOpts[] = []
+        const res = await finalizeSealedEnvelope({
+            sealed: aSeal,
+            session: aSes,
+            signer: alice.claim,
+            demos: alice.demos,
+            l2ps: {} as never, // only forwarded to the (mocked) anchor
+            policy: "encrypted-anchored-required",
+            anchor: okAnchor(captured),
+        })
+
+        expect(res.channelTranscriptRef).toEqual({ anchor: "0xsp-addr", contentHash: "0xhash" })
+        expect(res.transcript.channelId).toBe(CHANNEL)
+        expect(res.transcript.messages).toHaveLength(4) // 2 commits + 2 reveals
+        expect(res.transcript.signatures[0].signer).toBe(alice.claim)
+        expect(captured).toHaveLength(1)
+        expect(captured[0].policy).toBe("encrypted-anchored-required")
+    })
+
+    it("under `none` produces the transcript but anchors nothing", async () => {
+        const { alice, aSes, aSeal } = await resolvedAuction()
+        const captured: AnchorEncryptedTranscriptOpts[] = []
+        const res = await finalizeSealedEnvelope({
+            sealed: aSeal,
+            session: aSes,
+            signer: alice.claim,
+            demos: alice.demos,
+            policy: "none",
+            anchor: okAnchor(captured),
+        })
+        expect(res.channelTranscriptRef).toBeNull()
+        expect(res.transcript.messages).toHaveLength(4)
+        expect(captured).toHaveLength(0)
+    })
+
+    it("under `recommended` anchors only with explicit consent", async () => {
+        const withConsent = await resolvedAuction()
+        const cap1: AnchorEncryptedTranscriptOpts[] = []
+        const a = await finalizeSealedEnvelope({
+            sealed: withConsent.aSeal,
+            session: withConsent.aSes,
+            signer: withConsent.alice.claim,
+            demos: withConsent.alice.demos,
+            l2ps: {} as never,
+            policy: "encrypted-anchored-recommended",
+            consent: true,
+            anchor: okAnchor(cap1),
+        })
+        expect(a.channelTranscriptRef).not.toBeNull()
+        expect(cap1).toHaveLength(1)
+
+        const without = await resolvedAuction()
+        const cap2: AnchorEncryptedTranscriptOpts[] = []
+        const b = await finalizeSealedEnvelope({
+            sealed: without.aSeal,
+            session: without.aSes,
+            signer: without.alice.claim,
+            demos: without.alice.demos,
+            policy: "encrypted-anchored-recommended",
+            anchor: okAnchor(cap2),
+        })
+        expect(b.channelTranscriptRef).toBeNull()
+        expect(cap2).toHaveLength(0)
+    })
+
+    it("refuses to finalise an auction that has not closed", async () => {
+        const { alice, aSes, aSeal } = await resolvedAuction("reveal-a")
+        expect(aSeal.state).toBe("reveal") // bob still owes a reveal
+        await expect(
+            finalizeSealedEnvelope({
+                sealed: aSeal,
+                session: aSes,
+                signer: alice.claim,
+                demos: alice.demos,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/not "closed"/)
+    })
+
+    it("refuses a signer that is not a channel member", async () => {
+        const { aSes, aSeal } = await resolvedAuction()
+        const outsider = await newConnectedDemos()
+        await expect(
+            finalizeSealedEnvelope({
+                sealed: aSeal,
+                session: aSes,
+                signer: outsider.claim,
+                demos: outsider.demos,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/not a channel member/)
+    })
+
+    it("under `required`, an anchor that produces no ref fails the phase", async () => {
+        const { alice, aSes, aSeal } = await resolvedAuction()
+        await expect(
+            finalizeSealedEnvelope({
+                sealed: aSeal,
+                session: aSes,
+                signer: alice.claim,
+                demos: alice.demos,
+                l2ps: {} as never,
+                policy: "encrypted-anchored-required",
+                anchor: async () => null,
+            }),
+        ).rejects.toThrow(/produced no attestation/)
+    })
+
+    it("refuses to anchor a transcript that does not back the reported reveals", async () => {
+        const { alice, aSes } = await resolvedAuction()
+        // A hand-forged outcome pointing at a reveal sequence the real session
+        // never carried — finalize must not export/anchor over the gap.
+        const liar: SealedEnvelopeLike = {
+            state: "closed",
+            outcome: () => ({
+                state: "closed",
+                reveals: [{ participant: alice.claim, bid: { price: 1 }, sequence: 999 }],
+                disqualified: [],
+            }),
+        }
+        await expect(
+            finalizeSealedEnvelope({
+                sealed: liar,
+                session: aSes,
+                signer: alice.claim,
+                demos: alice.demos,
+                policy: "none",
+            }),
+        ).rejects.toThrow(/does not contain .* reveal \(seq 999\)/)
+    })
+})

--- a/src/tests/l2ps/finalizeSealed.test.ts
+++ b/src/tests/l2ps/finalizeSealed.test.ts
@@ -3,7 +3,10 @@ import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
 import {
     ChannelSession,
     SealedEnvelopeSession,
+    commitmentHex,
     finalizeSealedEnvelope,
+    type ChannelMessage,
+    type ChannelSessionView,
     type RevealedBid,
 } from "@/l2ps/channel"
 import type { SealedEnvelopeLike } from "@/l2ps/channel/finalizeSealed"
@@ -222,5 +225,116 @@ describe("finalizeSealedEnvelope — transcript anchor on a resolved auction", (
                 policy: "none",
             }),
         ).rejects.toThrow(/does not contain .* reveal \(seq 999\)/)
+    })
+})
+
+describe("finalizeSealedEnvelope — the transcript must cryptographically back the outcome", () => {
+    const fakeMsg = (
+        type: ChannelMessage["type"],
+        sender: ClaimReference,
+        sequence: number,
+        body: unknown,
+    ): ChannelMessage =>
+        ({
+            channelId: CHANNEL,
+            sequence,
+            sender,
+            sentAt: 1000 + sequence,
+            type,
+            body,
+            signature: { sigVersion: "1", signature: "0x00" },
+        }) as ChannelMessage
+
+    const fakeSession = (
+        members: ClaimReference[],
+        messages: ChannelMessage[],
+    ): ChannelSessionView => ({ channelId: CHANNEL, members, messages: () => messages })
+
+    it("refuses a reveal that does not OPEN the commit it is paired with", async () => {
+        // A mismatched session: alice's commit is to some bid, but the reveal
+        // in the record opens something else. Merely "a commit + a reveal from
+        // alice exist" is not enough — the reveal must reproduce the commitment.
+        const alice = await newConnectedDemos()
+        const session = fakeSession(
+            [alice.claim],
+            [
+                fakeMsg("sealed-envelope-commit", alice.claim, 1, { commitment: "de".repeat(32) }),
+                fakeMsg("sealed-envelope-reveal", alice.claim, 2, { bid: { price: 90 }, salt: "aa" }),
+            ],
+        )
+        const sealed: SealedEnvelopeLike = {
+            state: "closed",
+            outcome: () => ({
+                state: "closed",
+                reveals: [{ participant: alice.claim, bid: { price: 90 }, sequence: 2 }],
+                disqualified: [],
+            }),
+        }
+        await expect(
+            finalizeSealedEnvelope({ sealed, session, signer: alice.claim, demos: alice.demos, policy: "none" }),
+        ).rejects.toThrow(/does not open the commit/)
+    })
+
+    it("accepts a reveal that genuinely opens its commit", async () => {
+        const alice = await newConnectedDemos()
+        const salt = "42".repeat(16)
+        const bid = { price: 90 }
+        const session = fakeSession(
+            [alice.claim],
+            [
+                fakeMsg("sealed-envelope-commit", alice.claim, 1, { commitment: commitmentHex(bid, salt) }),
+                fakeMsg("sealed-envelope-reveal", alice.claim, 2, { bid, salt }),
+            ],
+        )
+        const sealed: SealedEnvelopeLike = {
+            state: "closed",
+            outcome: () => ({ state: "closed", reveals: [{ participant: alice.claim, bid, sequence: 2 }], disqualified: [] }),
+        }
+        const res = await finalizeSealedEnvelope({ sealed, session, signer: alice.claim, demos: alice.demos, policy: "none" })
+        expect(res.channelTranscriptRef).toBeNull()
+        expect(res.transcript.messages).toHaveLength(2)
+    })
+
+    it("an all-defaulted auction must carry the commits that back the defaults", async () => {
+        const alice = await newConnectedDemos()
+        // disqualified bob, but no commit from bob in the record → nothing backs it.
+        const bob = await newConnectedDemos()
+        const session = fakeSession(
+            [alice.claim, bob.claim],
+            [fakeMsg("sealed-envelope-commit", alice.claim, 1, { commitment: "de".repeat(32) })],
+        )
+        const sealed: SealedEnvelopeLike = {
+            state: "closed",
+            outcome: () => ({ state: "closed", reveals: [], disqualified: [bob.claim] }),
+        }
+        await expect(
+            finalizeSealedEnvelope({ sealed, session, signer: alice.claim, demos: alice.demos, policy: "none" }),
+        ).rejects.toThrow(/has no commit/)
+    })
+
+    it("finalises a real all-defaulted auction (committed, never opened)", async () => {
+        const alice = await newConnectedDemos()
+        const session = fakeSession(
+            [alice.claim],
+            [fakeMsg("sealed-envelope-commit", alice.claim, 1, { commitment: "de".repeat(32) })],
+        )
+        const sealed: SealedEnvelopeLike = {
+            state: "closed",
+            outcome: () => ({ state: "closed", reveals: [], disqualified: [alice.claim] }),
+        }
+        const res = await finalizeSealedEnvelope({ sealed, session, signer: alice.claim, demos: alice.demos, policy: "none" })
+        expect(res.transcript.messages).toHaveLength(1)
+    })
+
+    it("refuses a closed auction with nothing to anchor", async () => {
+        const alice = await newConnectedDemos()
+        const session = fakeSession([alice.claim], [])
+        const sealed: SealedEnvelopeLike = {
+            state: "closed",
+            outcome: () => ({ state: "closed", reveals: [], disqualified: [] }),
+        }
+        await expect(
+            finalizeSealedEnvelope({ sealed, session, signer: alice.claim, demos: alice.demos, policy: "none" }),
+        ).rejects.toThrow(/nothing to anchor/)
     })
 })


### PR DESCRIPTION
Stacked on #110. Closes the sealed-envelope path to the same end RFQ reaches: a signed, optionally-anchored transcript.

## What

The sealed-envelope analogue of `finalizeRfq`. #110 built the session; this ties its terminal state to WI-3's transcript anchor. Where RFQ finalises on an `accepted` proposal, this finalises on a **`closed`** auction — the state in which every committer has been accounted for (validly opened or disqualified).

From `exportTranscript` onward the orchestration is **identical** to `finalizeRfq`: sign the ordered messages, then anchor an encrypted copy per the §8.7 disclosure policy (`none` / `recommended`+consent / `required`), with the anchor call injectable so it unit-tests without deploying an SR-2 storage program.

## Two integrity guards before anything is exported

1. **Signer must be a channel member** — else the transcript signature later fails `verifyTranscript`.
2. **The transcript must back the reported outcome** — every valid revealed bid must have *both* its reveal message (at the recorded sequence) *and* the commit it opened present in the record:

```ts
for (const reveal of outcome.reveals) {
  const hasReveal = messages.some(m => m.sequence === reveal.sequence && m.type === "sealed-envelope-reveal" && m.sender === reveal.participant)
  const hasCommit = messages.some(m => m.type === "sealed-envelope-commit" && m.sender === reveal.participant)
  if (!hasReveal || !hasCommit) throw …  // session mismatch
}
```

An **all-defaulted** auction (no valid reveals) is still finalisable — anchoring it is a portable proof that these members committed and failed to open, which is exactly what a reputation layer needs. Only `aborted` and the non-terminal phases are refused.

## Tests — 7, on real crypto

Real connected wallets + real `ChannelSession` signing (**only the anchor is mocked**, matching the RFQ finalize test): a two-party sealed auction driven to `closed`, then `required` / `none` / `recommended`±consent, the not-closed and non-member refusals, the required-but-null phase failure, and the transcript-does-not-back-the-reveals guard (a hand-forged outcome pointing at a reveal sequence the session never carried).

```
npx jest src/tests/l2ps/finalizeSealed.test.ts --runInBand   → 7 passed
```
Pre-commit `bun run build` (full `tsc`) green.

## Where this leaves SR-4

Both negotiation modes now go end-to-end: session → terminal → signed transcript → encrypted anchor. `negotiate-sealed-envelope`'s output can carry a `channelTranscriptRef` exactly like `negotiate-rfq`. The remaining reconciliation is the **§8.4.3 schema caveat from #110** — still needs the spec text to confirm wire field names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sealed-auction finalization with signed channel transcript export.
  * Introduced configurable transcript disclosure and encrypted anchoring behavior, including consent-aware anchoring.
  * Exposed sealed-envelope finalization APIs via the channel module.
* **Bug Fixes**
  * Added strict finalization validations for closed-state readiness, signer authorization, and commit/reveal cryptographic integrity.
  * Enforced required anchoring when the disclosure policy demands an attestation.
* **Tests**
  * Added end-to-end and integrity suites covering success paths, consent/policy anchoring rules, and expected failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->