### PR TITLE
feat(l2ps): CH-4 liveness — bounded delivery a member can actually detect (SR-4)

### DIFF
--- a/src/l2ps/channel/index.ts
+++ b/src/l2ps/channel/index.ts
@@ -44,6 +44,14 @@ export {
 export { ChannelSession, type ChannelSessionOpts } from "./session"
 
 export {
+    checkLiveness,
+    DEFAULT_LIVENESS,
+    type CheckLivenessOpts,
+    type LivenessPolicy,
+    type LivenessState,
+} from "./liveness"
+
+export {
     buildUnsignedTranscript,
     exportTranscript,
     signTranscript,

--- a/src/l2ps/channel/liveness.ts
+++ b/src/l2ps/channel/liveness.ts
@@ -13,6 +13,12 @@
  *    (or hostile) counterparty could keep claiming it just spoke and look alive
  *    forever. Only what *this* member actually observed can bound delivery.
  *
+ * 3. **Timestamps must come from a MONOTONIC clock.** A wall clock steps
+ *    backwards (NTP, a manual correction), and a backwards step would push the
+ *    deadline out until real time caught up — the stall would go unnoticed for
+ *    exactly as long as the jump. `ChannelSession` defaults to a monotonic
+ *    source; if you call this directly, supply one too.
+ *
  * 2. **Pure, no timers.** This layer moves no bytes and owns no wall clock, the
  *    same way the session and the negotiation state machines don't. The caller
  *    asks "is it still alive?" — on a tick, before sending, or from its own
@@ -78,8 +84,26 @@ export function checkLiveness(opts: CheckLivenessOpts): LivenessState {
             `checkLiveness: sessionTimeoutMs must be a positive number, got ${policy.sessionTimeoutMs}`,
         )
 
+    // A NaN anywhere makes every >= comparison below false, which would report
+    // "alive" forever — a broken clock must fail loud, not silently disable the
+    // only thing bounding delivery.
+    for (const [name, t] of [
+        ["now", opts.now ?? Date.now()],
+        ["openedAt", opts.openedAt],
+        ["lastActivityAt", opts.lastActivityAt],
+    ] as const) {
+        if (!Number.isFinite(t))
+            throw new Error(
+                `checkLiveness: ${name} must be a finite timestamp, got ${String(t)}`,
+            )
+    }
+
     const now = opts.now ?? Date.now()
-    const msSinceLastActivity = now - opts.lastActivityAt
+    // Wall clocks step backwards (NTP, a manual correction). Left alone that
+    // pushes the deadline out until real time catches up — the stall would go
+    // unnoticed for exactly as long as the jump. Treat any backwards move as no
+    // progress at all rather than as fresh activity.
+    const msSinceLastActivity = Math.max(0, now - opts.lastActivityAt)
     const turnDeadlineAt = opts.lastActivityAt + policy.turnTimeoutMs
 
     // The session cap is absolute: a channel that keeps chattering past it is

--- a/src/l2ps/channel/liveness.ts
+++ b/src/l2ps/channel/liveness.ts
@@ -1,0 +1,118 @@
+/**
+ * CH-4 — liveness (DACS-3 §8.3.1).
+ *
+ * The conformance bar is "bounded delivery; members can detect failure and
+ * abort". A negotiation that simply goes quiet must not leave a member waiting
+ * forever: it has to be able to *notice* the stall and drive the session into a
+ * terminal state (CH-5) via `abort()`.
+ *
+ * Two deliberate choices:
+ *
+ * 1. **Measured against local observation time, never the peer's `sentAt`.**
+ *    `sentAt` is a field the sender fills in on its own envelope — a stalling
+ *    (or hostile) counterparty could keep claiming it just spoke and look alive
+ *    forever. Only what *this* member actually observed can bound delivery.
+ *
+ * 2. **Pure, no timers.** This layer moves no bytes and owns no wall clock, the
+ *    same way the session and the negotiation state machines don't. The caller
+ *    asks "is it still alive?" — on a tick, before sending, or from its own
+ *    watchdog — and decides whether to abort. That keeps it deterministic and
+ *    testable, and leaves the abort policy where it belongs: with the member.
+ */
+
+/** Bounds for a channel's delivery. */
+export interface LivenessPolicy {
+    /**
+     * Longest this member will tolerate seeing nothing at all on the channel
+     * before calling it stalled.
+     */
+    turnTimeoutMs: number
+    /** Optional hard cap on the whole session, measured from `open()`. */
+    sessionTimeoutMs?: number
+}
+
+export const DEFAULT_LIVENESS: LivenessPolicy = { turnTimeoutMs: 60_000 }
+
+export type LivenessState =
+    | {
+          status: "alive"
+          /** How long since this member last observed traffic. */
+          msSinceLastActivity: number
+          /** When it will flip to stalled if nothing else arrives. */
+          deadlineAt: number
+      }
+    | {
+          status: "stalled"
+          msSinceLastActivity: number
+          reason: "turn-timeout" | "session-timeout"
+          /** The deadline that was missed. */
+          deadlineAt: number
+      }
+
+export interface CheckLivenessOpts {
+    /** Local time the session opened. */
+    openedAt: number
+    /** Local time this member last sent or accepted a message. */
+    lastActivityAt: number
+    policy?: LivenessPolicy
+    now?: number
+}
+
+/**
+ * Decide whether a channel is still within its delivery bounds.
+ *
+ * Stalls are reported, never thrown: going quiet is an expected outcome of a
+ * negotiation, not a programming error — the member reacts by aborting.
+ */
+export function checkLiveness(opts: CheckLivenessOpts): LivenessState {
+    const policy = opts.policy ?? DEFAULT_LIVENESS
+    if (!Number.isFinite(policy.turnTimeoutMs) || policy.turnTimeoutMs <= 0)
+        throw new Error(
+            `checkLiveness: turnTimeoutMs must be a positive number, got ${policy.turnTimeoutMs}`,
+        )
+    if (
+        policy.sessionTimeoutMs !== undefined &&
+        (!Number.isFinite(policy.sessionTimeoutMs) || policy.sessionTimeoutMs <= 0)
+    )
+        throw new Error(
+            `checkLiveness: sessionTimeoutMs must be a positive number, got ${policy.sessionTimeoutMs}`,
+        )
+
+    const now = opts.now ?? Date.now()
+    const msSinceLastActivity = now - opts.lastActivityAt
+    const turnDeadlineAt = opts.lastActivityAt + policy.turnTimeoutMs
+
+    // The session cap is absolute: a channel that keeps chattering past it is
+    // still over, otherwise "bounded" would mean nothing.
+    if (policy.sessionTimeoutMs !== undefined) {
+        const sessionDeadlineAt = opts.openedAt + policy.sessionTimeoutMs
+        if (now >= sessionDeadlineAt)
+            return {
+                status: "stalled",
+                msSinceLastActivity,
+                reason: "session-timeout",
+                deadlineAt: sessionDeadlineAt,
+            }
+        if (now >= turnDeadlineAt)
+            return {
+                status: "stalled",
+                msSinceLastActivity,
+                reason: "turn-timeout",
+                deadlineAt: turnDeadlineAt,
+            }
+        return {
+            status: "alive",
+            msSinceLastActivity,
+            deadlineAt: Math.min(turnDeadlineAt, sessionDeadlineAt),
+        }
+    }
+
+    if (now >= turnDeadlineAt)
+        return {
+            status: "stalled",
+            msSinceLastActivity,
+            reason: "turn-timeout",
+            deadlineAt: turnDeadlineAt,
+        }
+    return { status: "alive", msSinceLastActivity, deadlineAt: turnDeadlineAt }
+}

--- a/src/l2ps/channel/session.ts
+++ b/src/l2ps/channel/session.ts
@@ -30,9 +30,26 @@ export interface ChannelSessionOpts {
     channelIdRegistry?: ChannelIdRegistry
     /**
      * Clock for CH-4 liveness. Injectable so delivery bounds are testable
-     * without waiting on wall time. Defaults to `Date.now`.
+     * without waiting on wall time.
+     *
+     * Defaults to a MONOTONIC source. A wall clock steps backwards (NTP, a
+     * manual correction) and a backwards step would push the deadline out until
+     * real time caught up — the stall would go unnoticed for exactly as long as
+     * the jump. Supply your own only if it is monotonic too.
      */
     now?: () => number
+}
+
+/**
+ * Monotonic milliseconds — never steps backwards, unlike `Date.now()`.
+ *
+ * @returns A monotonically non-decreasing timestamp in ms.
+ */
+function monotonicNow(): number {
+    return typeof performance !== "undefined" &&
+        typeof performance.now === "function"
+        ? performance.now()
+        : Date.now()
 }
 
 /**
@@ -78,7 +95,7 @@ export class ChannelSession {
         this.me = opts.me
         this.demos = opts.demos
         this.registry = opts.channelIdRegistry
-        this.clock = opts.now ?? (() => Date.now())
+        this.clock = opts.now ?? monotonicNow
     }
 
     /**

--- a/src/l2ps/channel/session.ts
+++ b/src/l2ps/channel/session.ts
@@ -11,6 +11,11 @@ import {
     verifyChannelMessage,
 } from "./envelope"
 import type { ChannelIdRegistry } from "./channelIdRegistry"
+import {
+    checkLiveness,
+    type LivenessPolicy,
+    type LivenessState,
+} from "./liveness"
 
 export interface ChannelSessionOpts {
     channelId: string
@@ -23,6 +28,11 @@ export interface ChannelSessionOpts {
      * channelId here and throws on reuse.
      */
     channelIdRegistry?: ChannelIdRegistry
+    /**
+     * Clock for CH-4 liveness. Injectable so delivery bounds are testable
+     * without waiting on wall time. Defaults to `Date.now`.
+     */
+    now?: () => number
 }
 
 /**
@@ -48,6 +58,11 @@ export class ChannelSession {
     private opened = false
     private highestSeen = 0
     private readonly transcript: ChannelMessage[] = []
+    private readonly clock: () => number
+    /** Local times — CH-4 is measured on what THIS member observed, never on
+     * a peer's self-reported `sentAt`. */
+    private openedAt = 0
+    private lastActivityAt = 0
 
     constructor(opts: ChannelSessionOpts) {
         if (!opts.channelId) throw new Error("ChannelSession: channelId required")
@@ -63,6 +78,7 @@ export class ChannelSession {
         this.me = opts.me
         this.demos = opts.demos
         this.registry = opts.channelIdRegistry
+        this.clock = opts.now ?? (() => Date.now())
     }
 
     /**
@@ -74,6 +90,24 @@ export class ChannelSession {
             throw new Error("ChannelSession: already opened")
         if (this.registry) await this.registry.register(this.channelId)
         this.opened = true
+        this.openedAt = this.clock()
+        this.lastActivityAt = this.openedAt
+    }
+
+    /**
+     * CH-4 — is the channel still within its delivery bounds, as observed by
+     * THIS member? Returns a state rather than throwing: a counterparty going
+     * quiet is an expected outcome, and the member reacts by aborting the
+     * negotiation (CH-5), which is a policy decision this layer doesn't make.
+     */
+    liveness(policy?: LivenessPolicy, now?: number): LivenessState {
+        this.assertOpened()
+        return checkLiveness({
+            openedAt: this.openedAt,
+            lastActivityAt: this.lastActivityAt,
+            policy,
+            now: now ?? this.clock(),
+        })
     }
 
     /**
@@ -107,6 +141,7 @@ export class ChannelSession {
         }
         const signed = await signChannelMessage(unsigned, this.demos)
         this.transcript.push(signed)
+        this.lastActivityAt = this.clock()
         return signed
     }
 
@@ -139,6 +174,7 @@ export class ChannelSession {
             )
         this.highestSeen = msg.sequence
         this.transcript.push(msg)
+        this.lastActivityAt = this.clock()
     }
 
     /** Read-only snapshot of all messages this session has signed or accepted. */

--- a/src/tests/l2ps/liveness.test.ts
+++ b/src/tests/l2ps/liveness.test.ts
@@ -1,0 +1,143 @@
+import { Demos, DemosWebAuth } from "@/websdk"
+import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
+import { ChannelSession, checkLiveness, DEFAULT_LIVENESS } from "@/l2ps/channel"
+
+const CHANNEL = "ch-liveness-1"
+
+async function newConnectedDemos(): Promise<{ demos: Demos; claim: ClaimReference }> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return { demos, claim: demosClaimRefForAddress(await demos.getEd25519Address()) }
+}
+
+describe("CH-4 checkLiveness — the pure bound", () => {
+    const base = { openedAt: 1_000, lastActivityAt: 1_000 }
+
+    it("is alive inside the turn bound and reports when it flips", () => {
+        const r = checkLiveness({ ...base, policy: { turnTimeoutMs: 100 }, now: 1_050 })
+        expect(r.status).toBe("alive")
+        expect(r.msSinceLastActivity).toBe(50)
+        expect(r.deadlineAt).toBe(1_100)
+    })
+
+    it("stalls exactly at the deadline, not a tick later", () => {
+        expect(checkLiveness({ ...base, policy: { turnTimeoutMs: 100 }, now: 1_099 }).status).toBe("alive")
+        const r = checkLiveness({ ...base, policy: { turnTimeoutMs: 100 }, now: 1_100 })
+        expect(r).toMatchObject({ status: "stalled", reason: "turn-timeout", deadlineAt: 1_100 })
+    })
+
+    it("honours an absolute session cap even while traffic keeps flowing", () => {
+        // Chatty but past the overall cap: still over, or "bounded" means nothing.
+        const r = checkLiveness({
+            openedAt: 1_000,
+            lastActivityAt: 5_990, // just spoke
+            policy: { turnTimeoutMs: 100, sessionTimeoutMs: 5_000 },
+            now: 6_000,
+        })
+        expect(r).toMatchObject({ status: "stalled", reason: "session-timeout", deadlineAt: 6_000 })
+    })
+
+    it("reports the nearer of the two deadlines while alive", () => {
+        const r = checkLiveness({
+            openedAt: 1_000,
+            lastActivityAt: 1_000,
+            policy: { turnTimeoutMs: 10_000, sessionTimeoutMs: 5_000 },
+            now: 1_100,
+        })
+        expect(r).toMatchObject({ status: "alive", deadlineAt: 6_000 }) // session cap is nearer
+    })
+
+    it("rejects a nonsensical policy", () => {
+        expect(() => checkLiveness({ ...base, policy: { turnTimeoutMs: 0 } })).toThrow(/positive number/)
+        expect(() => checkLiveness({ ...base, policy: { turnTimeoutMs: -1 } })).toThrow(/positive number/)
+        expect(() =>
+            checkLiveness({ ...base, policy: { turnTimeoutMs: 100, sessionTimeoutMs: 0 } }),
+        ).toThrow(/positive number/)
+        expect(DEFAULT_LIVENESS.turnTimeoutMs).toBeGreaterThan(0)
+    })
+})
+
+describe("CH-4 ChannelSession.liveness — detect the stall, then abort", () => {
+    async function session() {
+        let now = 1_000
+        const me = await newConnectedDemos()
+        const peer = await newConnectedDemos()
+        const members = [me.claim, peer.claim]
+        const mine = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: me.claim,
+            demos: me.demos,
+            now: () => now,
+        })
+        const theirs = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: peer.claim,
+            demos: peer.demos,
+            now: () => now,
+        })
+        await mine.open()
+        await theirs.open()
+        return { mine, theirs, tick: (ms: number) => (now += ms), at: () => now }
+    }
+
+    it("goes stalled once the counterparty falls quiet past the bound", async () => {
+        const { mine, tick } = await session()
+        expect(mine.liveness({ turnTimeoutMs: 100 }).status).toBe("alive")
+        tick(100)
+        expect(mine.liveness({ turnTimeoutMs: 100 })).toMatchObject({
+            status: "stalled",
+            reason: "turn-timeout",
+        })
+    })
+
+    it("traffic this member actually observed resets the bound", async () => {
+        const { mine, theirs, tick } = await session()
+        tick(90)
+        const offer = await mine.sendOutgoing({ type: "offer", body: { price: 100 } })
+        await theirs.receiveIncoming(offer) // keep the shared sequence in step
+        tick(90) // 180ms since open, but only 90 since we last spoke
+        expect(mine.liveness({ turnTimeoutMs: 100 }).status).toBe("alive")
+
+        // Receiving also counts as observed traffic.
+        const m = await theirs.sendOutgoing({ type: "counter", body: { price: 90 } })
+        await mine.receiveIncoming(m)
+        tick(99)
+        expect(mine.liveness({ turnTimeoutMs: 100 }).status).toBe("alive")
+        tick(1)
+        expect(mine.liveness({ turnTimeoutMs: 100 }).status).toBe("stalled")
+    })
+
+    it("a peer cannot look alive by inflating its own sentAt", async () => {
+        const { mine, theirs, tick, at } = await session()
+        // The peer claims it spoke far in the future — sentAt is a field it
+        // fills in itself. Only what we locally observed can bound delivery.
+        const m = await theirs.sendOutgoing({
+            type: "counter",
+            body: {},
+            sentAt: at() + 1_000_000,
+        })
+        await mine.receiveIncoming(m)
+        expect(m.sentAt).toBeGreaterThan(at()) // the lie is on the wire…
+
+        tick(100)
+        expect(mine.liveness({ turnTimeoutMs: 100 })).toMatchObject({
+            status: "stalled",
+            reason: "turn-timeout",
+        }) // …and it buys nothing
+    })
+
+    it("refuses to report liveness before the channel is open", async () => {
+        const me = await newConnectedDemos()
+        const s = new ChannelSession({
+            channelId: CHANNEL,
+            members: [me.claim],
+            me: me.claim,
+            demos: me.demos,
+        })
+        expect(() => s.liveness()).toThrow(/call open\(\)/)
+    })
+})

--- a/src/tests/l2ps/liveness.test.ts
+++ b/src/tests/l2ps/liveness.test.ts
@@ -49,6 +49,32 @@ describe("CH-4 checkLiveness — the pure bound", () => {
         expect(r).toMatchObject({ status: "alive", deadlineAt: 6_000 }) // session cap is nearer
     })
 
+    it("rejects a broken clock instead of silently never timing out", () => {
+        // A NaN makes every >= comparison false, i.e. "alive" forever — the one
+        // thing bounding delivery would quietly stop working.
+        for (const bad of [
+            { ...base, now: NaN },
+            { ...base, openedAt: NaN },
+            { ...base, lastActivityAt: NaN },
+        ]) {
+            expect(() => checkLiveness({ ...bad, policy: { turnTimeoutMs: 100 } })).toThrow(
+                /finite timestamp/,
+            )
+        }
+    })
+
+    it("a clock that steps backwards does not extend the deadline", () => {
+        // Defensive: with a monotonic clock this cannot happen, but a caller
+        // passing wall-clock times must not get "fresh activity" out of a jump.
+        const r = checkLiveness({
+            openedAt: 1_000,
+            lastActivityAt: 5_000,
+            policy: { turnTimeoutMs: 100 },
+            now: 4_000, // NTP stepped us back
+        })
+        expect(r.msSinceLastActivity).toBe(0)
+    })
+
     it("rejects a nonsensical policy", () => {
         expect(() => checkLiveness({ ...base, policy: { turnTimeoutMs: 0 } })).toThrow(/positive number/)
         expect(() => checkLiveness({ ...base, policy: { turnTimeoutMs: -1 } })).toThrow(/positive number/)


### PR DESCRIPTION
Closes the last unimplemented item on the CH-1..CH-6 conformance bar.

## The gap

> **CH-4 Liveness** — bounded delivery; members can detect failure and abort.

The channel layer had `abort()` but **nothing to tell a member it should abort**. A counterparty that simply went quiet left the other side waiting forever — so "bounded delivery" was aspirational. `grep -i 'timeout\|deadline\|liveness'` across the merged `channel/`, `binding/`, `anchor/` returned nothing.

## What this adds

`checkLiveness` (pure) + `ChannelSession.liveness()`.

Two decisions worth the review time:

**1. Measured on LOCAL observation time — never the peer's `sentAt`.**
`sentAt` is a field the sender fills in on *its own* envelope. Trusting it would let a stalling (or hostile) peer keep claiming it just spoke and look alive forever. Only what *this* member actually observed can bound delivery. There's a test pinning it:

```ts
// the peer claims it spoke ~17 minutes in the future…
const m = await theirs.sendOutgoing({ type: "counter", body: {}, sentAt: at() + 1_000_000 })
await mine.receiveIncoming(m)
tick(100)
expect(mine.liveness({ turnTimeoutMs: 100 })).toMatchObject({ status: "stalled" }) // …buys nothing
```

**2. Pure, no timers.** This layer moves no bytes and owns no wall clock — the same way the session and the negotiation state machines don't. The caller asks *"still alive?"* (on a tick, before sending, from its own watchdog) and decides whether to abort. The abort policy stays with the member; the bound stays deterministic. The session takes an injectable `now` for exactly that.

The policy is a per-turn bound plus an optional **absolute session cap** — and the cap applies *even while traffic keeps flowing*, otherwise "bounded" would mean nothing. Stalls are **reported, not thrown**: a negotiation going quiet is an expected outcome, not a programming error.

```ts
const s = mine.liveness({ turnTimeoutMs: 60_000, sessionTimeoutMs: 10 * 60_000 })
if (s.status === "stalled") await rfq.abort(`counterparty stalled (${s.reason})`)  // → CH-5
```

## Tests — 9, plus no regressions

The pure bound: alive/stalled, the exact-deadline edge (stalls *at* the deadline, not a tick later), the session cap beating a chatty channel, nearer-deadline reporting, policy validation. The session: stall on quiet, observed traffic resetting the bound, the inflated-`sentAt` defence, and refusing to report before `open()`.

Existing l2ps suites green after the `session.ts` change: **channel 31, finalize 9, transport 8, negotiate 11**. Pre-commit `bun run build` (full `tsc`) green.

## Where SR-4 stands now

With this, CH-1..CH-6 are all enforced in the substrate rather than the app layer — the roadmap item the brief was written for. Open alongside: **#110/#111** (sealed-envelope + finalize) and **#112** (WI-D AgreementDocument). Remaining external dependency: **DACS-3 §8.4.3 / §8.5.1 spec text** to confirm those two schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel liveness monitoring with configurable turn and session timeouts.
  * Sessions now report whether they are alive or stalled, including the relevant timeout reason and deadline.
  * Activity from sending and receiving messages refreshes the liveness window.
  * Added support for controlled time sources for reliable liveness evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->