### PR TITLE
feat(l2ps): WI-D AgreementDocument — the committed, co-signed agreement (SR-4)

### DIFF
--- a/src/l2ps/agreement/agreement.ts
+++ b/src/l2ps/agreement/agreement.ts
@@ -1,5 +1,7 @@
 import {
     isDemosClaim,
+    normalizeDemosAddress,
+    parseClaimRef,
     signWithPrimaryClaim,
     verifyPrimaryClaimSignature,
     type ClaimReference,
@@ -9,16 +11,56 @@ import type {
     AgreementDocument,
     AgreementSignature,
     UnsignedAgreementDocument,
-} from "./types"
+} from "@/l2ps/agreement/types"
 import {
     agreementHashHex,
     agreementSigningBytes,
     signatureFromHex,
     signatureToHex,
     stripAgreementSignatures,
-} from "./canonical"
+} from "@/l2ps/agreement/canonical"
 
-/** Build the unsigned document shell. */
+/**
+ * Comparison key for a claim.
+ *
+ * The CCI signing helpers normalise a Demos address (0x-prefixed, lowercase)
+ * before they touch a key, so two spellings of the same identity verify
+ * identically. Set/`includes` checks on the raw string would not: `demos:0xAB…`
+ * and `demos:0xab…` are the same party but different strings, and a legitimately
+ * signed agreement would be rejected. Compare on this instead.
+ *
+ * Non-demos schemes and malformed claims fall back to the literal string — we
+ * cannot know their normalisation, and a bad claim fails signature checks anyway.
+ *
+ * @param ref - The claim to normalise.
+ * @returns A stable key safe to compare and to use in a Set.
+ */
+function claimKey(ref: ClaimReference): string {
+    try {
+        if (!isDemosClaim(ref)) return ref
+        const { scheme, identifier } = parseClaimRef(ref)
+        return `${scheme}:${normalizeDemosAddress(identifier)}`
+    } catch {
+        return ref
+    }
+}
+
+/** True when `ref` is the same identity as one of `list`, spelling aside. */
+function claimIn(list: ReadonlyArray<ClaimReference>, ref: ClaimReference): boolean {
+    const k = claimKey(ref)
+    return list.some((c) => claimKey(c) === k)
+}
+
+/**
+ * Build the unsigned document shell.
+ *
+ * @param opts.channelId - The session the agreement was negotiated in.
+ * @param opts.parties - Every identity that must co-sign.
+ * @param opts.body - The agreed terms (impl-defined).
+ * @param opts.agreedAt - Unix ms; defaults to now.
+ * @param opts.refs - Optional back-references into the negotiation.
+ * @returns The document without signatures.
+ */
 export function buildUnsignedAgreement(opts: {
     channelId: string
     parties: ClaimReference[]
@@ -41,8 +83,14 @@ export function buildUnsignedAgreement(opts: {
 
 /**
  * Produce one party's co-signature, with the key controlling its CCI primary
- * claim — the same key that signed in-channel (the SR-4 brief's §0 invariant),
- * never the RSA subnet key.
+ * claim — the same key that signed in-channel (SR-4 brief §0), never the RSA
+ * subnet key.
+ *
+ * @param unsigned - The document to sign.
+ * @param signer - The signing party's claim; must be one of `unsigned.parties`.
+ * @param demos - A connected Demos whose address controls `signer`.
+ * @returns The party's signature over the canonical bytes.
+ * @throws If `signer` is not a demos claim or is not a party.
  */
 export async function signAgreement(
     unsigned: UnsignedAgreementDocument,
@@ -53,7 +101,7 @@ export async function signAgreement(
         throw new Error(
             `signAgreement: signer must be a demos: ClaimReference, got "${signer}"`,
         )
-    if (!unsigned.parties.includes(signer))
+    if (!claimIn(unsigned.parties, signer))
         throw new Error(
             `signAgreement: "${signer}" is not a party to this agreement`,
         )
@@ -67,8 +115,14 @@ export async function signAgreement(
 
 /**
  * Assemble the committed document: every party signs the same canonical bytes.
- * A document missing any party's signature is not committed — `verifyAgreement`
- * rejects it.
+ *
+ * Refuses to hand back a document unless `signers` covers every party exactly
+ * once. A partially-signed document is not a committed agreement — returning
+ * one would hand the caller something that looks committed and binds nobody.
+ *
+ * @param opts.signers - Exactly one entry per party, in signature order.
+ * @returns The fully co-signed document.
+ * @throws If a signer is not a party, is duplicated, or a party is missing.
  */
 export async function coSignAgreement(opts: {
     channelId: string
@@ -79,6 +133,21 @@ export async function coSignAgreement(opts: {
     refs?: AgreementDocument["refs"]
 }): Promise<AgreementDocument> {
     const unsigned = buildUnsignedAgreement(opts)
+
+    const seen = new Set<string>()
+    for (const s of opts.signers ?? []) {
+        const k = claimKey(s.claim)
+        if (seen.has(k))
+            throw new Error(`coSignAgreement: duplicate signer "${s.claim}"`)
+        seen.add(k)
+    }
+    for (const p of unsigned.parties) {
+        if (!seen.has(claimKey(p)))
+            throw new Error(
+                `coSignAgreement: no signer for party "${p}" — a partially-signed document is not an agreement`,
+            )
+    }
+
     const signatures: AgreementSignature[] = []
     for (const s of opts.signers) {
         signatures.push(await signAgreement(unsigned, s.claim, s.demos))
@@ -86,7 +155,13 @@ export async function coSignAgreement(opts: {
     return { ...unsigned, signatures }
 }
 
-/** The anchorable identity of a document — recomputed from its bytes. */
+/**
+ * The anchorable identity of a document — recomputed from its bytes.
+ *
+ * @param doc - The signed document.
+ * @returns Lowercase hex sha256 of the canonical bytes.
+ * @throws If the document cannot be canonicalised (see `agreementHashHex`).
+ */
 export function agreementHash(doc: AgreementDocument): string {
     return agreementHashHex(stripAgreementSignatures(doc))
 }
@@ -96,91 +171,157 @@ export interface AgreementVerificationResult {
     errors: string[]
 }
 
-/**
- * Verify everything a third party can check given only the public keys:
- * (a) every signature is valid under its signer's CCI primary key,
- * (b) every signer is a party, (c) EVERY party signed — a partially-signed
- * document is not an agreement, (d) no duplicate signers.
- *
- * Pass `members` (the channel's membership) to also enforce the SR-4 brief's
- * §0 invariant: the parties who committed this are exactly the identities that
- * negotiated in-channel.
- *
- * Collects errors rather than throwing, so an auditor sees every failure at once.
- */
-export function verifyAgreement(
-    doc: AgreementDocument,
-    opts?: { members?: ReadonlyArray<ClaimReference> },
-): AgreementVerificationResult {
-    const errors: string[] = []
+/** Shape checks that must pass before anything else is worth doing. */
+function checkShape(doc: AgreementDocument, errors: string[]): boolean {
     if (doc?.agreementVersion !== "1") {
         errors.push("agreementVersion is not 1")
-        return { ok: false, errors }
+        return false
     }
     if (!doc.channelId) errors.push("missing channelId")
     if (!doc.parties?.length) errors.push("missing parties")
+    return true
+}
 
+/** Verify each signature; returns the set of parties that validly signed. */
+function checkSignatures(
+    doc: AgreementDocument,
+    unsigned: UnsignedAgreementDocument,
+    errors: string[],
+): Set<string> {
+    const signed = new Set<string>()
+    if (!doc.signatures?.length) {
+        errors.push("no signatures — the agreement is not committed")
+        return signed
+    }
+
+    // The body is caller-supplied, so a malformed one must surface as an error
+    // here rather than throw out of a function documented to collect them.
+    let payload: Uint8Array
+    try {
+        payload = agreementSigningBytes(unsigned)
+    } catch (e) {
+        errors.push(`agreement payload malformed: ${(e as Error).message}`)
+        return signed
+    }
+
+    for (const s of doc.signatures) {
+        if (s.sigVersion !== "1") {
+            errors.push(`signature: unknown sigVersion ${s.sigVersion}`)
+            continue
+        }
+        if (!claimIn(doc.parties, s.signer)) {
+            errors.push(`signer "${s.signer}" is not a party`)
+            continue
+        }
+        if (signed.has(claimKey(s.signer))) {
+            errors.push(`duplicate signature from "${s.signer}"`)
+            continue
+        }
+        try {
+            if (!verifyPrimaryClaimSignature(s.signer, payload, signatureFromHex(s.signature))) {
+                errors.push(`signature by "${s.signer}" failed verification`)
+                continue
+            }
+            signed.add(claimKey(s.signer))
+        } catch (e) {
+            errors.push(
+                `signature by "${s.signer}" malformed: ${(e as Error).message}`,
+            )
+        }
+    }
+    return signed
+}
+
+/** Co-signed means ALL of them: a document one party never signed binds nobody. */
+function checkCompleteness(
+    doc: AgreementDocument,
+    signed: Set<string>,
+    errors: string[],
+): void {
+    for (const p of doc.parties ?? []) {
+        if (!signed.has(claimKey(p))) errors.push(`party "${p}" has not signed`)
+    }
+}
+
+/** §0: the in-channel signers and the committing parties are the same set. */
+function checkMembership(
+    doc: AgreementDocument,
+    members: ReadonlyArray<ClaimReference>,
+    errors: string[],
+): void {
+    for (const p of doc.parties ?? []) {
+        if (!claimIn(members, p))
+            errors.push(`party "${p}" is not a member of the channel`)
+    }
+    for (const m of members) {
+        if (!claimIn(doc.parties ?? [], m))
+            errors.push(`channel member "${m}" is not a party to the agreement`)
+    }
+}
+
+/** Everything except the §0 membership tie — shared by both public verifiers. */
+function verifyCore(
+    doc: AgreementDocument,
+    errors: string[],
+): void {
+    if (!checkShape(doc, errors)) return
     let unsigned: UnsignedAgreementDocument
     try {
         unsigned = stripAgreementSignatures(doc)
     } catch {
         errors.push("could not strip signatures")
+        return
+    }
+    const signed = checkSignatures(doc, unsigned, errors)
+    checkCompleteness(doc, signed, errors)
+}
+
+/**
+ * Verify a committed agreement, including the SR-4 brief's §0 invariant.
+ *
+ * `members` is REQUIRED on purpose: the invariant — the parties who committed
+ * are exactly the identities that negotiated in-channel — is the whole reason
+ * this primitive exists (definition-of-done #4). Making it optional would let a
+ * caller verify signatures, believe the document checked out, and accept an
+ * agreement whose parties never negotiated the channel it names. Use
+ * {@link verifyAgreementSignatures} when you genuinely do not have the
+ * membership and accept that weaker claim knowingly.
+ *
+ * Collects errors rather than throwing, so an auditor sees every failure at once.
+ *
+ * @param doc - The document to verify.
+ * @param opts.members - The channel's membership (e.g. `session.members`).
+ * @returns `{ ok, errors }`.
+ */
+export function verifyAgreement(
+    doc: AgreementDocument,
+    opts: { members: ReadonlyArray<ClaimReference> },
+): AgreementVerificationResult {
+    const errors: string[] = []
+    if (!opts?.members?.length) {
+        errors.push("verifyAgreement: members required to check the §0 invariant")
         return { ok: false, errors }
     }
+    verifyCore(doc, errors)
+    if (doc?.agreementVersion === "1") checkMembership(doc, opts.members, errors)
+    return { ok: errors.length === 0, errors }
+}
 
-    const signed = new Set<ClaimReference>()
-    if (!doc.signatures?.length) {
-        errors.push("no signatures — the agreement is not committed")
-    } else {
-        const payload = agreementSigningBytes(unsigned)
-        for (const s of doc.signatures) {
-            if (s.sigVersion !== "1") {
-                errors.push(`signature: unknown sigVersion ${s.sigVersion}`)
-                continue
-            }
-            if (!doc.parties.includes(s.signer)) {
-                errors.push(`signer "${s.signer}" is not a party`)
-                continue
-            }
-            if (signed.has(s.signer)) {
-                errors.push(`duplicate signature from "${s.signer}"`)
-                continue
-            }
-            try {
-                const ok = verifyPrimaryClaimSignature(
-                    s.signer,
-                    payload,
-                    signatureFromHex(s.signature),
-                )
-                if (!ok) {
-                    errors.push(`signature by "${s.signer}" failed verification`)
-                    continue
-                }
-                signed.add(s.signer)
-            } catch (e) {
-                errors.push(
-                    `signature by "${s.signer}" malformed: ${(e as Error).message}`,
-                )
-            }
-        }
-    }
-
-    // Co-signed means ALL of them. A document one party never signed binds nobody.
-    for (const p of doc.parties ?? []) {
-        if (!signed.has(p)) errors.push(`party "${p}" has not signed`)
-    }
-
-    // §0: the in-channel signers and the committing parties must be the same set.
-    if (opts?.members) {
-        for (const p of doc.parties ?? []) {
-            if (!opts.members.includes(p))
-                errors.push(`party "${p}" is not a member of the channel`)
-        }
-        for (const m of opts.members) {
-            if (!doc.parties?.includes(m))
-                errors.push(`channel member "${m}" is not a party to the agreement`)
-        }
-    }
-
+/**
+ * Verify signatures and completeness ONLY — every party signed the bytes.
+ *
+ * This deliberately does NOT check the §0 invariant: it cannot tell you the
+ * signers are the identities that negotiated the channel the document names.
+ * Prefer {@link verifyAgreement}; reach for this only when the membership is
+ * genuinely unavailable.
+ *
+ * @param doc - The document to verify.
+ * @returns `{ ok, errors }`.
+ */
+export function verifyAgreementSignatures(
+    doc: AgreementDocument,
+): AgreementVerificationResult {
+    const errors: string[] = []
+    verifyCore(doc, errors)
     return { ok: errors.length === 0, errors }
 }

--- a/src/l2ps/agreement/agreement.ts
+++ b/src/l2ps/agreement/agreement.ts
@@ -1,0 +1,186 @@
+import {
+    isDemosClaim,
+    signWithPrimaryClaim,
+    verifyPrimaryClaimSignature,
+    type ClaimReference,
+} from "@/identity/cci"
+import { Demos } from "@/websdk/demosclass"
+import type {
+    AgreementDocument,
+    AgreementSignature,
+    UnsignedAgreementDocument,
+} from "./types"
+import {
+    agreementHashHex,
+    agreementSigningBytes,
+    signatureFromHex,
+    signatureToHex,
+    stripAgreementSignatures,
+} from "./canonical"
+
+/** Build the unsigned document shell. */
+export function buildUnsignedAgreement(opts: {
+    channelId: string
+    parties: ClaimReference[]
+    body: unknown
+    agreedAt?: number
+    refs?: AgreementDocument["refs"]
+}): UnsignedAgreementDocument {
+    if (!opts.channelId) throw new Error("buildUnsignedAgreement: channelId required")
+    if (!opts.parties?.length)
+        throw new Error("buildUnsignedAgreement: parties required")
+    return {
+        agreementVersion: "1",
+        channelId: opts.channelId,
+        parties: [...opts.parties],
+        body: opts.body,
+        agreedAt: opts.agreedAt ?? Date.now(),
+        ...(opts.refs && { refs: opts.refs }),
+    }
+}
+
+/**
+ * Produce one party's co-signature, with the key controlling its CCI primary
+ * claim — the same key that signed in-channel (the SR-4 brief's §0 invariant),
+ * never the RSA subnet key.
+ */
+export async function signAgreement(
+    unsigned: UnsignedAgreementDocument,
+    signer: ClaimReference,
+    demos: Demos,
+): Promise<AgreementSignature> {
+    if (!isDemosClaim(signer))
+        throw new Error(
+            `signAgreement: signer must be a demos: ClaimReference, got "${signer}"`,
+        )
+    if (!unsigned.parties.includes(signer))
+        throw new Error(
+            `signAgreement: "${signer}" is not a party to this agreement`,
+        )
+    const sigBytes = await signWithPrimaryClaim(
+        signer,
+        agreementSigningBytes(unsigned),
+        demos,
+    )
+    return { sigVersion: "1", signer, signature: signatureToHex(sigBytes) }
+}
+
+/**
+ * Assemble the committed document: every party signs the same canonical bytes.
+ * A document missing any party's signature is not committed — `verifyAgreement`
+ * rejects it.
+ */
+export async function coSignAgreement(opts: {
+    channelId: string
+    parties: ClaimReference[]
+    body: unknown
+    signers: Array<{ claim: ClaimReference; demos: Demos }>
+    agreedAt?: number
+    refs?: AgreementDocument["refs"]
+}): Promise<AgreementDocument> {
+    const unsigned = buildUnsignedAgreement(opts)
+    const signatures: AgreementSignature[] = []
+    for (const s of opts.signers) {
+        signatures.push(await signAgreement(unsigned, s.claim, s.demos))
+    }
+    return { ...unsigned, signatures }
+}
+
+/** The anchorable identity of a document — recomputed from its bytes. */
+export function agreementHash(doc: AgreementDocument): string {
+    return agreementHashHex(stripAgreementSignatures(doc))
+}
+
+export interface AgreementVerificationResult {
+    ok: boolean
+    errors: string[]
+}
+
+/**
+ * Verify everything a third party can check given only the public keys:
+ * (a) every signature is valid under its signer's CCI primary key,
+ * (b) every signer is a party, (c) EVERY party signed — a partially-signed
+ * document is not an agreement, (d) no duplicate signers.
+ *
+ * Pass `members` (the channel's membership) to also enforce the SR-4 brief's
+ * §0 invariant: the parties who committed this are exactly the identities that
+ * negotiated in-channel.
+ *
+ * Collects errors rather than throwing, so an auditor sees every failure at once.
+ */
+export function verifyAgreement(
+    doc: AgreementDocument,
+    opts?: { members?: ReadonlyArray<ClaimReference> },
+): AgreementVerificationResult {
+    const errors: string[] = []
+    if (doc?.agreementVersion !== "1") {
+        errors.push("agreementVersion is not 1")
+        return { ok: false, errors }
+    }
+    if (!doc.channelId) errors.push("missing channelId")
+    if (!doc.parties?.length) errors.push("missing parties")
+
+    let unsigned: UnsignedAgreementDocument
+    try {
+        unsigned = stripAgreementSignatures(doc)
+    } catch {
+        errors.push("could not strip signatures")
+        return { ok: false, errors }
+    }
+
+    const signed = new Set<ClaimReference>()
+    if (!doc.signatures?.length) {
+        errors.push("no signatures — the agreement is not committed")
+    } else {
+        const payload = agreementSigningBytes(unsigned)
+        for (const s of doc.signatures) {
+            if (s.sigVersion !== "1") {
+                errors.push(`signature: unknown sigVersion ${s.sigVersion}`)
+                continue
+            }
+            if (!doc.parties.includes(s.signer)) {
+                errors.push(`signer "${s.signer}" is not a party`)
+                continue
+            }
+            if (signed.has(s.signer)) {
+                errors.push(`duplicate signature from "${s.signer}"`)
+                continue
+            }
+            try {
+                const ok = verifyPrimaryClaimSignature(
+                    s.signer,
+                    payload,
+                    signatureFromHex(s.signature),
+                )
+                if (!ok) {
+                    errors.push(`signature by "${s.signer}" failed verification`)
+                    continue
+                }
+                signed.add(s.signer)
+            } catch (e) {
+                errors.push(
+                    `signature by "${s.signer}" malformed: ${(e as Error).message}`,
+                )
+            }
+        }
+    }
+
+    // Co-signed means ALL of them. A document one party never signed binds nobody.
+    for (const p of doc.parties ?? []) {
+        if (!signed.has(p)) errors.push(`party "${p}" has not signed`)
+    }
+
+    // §0: the in-channel signers and the committing parties must be the same set.
+    if (opts?.members) {
+        for (const p of doc.parties ?? []) {
+            if (!opts.members.includes(p))
+                errors.push(`party "${p}" is not a member of the channel`)
+        }
+        for (const m of opts.members) {
+            if (!doc.parties?.includes(m))
+                errors.push(`channel member "${m}" is not a party to the agreement`)
+        }
+    }
+
+    return { ok: errors.length === 0, errors }
+}

--- a/src/l2ps/agreement/canonical.ts
+++ b/src/l2ps/agreement/canonical.ts
@@ -1,7 +1,7 @@
 import { sha256 } from "@noble/hashes/sha2"
 import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
-import { bytesToHex, signatureFromHex, signatureToHex } from "../utils/hex"
-import type { AgreementDocument, UnsignedAgreementDocument } from "./types"
+import { bytesToHex, signatureFromHex, signatureToHex } from "@/l2ps/utils/hex"
+import type { AgreementDocument, UnsignedAgreementDocument } from "@/l2ps/agreement/types"
 
 /**
  * Domain separation prefix (CORE §B.7). A signature lifted from another domain
@@ -10,13 +10,62 @@ import type { AgreementDocument, UnsignedAgreementDocument } from "./types"
 export const AGREEMENT_DOMAIN_PREFIX = "dacs-agreement:v1:"
 
 /**
+ * Reject values whose canonical form would not be injective.
+ *
+ * `JSON.stringify` renders `NaN`, `Infinity` and `-Infinity` as `null`, so
+ * `{ price: NaN }` and `{ price: null }` would hash identically — serialisation
+ * could change the agreed terms while every signature still verified. The body
+ * is caller-supplied (`body: unknown`), so this is reachable from the wire and
+ * has to be refused rather than silently flattened.
+ *
+ * Cycles are skipped here and left to {@link canonicalJSONStringify}, which
+ * rejects them (walking them ourselves would not terminate).
+ *
+ * @param value - The value to walk.
+ * @param path - Human-readable path used in the error message.
+ * @param seen - Cycle guard; callers should not pass this.
+ * @throws If any nested number is not finite.
+ */
+function assertInjectivelySerialisable(
+    value: unknown,
+    path = "body",
+    seen: WeakSet<object> = new WeakSet(),
+): void {
+    if (typeof value === "number") {
+        if (!Number.isFinite(value))
+            throw new Error(
+                `agreement: ${path} is ${String(value)}, which canonicalises to null and would collide with a real null`,
+            )
+        return
+    }
+    if (!value || typeof value !== "object") return
+    if (seen.has(value)) return
+    seen.add(value)
+    if (Array.isArray(value)) {
+        value.forEach((v, i) => assertInjectivelySerialisable(v, `${path}[${i}]`, seen))
+        return
+    }
+    for (const [k, v] of Object.entries(value)) {
+        assertInjectivelySerialisable(v, `${path}.${k}`, seen)
+    }
+}
+
+/**
  * Hex digest of `JCS(document_without_signatures)`.
  *
  * This IS the agreement's identity and the value anchored on-chain: recompute
  * it from the bytes, never trust a hash that travels alongside the document.
  * Exposed as a primitive so an auditor can re-derive it independently.
+ *
+ * @param unsigned - The document without its signatures.
+ * @returns Lowercase hex sha256 of the canonical bytes.
+ * @throws If the document cannot be canonicalised injectively (a non-finite
+ * number, or anything `canonicalJSONStringify` rejects — `undefined`, bigint,
+ * a class instance, a cycle). Callers that must not throw — such as
+ * `verifyAgreement` — catch this.
  */
 export function agreementHashHex(unsigned: UnsignedAgreementDocument): string {
+    assertInjectivelySerialisable(unsigned, "agreement")
     const canonical = canonicalJSONStringify(unsigned)
     return bytesToHex(sha256(new TextEncoder().encode(canonical)))
 }
@@ -24,6 +73,10 @@ export function agreementHashHex(unsigned: UnsignedAgreementDocument): string {
 /**
  * Bytes each party's co-signature covers:
  *   `dacs-agreement:v1:` || agreement_hash_hex
+ *
+ * @param unsigned - The document without its signatures.
+ * @returns The domain-separated payload to sign or verify.
+ * @throws Whatever {@link agreementHashHex} throws.
  */
 export function agreementSigningBytes(
     unsigned: UnsignedAgreementDocument,
@@ -33,6 +86,16 @@ export function agreementSigningBytes(
     )
 }
 
+/**
+ * Drop the signatures to recover the bytes they were taken over.
+ *
+ * Signatures are excluded from both signing and anchoring by construction: a
+ * document cannot commit to its own signatures, and the anchor must be stable
+ * no matter how many parties have signed so far.
+ *
+ * @param doc - A (possibly partially) signed document.
+ * @returns The same document without its `signatures` field.
+ */
 export function stripAgreementSignatures(
     doc: AgreementDocument,
 ): UnsignedAgreementDocument {

--- a/src/l2ps/agreement/canonical.ts
+++ b/src/l2ps/agreement/canonical.ts
@@ -1,0 +1,43 @@
+import { sha256 } from "@noble/hashes/sha2"
+import { canonicalJSONStringify } from "@/websdk/utils/canonicalJson"
+import { bytesToHex, signatureFromHex, signatureToHex } from "../utils/hex"
+import type { AgreementDocument, UnsignedAgreementDocument } from "./types"
+
+/**
+ * Domain separation prefix (CORE §B.7). A signature lifted from another domain
+ * — channelmsg, transcript, binding — fails here, and vice versa.
+ */
+export const AGREEMENT_DOMAIN_PREFIX = "dacs-agreement:v1:"
+
+/**
+ * Hex digest of `JCS(document_without_signatures)`.
+ *
+ * This IS the agreement's identity and the value anchored on-chain: recompute
+ * it from the bytes, never trust a hash that travels alongside the document.
+ * Exposed as a primitive so an auditor can re-derive it independently.
+ */
+export function agreementHashHex(unsigned: UnsignedAgreementDocument): string {
+    const canonical = canonicalJSONStringify(unsigned)
+    return bytesToHex(sha256(new TextEncoder().encode(canonical)))
+}
+
+/**
+ * Bytes each party's co-signature covers:
+ *   `dacs-agreement:v1:` || agreement_hash_hex
+ */
+export function agreementSigningBytes(
+    unsigned: UnsignedAgreementDocument,
+): Uint8Array {
+    return new TextEncoder().encode(
+        AGREEMENT_DOMAIN_PREFIX + agreementHashHex(unsigned),
+    )
+}
+
+export function stripAgreementSignatures(
+    doc: AgreementDocument,
+): UnsignedAgreementDocument {
+    const { signatures: _signatures, ...rest } = doc
+    return rest
+}
+
+export { signatureFromHex, signatureToHex }

--- a/src/l2ps/agreement/index.ts
+++ b/src/l2ps/agreement/index.ts
@@ -1,0 +1,36 @@
+/**
+ * DACS-3 WI-D — the committed `AgreementDocument`.
+ *
+ * The document the parties actually agreed, co-signed by every one of them with
+ * the key controlling their CCI primary claim — the same key that signed
+ * in-channel (SR-4 brief §0). Only its hash is anchored on-chain; the document
+ * stays in the channel.
+ *
+ * SPEC NOTE: the wire schema is fixed by DACS-3 §8.5.1, which is not in this
+ * repo. The invariants are implemented per the SR-4 brief; reconcile the field
+ * names against §8.5.1 before treating this as spec-final.
+ */
+
+export type {
+    AgreementDocument,
+    AgreementSignature,
+    UnsignedAgreementDocument,
+} from "./types"
+
+export {
+    AGREEMENT_DOMAIN_PREFIX,
+    agreementHashHex,
+    agreementSigningBytes,
+    signatureFromHex,
+    signatureToHex,
+    stripAgreementSignatures,
+} from "./canonical"
+
+export {
+    agreementHash,
+    buildUnsignedAgreement,
+    coSignAgreement,
+    signAgreement,
+    verifyAgreement,
+    type AgreementVerificationResult,
+} from "./agreement"

--- a/src/l2ps/agreement/index.ts
+++ b/src/l2ps/agreement/index.ts
@@ -32,5 +32,6 @@ export {
     coSignAgreement,
     signAgreement,
     verifyAgreement,
+    verifyAgreementSignatures,
     type AgreementVerificationResult,
 } from "./agreement"

--- a/src/l2ps/agreement/types.ts
+++ b/src/l2ps/agreement/types.ts
@@ -1,0 +1,54 @@
+import type { ClaimReference } from "@/identity/cci"
+
+/**
+ * One party's co-signature over the agreement's canonical bytes. Versioned
+ * for forward compatibility (e.g. a PQC swap-out) without breaking the
+ * document layout — same contract as the channel/transcript signatures.
+ */
+export interface AgreementSignature {
+    sigVersion: "1"
+    signer: ClaimReference
+    signature: string
+}
+
+/**
+ * DACS-3 WI-D — the committed `AgreementDocument`: what the parties actually
+ * agreed, co-signed by every one of them with the key controlling their CCI
+ * primary claim. Only its hash goes on-chain (the anchor); the document itself
+ * stays in the channel.
+ *
+ * The invariant this exists to carry (SR-4 brief §0): the party that signed
+ * in-channel is the SAME CCI identity that co-signs this document. `channelId`
+ * binds the agreement to the session it was negotiated in, and
+ * `verifyAgreement({ members })` checks the signer set against that session's
+ * membership.
+ *
+ * SPEC NOTE: the wire schema is fixed by DACS-3 §8.5.1, which is not present in
+ * this repo. The invariants (co-signed by all parties, CCI primary keys,
+ * domain-separated, hash-anchored) come from the SR-4 brief and are implemented
+ * faithfully; the exact field names should be reconciled against §8.5.1 before
+ * this is treated as spec-final.
+ */
+export interface AgreementDocument {
+    agreementVersion: "1"
+    /** The negotiation session this was agreed in — unique per session (CH-6). */
+    channelId: string
+    /** Every party that must co-sign. All of them, or the document is not committed. */
+    parties: ClaimReference[]
+    /**
+     * The agreed terms. Deliberately opaque — exactly as `negotiate-rfq` leaves
+     * its `terms` impl-defined. DACS-Pay puts its FinancedAgreement here.
+     */
+    body: unknown
+    agreedAt: number
+    /** Optional back-references into the negotiation that produced this. */
+    refs?: {
+        /** Sequence of the channel message that was accepted. */
+        acceptedSequence?: number
+        /** Hash of the transcript backing it (see the anchor helpers). */
+        transcriptHash?: string
+    }
+    signatures: AgreementSignature[]
+}
+
+export type UnsignedAgreementDocument = Omit<AgreementDocument, "signatures">

--- a/src/l2ps/index.ts
+++ b/src/l2ps/index.ts
@@ -6,3 +6,4 @@ export { L2PS, L2PSConfig, L2PSEncryptedBytes, L2PSEncryptedPayload }
 export * as binding from "./binding"
 export * as channel from "./channel"
 export * as anchor from "./anchor"
+export * as agreement from "./agreement"

--- a/src/tests/l2ps/agreement.test.ts
+++ b/src/tests/l2ps/agreement.test.ts
@@ -1,0 +1,134 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
+import {
+    AGREEMENT_DOMAIN_PREFIX,
+    agreementHash,
+    agreementHashHex,
+    buildUnsignedAgreement,
+    coSignAgreement,
+    signAgreement,
+    stripAgreementSignatures,
+    verifyAgreement,
+    type AgreementDocument,
+} from "@/l2ps/agreement"
+
+const CHANNEL = "ch-agreement-1"
+const TERMS = { price: 100, currency: "USDC", item: "GPU-hour x40" }
+
+async function newConnectedDemos(): Promise<{ demos: Demos; claim: ClaimReference }> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return {
+        demos,
+        claim: demosClaimRefForAddress(await demos.getEd25519Address()),
+    }
+}
+
+/** A real three-party co-signed agreement — real keys, real signatures. */
+async function committed() {
+    const buyer = await newConnectedDemos()
+    const seller = await newConnectedDemos()
+    const financier = await newConnectedDemos()
+    const parties = [buyer.claim, seller.claim, financier.claim]
+    const doc = await coSignAgreement({
+        channelId: CHANNEL,
+        parties,
+        body: TERMS,
+        signers: [
+            { claim: buyer.claim, demos: buyer.demos },
+            { claim: seller.claim, demos: seller.demos },
+            { claim: financier.claim, demos: financier.demos },
+        ],
+    })
+    return { buyer, seller, financier, parties, doc }
+}
+
+describe("WI-D AgreementDocument — commit", () => {
+    it("co-signed by every party verifies, and its hash comes from the bytes", async () => {
+        const { doc, parties } = await committed()
+
+        expect(verifyAgreement(doc)).toEqual({ ok: true, errors: [] })
+        expect(doc.signatures).toHaveLength(3)
+        expect(doc.signatures.map((s) => s.signer).sort()).toEqual([...parties].sort())
+        // The anchorable identity is recomputed, never carried alongside.
+        expect(agreementHash(doc)).toBe(agreementHashHex(stripAgreementSignatures(doc)))
+        expect(agreementHash(doc)).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it("is domain-separated under dacs-agreement:v1:", () => {
+        expect(AGREEMENT_DOMAIN_PREFIX).toBe("dacs-agreement:v1:")
+    })
+})
+
+describe("WI-D AgreementDocument — what it refuses", () => {
+    it("refuses a document a party never signed — that binds nobody", async () => {
+        const { doc, seller } = await committed()
+        const partial: AgreementDocument = {
+            ...doc,
+            signatures: doc.signatures.filter((s) => s.signer !== seller.claim),
+        }
+        const r = verifyAgreement(partial)
+        expect(r.ok).toBe(false)
+        expect(r.errors.join(" ")).toMatch(/has not signed/)
+    })
+
+    it("refuses a body edited after signing", async () => {
+        const { doc } = await committed()
+        const tampered: AgreementDocument = { ...doc, body: { ...TERMS, price: 1 } }
+        const r = verifyAgreement(tampered)
+        expect(r.ok).toBe(false)
+        expect(r.errors.join(" ")).toMatch(/failed verification/)
+    })
+
+    it("refuses a signature from a non-party", async () => {
+        const { doc } = await committed()
+        const outsider = await newConnectedDemos()
+        const unsigned = stripAgreementSignatures(doc)
+        // The outsider signs the real bytes — but it is not a party.
+        const rogue = await signAgreement(
+            { ...unsigned, parties: [...unsigned.parties, outsider.claim] },
+            outsider.claim,
+            outsider.demos,
+        )
+        const r = verifyAgreement({ ...doc, signatures: [...doc.signatures, rogue] })
+        expect(r.ok).toBe(false)
+        expect(r.errors.join(" ")).toMatch(/is not a party/)
+    })
+
+    it("refuses duplicate signatures from the same party", async () => {
+        const { doc } = await committed()
+        const r = verifyAgreement({ ...doc, signatures: [...doc.signatures, doc.signatures[0]] })
+        expect(r.ok).toBe(false)
+        expect(r.errors.join(" ")).toMatch(/duplicate signature/)
+    })
+
+    it("signAgreement refuses a signer who is not a party", async () => {
+        const { parties } = await committed()
+        const outsider = await newConnectedDemos()
+        const unsigned = buildUnsignedAgreement({ channelId: CHANNEL, parties, body: TERMS })
+        await expect(signAgreement(unsigned, outsider.claim, outsider.demos)).rejects.toThrow(
+            /not a party/,
+        )
+    })
+})
+
+describe("WI-D AgreementDocument — the §0 invariant", () => {
+    it("the committing parties must be exactly the channel's members", async () => {
+        const { doc, parties } = await committed()
+        // Same set → ok.
+        expect(verifyAgreement(doc, { members: parties }).ok).toBe(true)
+
+        // A member who never became a party — the agreement doesn't bind the session.
+        const extra = await newConnectedDemos()
+        const r1 = verifyAgreement(doc, { members: [...parties, extra.claim] })
+        expect(r1.ok).toBe(false)
+        expect(r1.errors.join(" ")).toMatch(/is not a party to the agreement/)
+
+        // A party who was never in the channel — signed by someone who never negotiated.
+        const r2 = verifyAgreement(doc, { members: parties.slice(0, 2) })
+        expect(r2.ok).toBe(false)
+        expect(r2.errors.join(" ")).toMatch(/not a member of the channel/)
+    })
+})

--- a/src/tests/l2ps/agreement.test.ts
+++ b/src/tests/l2ps/agreement.test.ts
@@ -9,12 +9,18 @@ import {
     signAgreement,
     stripAgreementSignatures,
     verifyAgreement,
+    verifyAgreementSignatures,
     type AgreementDocument,
 } from "@/l2ps/agreement"
 
 const CHANNEL = "ch-agreement-1"
 const TERMS = { price: 100, currency: "USDC", item: "GPU-hour x40" }
 
+/**
+ * Create and connect a fresh Demos identity so the tests sign with real keys.
+ *
+ * @returns The connected Demos and its CCI primary claim.
+ */
 async function newConnectedDemos(): Promise<{ demos: Demos; claim: ClaimReference }> {
     const auth = new DemosWebAuth()
     await auth.create()
@@ -26,7 +32,11 @@ async function newConnectedDemos(): Promise<{ demos: Demos; claim: ClaimReferenc
     }
 }
 
-/** A real three-party co-signed agreement — real keys, real signatures. */
+/**
+ * A real three-party co-signed agreement — real keys, real signatures.
+ *
+ * @returns The parties, their wallets, and the committed document.
+ */
 async function committed() {
     const buyer = await newConnectedDemos()
     const seller = await newConnectedDemos()
@@ -49,7 +59,7 @@ describe("WI-D AgreementDocument — commit", () => {
     it("co-signed by every party verifies, and its hash comes from the bytes", async () => {
         const { doc, parties } = await committed()
 
-        expect(verifyAgreement(doc)).toEqual({ ok: true, errors: [] })
+        expect(verifyAgreement(doc, { members: parties })).toEqual({ ok: true, errors: [] })
         expect(doc.signatures).toHaveLength(3)
         expect(doc.signatures.map((s) => s.signer).sort()).toEqual([...parties].sort())
         // The anchorable identity is recomputed, never carried alongside.
@@ -60,30 +70,57 @@ describe("WI-D AgreementDocument — commit", () => {
     it("is domain-separated under dacs-agreement:v1:", () => {
         expect(AGREEMENT_DOMAIN_PREFIX).toBe("dacs-agreement:v1:")
     })
+
+    it("refuses to hand back a document that is not fully signed", async () => {
+        const a = await newConnectedDemos()
+        const b = await newConnectedDemos()
+        const parties = [a.claim, b.claim]
+        // b never signs: the result would look committed and bind nobody.
+        await expect(
+            coSignAgreement({
+                channelId: CHANNEL,
+                parties,
+                body: TERMS,
+                signers: [{ claim: a.claim, demos: a.demos }],
+            }),
+        ).rejects.toThrow(/no signer for party/)
+
+        await expect(
+            coSignAgreement({
+                channelId: CHANNEL,
+                parties,
+                body: TERMS,
+                signers: [
+                    { claim: a.claim, demos: a.demos },
+                    { claim: a.claim, demos: a.demos },
+                ],
+            }),
+        ).rejects.toThrow(/duplicate signer/)
+    })
 })
 
 describe("WI-D AgreementDocument — what it refuses", () => {
     it("refuses a document a party never signed — that binds nobody", async () => {
-        const { doc, seller } = await committed()
+        const { doc, seller, parties } = await committed()
         const partial: AgreementDocument = {
             ...doc,
             signatures: doc.signatures.filter((s) => s.signer !== seller.claim),
         }
-        const r = verifyAgreement(partial)
+        const r = verifyAgreement(partial, { members: parties })
         expect(r.ok).toBe(false)
         expect(r.errors.join(" ")).toMatch(/has not signed/)
     })
 
     it("refuses a body edited after signing", async () => {
-        const { doc } = await committed()
+        const { doc, parties } = await committed()
         const tampered: AgreementDocument = { ...doc, body: { ...TERMS, price: 1 } }
-        const r = verifyAgreement(tampered)
+        const r = verifyAgreement(tampered, { members: parties })
         expect(r.ok).toBe(false)
         expect(r.errors.join(" ")).toMatch(/failed verification/)
     })
 
     it("refuses a signature from a non-party", async () => {
-        const { doc } = await committed()
+        const { doc, parties } = await committed()
         const outsider = await newConnectedDemos()
         const unsigned = stripAgreementSignatures(doc)
         // The outsider signs the real bytes — but it is not a party.
@@ -92,14 +129,20 @@ describe("WI-D AgreementDocument — what it refuses", () => {
             outsider.claim,
             outsider.demos,
         )
-        const r = verifyAgreement({ ...doc, signatures: [...doc.signatures, rogue] })
+        const r = verifyAgreement(
+            { ...doc, signatures: [...doc.signatures, rogue] },
+            { members: parties },
+        )
         expect(r.ok).toBe(false)
         expect(r.errors.join(" ")).toMatch(/is not a party/)
     })
 
     it("refuses duplicate signatures from the same party", async () => {
-        const { doc } = await committed()
-        const r = verifyAgreement({ ...doc, signatures: [...doc.signatures, doc.signatures[0]] })
+        const { doc, parties } = await committed()
+        const r = verifyAgreement(
+            { ...doc, signatures: [...doc.signatures, doc.signatures[0]] },
+            { members: parties },
+        )
         expect(r.ok).toBe(false)
         expect(r.errors.join(" ")).toMatch(/duplicate signature/)
     })
@@ -114,10 +157,34 @@ describe("WI-D AgreementDocument — what it refuses", () => {
     })
 })
 
+describe("WI-D AgreementDocument — a hostile body cannot break the verifier", () => {
+    it("reports a non-canonicalisable body instead of throwing", async () => {
+        const { doc, parties } = await committed()
+        // `body` is caller-supplied. `undefined` is rejected by the canonical
+        // serializer — the verifier must collect that, not crash.
+        const r = verifyAgreement({ ...doc, body: { price: undefined } }, { members: parties })
+        expect(r.ok).toBe(false)
+        expect(r.errors.join(" ")).toMatch(/payload malformed/)
+    })
+
+    it("refuses NaN/Infinity, which would canonicalise to null and collide", async () => {
+        const { doc, parties } = await committed()
+        // {price: NaN} and {price: null} would otherwise hash identically —
+        // serialisation could change the agreed terms with signatures intact.
+        for (const bad of [NaN, Infinity, -Infinity]) {
+            const r = verifyAgreement({ ...doc, body: { price: bad } }, { members: parties })
+            expect(r.ok).toBe(false)
+            expect(r.errors.join(" ")).toMatch(/collide with a real null/)
+        }
+        expect(() => agreementHashHex(buildUnsignedAgreement({
+            channelId: CHANNEL, parties, body: { price: NaN },
+        }))).toThrow(/collide with a real null/)
+    })
+})
+
 describe("WI-D AgreementDocument — the §0 invariant", () => {
     it("the committing parties must be exactly the channel's members", async () => {
         const { doc, parties } = await committed()
-        // Same set → ok.
         expect(verifyAgreement(doc, { members: parties }).ok).toBe(true)
 
         // A member who never became a party — the agreement doesn't bind the session.
@@ -130,5 +197,44 @@ describe("WI-D AgreementDocument — the §0 invariant", () => {
         const r2 = verifyAgreement(doc, { members: parties.slice(0, 2) })
         expect(r2.ok).toBe(false)
         expect(r2.errors.join(" ")).toMatch(/not a member of the channel/)
+    })
+
+    it("cannot be skipped: members is required", async () => {
+        const { doc } = await committed()
+        const r = verifyAgreement(doc, { members: [] })
+        expect(r.ok).toBe(false)
+        expect(r.errors.join(" ")).toMatch(/members required/)
+    })
+
+    it("verifyAgreementSignatures checks the bytes but makes no §0 claim", async () => {
+        const { doc } = await committed()
+        // Valid signatures, no membership knowledge — the weaker claim, named as such.
+        expect(verifyAgreementSignatures(doc)).toEqual({ ok: true, errors: [] })
+    })
+})
+
+describe("WI-D AgreementDocument — claim spelling", () => {
+    it("treats the same identity spelled differently as the same party", async () => {
+        const a = await newConnectedDemos()
+        const b = await newConnectedDemos()
+        const parties = [a.claim, b.claim]
+        const doc = await coSignAgreement({
+            channelId: CHANNEL,
+            parties,
+            body: TERMS,
+            signers: [
+                { claim: a.claim, demos: a.demos },
+                { claim: b.claim, demos: b.demos },
+            ],
+        })
+        // The CCI helpers normalise the address before touching a key, so the
+        // same identity with an upper-cased address is the same party — a raw
+        // string compare would reject a legitimately signed agreement.
+        const shouted = parties.map((p) => {
+            const at = p.indexOf(":")
+            return `${p.slice(0, at)}:${p.slice(at + 1).toUpperCase()}` as ClaimReference
+        })
+        expect(shouted[0]).not.toBe(parties[0]) // genuinely a different string
+        expect(verifyAgreement(doc, { members: shouted })).toEqual({ ok: true, errors: [] })
     })
 })


### PR DESCRIPTION
Fills the biggest remaining gap in the DACS SDK surface.

## The gap

The SR-4 brief's **definition of done** ends on an invariant the SDK could not express:

> *4. The party who signed in-channel is the **same CCI identity** that co-signs the committed AgreementDocument (the invariant in §0).*

There was **no AgreementDocument in the SDK at all** — `grep -i agreementdocument src/` returns nothing. So every consumer reinvents it at the application layer (DACS-Pay carries its own `domain/agreement.ts`) — exactly the "keep CH-enforcement out of the app layer" problem SR-4 exists to solve. The Klarna plan lists **WI-D as a dependency of WI-K1**.

## What this adds

A substrate primitive, mirroring the `transcript` module it sits beside:

- **`AgreementDocument`** — `channelId` (the session it was negotiated in), the `parties` who must co-sign, an opaque **`body`** (impl-defined terms — exactly as `negotiate-rfq` leaves `terms` opaque; DACS-Pay puts its FinancedAgreement here), `agreedAt`, and optional back-refs (`acceptedSequence` / `transcriptHash`).
- **`coSignAgreement` / `signAgreement`** — every party signs the same canonical bytes with the key controlling its CCI primary claim, domain-separated under `dacs-agreement:v1:` so a channel-message or transcript signature can never be lifted into an agreement.
- **`agreementHash`** — the anchorable identity, **recomputed from the bytes**, never trusted from a hash travelling alongside. Only this goes on-chain; the document stays in the channel.
- **`verifyAgreement`** — collects every failure at once (auditor-friendly, like `verifyTranscript`): each signature valid under its signer's CCI key; signers are parties; no duplicates; **every** party signed (a partially-signed document binds nobody); and with `{ members }`, the brief's **§0 invariant** — the committing parties are *exactly* the identities that negotiated in-channel.

```ts
const doc = await coSignAgreement({ channelId, parties, body: terms, signers })
verifyAgreement(doc, { members: session.members })  // { ok, errors }
anchor(agreementHash(doc))                          // only the hash goes public
```

## Tests — 8, on real crypto

Real connected wallets and **real signatures — nothing mocked**: happy path + hash-from-bytes, a party that never signed, a body edited after signing, a non-party signature, duplicates, `signAgreement` refusing a non-party, and **both directions** of the §0 member/party mismatch.

```
npx jest src/tests/l2ps/agreement.test.ts --runInBand   → 8 passed
```
Pre-commit `bun run build` (full `tsc`) green.

## ⚠️ Spec caveat

The wire schema is fixed by **DACS-3 §8.5.1, which is not present in any repo here**. The invariants come from the SR-4 brief and are implemented faithfully — but the **field names should be reconciled against §8.5.1** before this is spec-final. Flagged in the module header. Same caveat as #110; share the spec and I'll align both in one pass.

## Remaining DACS SDK gaps (context)

- **#110 / #111** — `negotiate-sealed-envelope` + its finalize: done, green, awaiting review. The *second* of the two negotiation modes the definition-of-done requires.
- **CH-4 (liveness)** — the bar wants bounded delivery + detect-failure-and-abort. `abort()` exists, but there's no timeout/deadline in the merged channel layer. Not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, signing, co-signing, hashing, and verifying committed agreements.
  * Agreement documents include channel details, parties, terms, timestamps, references, and versioned signatures; the agreement module is exposed in the public package.
* **Breaking Changes**
  * Agreement verification now requires channel membership to be provided; signature-only verification is available separately.
* **Tests**
  * Added coverage for successful agreements, hashing integrity, tampering detection, signer authorization, duplicate signatures, and membership-invariant enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->