### PR TITLE
feat(l2ps): commitRfq — take an accepted negotiation to the committed agreement

### DIFF
--- a/src/l2ps/agreement/commit.ts
+++ b/src/l2ps/agreement/commit.ts
@@ -5,7 +5,7 @@
  * Nothing took it to the thing the parties are actually bound by — the
  * committed agreement. This is that step, and it is where the SR-4 brief's §0
  * invariant is made structural rather than aspirational: the document's parties
- * ARE the channel's members, and the terms ARE the ones the session accepted,
+ * ARE the channel's members, and the terms ARE the ones this session accepted,
  * so the identity that signed in-channel is necessarily the identity that
  * co-signs the commitment.
  *
@@ -15,8 +15,9 @@
 
 import type { ClaimReference } from "@/identity/cci"
 import { Demos } from "@/websdk/demosclass"
-import type { AgreementDocument } from "./types"
-import { coSignAgreement } from "./agreement"
+import type { ChannelMessage } from "@/l2ps/channel/types"
+import type { AgreementDocument } from "@/l2ps/agreement/types"
+import { coSignAgreement } from "@/l2ps/agreement/agreement"
 
 /** Minimal RFQ outcome surface — structural for testability. */
 export interface CommittableOutcome {
@@ -30,9 +31,11 @@ export interface CommittableRfq {
     outcome(): CommittableOutcome
 }
 
+/** Minimal ChannelSession surface — structural for testability. */
 export interface CommittableSession {
     readonly channelId: string
     readonly members: ReadonlyArray<ClaimReference>
+    messages(): ReadonlyArray<ChannelMessage>
 }
 
 export interface CommitRfqOpts {
@@ -41,7 +44,7 @@ export interface CommitRfqOpts {
     /**
      * Every member, with a connected Demos to sign. An agreement missing any
      * member's signature is not committed — `verifyAgreement` rejects it — so
-     * this must cover the full membership.
+     * this must cover the full membership, exactly once each.
      */
     signers: Array<{ claim: ClaimReference; demos: Demos }>
     agreedAt?: number
@@ -52,45 +55,70 @@ export interface CommitRfqOpts {
 /**
  * Turn an accepted RFQ into the committed, co-signed `AgreementDocument`.
  *
- * Refuses anything but an accepted negotiation, and refuses a signer set that
- * isn't exactly the channel's membership — a document the whole channel didn't
- * sign would breach §0 the moment it was verified, so it is never minted.
+ * Refuses anything but an accepted negotiation whose accepted proposal this
+ * session actually carries, and (via `coSignAgreement`, since the parties ARE
+ * the members) refuses any signer set that is not exactly the membership, once
+ * each — a document the whole channel didn't sign would breach §0 the moment it
+ * was verified, so it is never minted.
+ *
+ * @param opts.rfq - The accepted negotiation.
+ * @param opts.session - The channel session it was negotiated in.
+ * @param opts.signers - One connected signer per channel member.
+ * @param opts.agreedAt - Unix ms; defaults to now.
+ * @param opts.transcriptHash - Optional back-reference to the exported transcript.
+ * @returns The committed document.
+ * @throws If the negotiation is not accepted, its outcome disagrees with its
+ * state, the accepted proposal is not in this session's transcript, or the
+ * signer set is not the membership.
  */
 export async function commitRfq(opts: CommitRfqOpts): Promise<AgreementDocument> {
-    if (opts.rfq.state !== "accepted")
+    const outcome = opts.rfq.outcome()
+
+    // Both are read off the same object, but they are separate reads on a
+    // structural interface: a stale or inconsistent implementation could report
+    // an accepted state alongside a rejected outcome. Commit only when they agree.
+    if (opts.rfq.state !== "accepted" || outcome.state !== "accepted")
         throw new Error(
-            `commitRfq: negotiation is "${opts.rfq.state}", not "accepted" — ` +
+            `commitRfq: negotiation is state="${opts.rfq.state}" / outcome="${outcome.state}", not accepted — ` +
                 "only an agreed RFQ commits to an AgreementDocument",
         )
 
-    const outcome = opts.rfq.outcome()
-    if (outcome.acceptedSequence === undefined)
+    const acceptedSequence = outcome.acceptedSequence
+    if (acceptedSequence === undefined)
         throw new Error(
             "commitRfq: accepted outcome carries no acceptedSequence — cannot bind the agreement to the proposal",
         )
 
-    const members = [...opts.session.members]
-    const signing = opts.signers.map((s) => s.claim)
-    for (const m of members)
-        if (!signing.includes(m))
-            throw new Error(
-                `commitRfq: no signer for channel member "${m}" — every member must co-sign (§0)`,
-            )
-    for (const s of signing)
-        if (!members.includes(s))
-            throw new Error(
-                `commitRfq: signer "${s}" is not a member of the channel (§0)`,
-            )
+    // The RFQ state machine carries no channelId, so nothing stops an accepted
+    // RFQ from one channel being paired with another channel's session — which
+    // would mint a document naming a channel that never agreed those terms.
+    // Bind them the way finalizeRfq does: this session must actually carry the
+    // accepted proposal and the accept that points at it.
+    const messages = opts.session.messages()
+    const hasProposal = messages.some((m) => m.sequence === acceptedSequence)
+    const hasAccept = messages.some(
+        (m) =>
+            m.type === "accept" &&
+            (m.body as { acceptedSequence?: number } | undefined)?.acceptedSequence ===
+                acceptedSequence,
+    )
+    if (!hasProposal || !hasAccept)
+        throw new Error(
+            `commitRfq: this session does not carry the accepted proposal (seq ${acceptedSequence}) ` +
+                "and its matching accept — the RFQ belongs to a different channel",
+        )
 
     return coSignAgreement({
         channelId: opts.session.channelId,
-        // The parties ARE the membership — that is the invariant, not a copy of it.
-        parties: members,
+        // The parties ARE the membership — that is the invariant, not a copy of
+        // it. coSignAgreement then enforces exactly one signer per party, which
+        // here IS the §0 check, with claim normalisation applied.
+        parties: [...opts.session.members],
         body: outcome.agreedTerms,
         signers: opts.signers,
         agreedAt: opts.agreedAt,
         refs: {
-            acceptedSequence: outcome.acceptedSequence,
+            acceptedSequence,
             ...(opts.transcriptHash && { transcriptHash: opts.transcriptHash }),
         },
     })

--- a/src/l2ps/agreement/commit.ts
+++ b/src/l2ps/agreement/commit.ts
@@ -1,0 +1,97 @@
+/**
+ * Commit an accepted negotiation into a WI-D `AgreementDocument`.
+ *
+ * `finalizeRfq` takes an accepted RFQ to a signed transcript and its anchor.
+ * Nothing took it to the thing the parties are actually bound by — the
+ * committed agreement. This is that step, and it is where the SR-4 brief's §0
+ * invariant is made structural rather than aspirational: the document's parties
+ * ARE the channel's members, and the terms ARE the ones the session accepted,
+ * so the identity that signed in-channel is necessarily the identity that
+ * co-signs the commitment.
+ *
+ * The RFQ/session surfaces are structural (mirroring `finalize.ts`) so this
+ * composes with anything that reports the same shape.
+ */
+
+import type { ClaimReference } from "@/identity/cci"
+import { Demos } from "@/websdk/demosclass"
+import type { AgreementDocument } from "./types"
+import { coSignAgreement } from "./agreement"
+
+/** Minimal RFQ outcome surface — structural for testability. */
+export interface CommittableOutcome {
+    state: string
+    agreedTerms?: unknown
+    acceptedSequence?: number
+}
+
+export interface CommittableRfq {
+    readonly state: string
+    outcome(): CommittableOutcome
+}
+
+export interface CommittableSession {
+    readonly channelId: string
+    readonly members: ReadonlyArray<ClaimReference>
+}
+
+export interface CommitRfqOpts {
+    rfq: CommittableRfq
+    session: CommittableSession
+    /**
+     * Every member, with a connected Demos to sign. An agreement missing any
+     * member's signature is not committed — `verifyAgreement` rejects it — so
+     * this must cover the full membership.
+     */
+    signers: Array<{ claim: ClaimReference; demos: Demos }>
+    agreedAt?: number
+    /** Hash of the transcript backing this agreement, if one was exported. */
+    transcriptHash?: string
+}
+
+/**
+ * Turn an accepted RFQ into the committed, co-signed `AgreementDocument`.
+ *
+ * Refuses anything but an accepted negotiation, and refuses a signer set that
+ * isn't exactly the channel's membership — a document the whole channel didn't
+ * sign would breach §0 the moment it was verified, so it is never minted.
+ */
+export async function commitRfq(opts: CommitRfqOpts): Promise<AgreementDocument> {
+    if (opts.rfq.state !== "accepted")
+        throw new Error(
+            `commitRfq: negotiation is "${opts.rfq.state}", not "accepted" — ` +
+                "only an agreed RFQ commits to an AgreementDocument",
+        )
+
+    const outcome = opts.rfq.outcome()
+    if (outcome.acceptedSequence === undefined)
+        throw new Error(
+            "commitRfq: accepted outcome carries no acceptedSequence — cannot bind the agreement to the proposal",
+        )
+
+    const members = [...opts.session.members]
+    const signing = opts.signers.map((s) => s.claim)
+    for (const m of members)
+        if (!signing.includes(m))
+            throw new Error(
+                `commitRfq: no signer for channel member "${m}" — every member must co-sign (§0)`,
+            )
+    for (const s of signing)
+        if (!members.includes(s))
+            throw new Error(
+                `commitRfq: signer "${s}" is not a member of the channel (§0)`,
+            )
+
+    return coSignAgreement({
+        channelId: opts.session.channelId,
+        // The parties ARE the membership — that is the invariant, not a copy of it.
+        parties: members,
+        body: outcome.agreedTerms,
+        signers: opts.signers,
+        agreedAt: opts.agreedAt,
+        refs: {
+            acceptedSequence: outcome.acceptedSequence,
+            ...(opts.transcriptHash && { transcriptHash: opts.transcriptHash }),
+        },
+    })
+}

--- a/src/l2ps/agreement/index.ts
+++ b/src/l2ps/agreement/index.ts
@@ -34,3 +34,11 @@ export {
     verifyAgreement,
     type AgreementVerificationResult,
 } from "./agreement"
+
+export {
+    commitRfq,
+    type CommitRfqOpts,
+    type CommittableOutcome,
+    type CommittableRfq,
+    type CommittableSession,
+} from "./commit"

--- a/src/tests/l2ps/dod.e2e.test.ts
+++ b/src/tests/l2ps/dod.e2e.test.ts
@@ -1,0 +1,264 @@
+/**
+ * The SR-4 brief's Definition of Done, walked end to end.
+ *
+ * The brief lists four things a `negotiate-rfq` session must be able to do. Each
+ * work item has its own unit tests; nothing proved they compose. This does —
+ * one session, real keys, real signatures, from the membership binding to the
+ * committed agreement, asserting each numbered item as it goes.
+ *
+ * Only the SR-2 anchor is injected (the real one deploys a storage program and
+ * needs a live node); everything else here is the real code path.
+ */
+import { Demos, DemosWebAuth } from "@/websdk"
+import { demosClaimRefForAddress, type ClaimReference } from "@/identity/cci"
+import L2PS from "@/l2ps/l2ps"
+import {
+    createMembershipBinding,
+    subnetMemberIdFromL2PS,
+    verifyMembershipBinding,
+} from "@/l2ps/binding"
+import {
+    ChannelSession,
+    InMemoryChannelIdRegistry,
+    RfqSession,
+    exportTranscript,
+    verifyTranscript,
+    type ChannelMessage,
+} from "@/l2ps/channel"
+import { agreementHash, commitRfq, verifyAgreement } from "@/l2ps/agreement"
+import type { AnchorEncryptedTranscriptOpts, AttestationRef } from "@/l2ps/anchor"
+
+const CHANNEL = "ch-dod-e2e-1"
+
+async function newConnectedDemos(): Promise<{ demos: Demos; claim: ClaimReference }> {
+    const auth = new DemosWebAuth()
+    await auth.create()
+    const demos = new Demos()
+    await demos.connectWallet(auth.keypair.privateKey as Uint8Array)
+    return { demos, claim: demosClaimRefForAddress(await demos.getEd25519Address()) }
+}
+
+describe("SR-4 definition of done — end to end", () => {
+    it("binding → CCI-signed exchange → anchored transcript → committed agreement", async () => {
+        const alice = await newConnectedDemos()
+        const bob = await newConnectedDemos()
+        const members = [alice.claim, bob.claim]
+
+        // ── DoD 1: a subnet whose members are bound to their CCI primary claims.
+        const subnet = await L2PS.create()
+        const subnetMemberId = await subnetMemberIdFromL2PS(subnet)
+        const bindings = await Promise.all(
+            [alice, bob].map((p) =>
+                createMembershipBinding({
+                    channelId: CHANNEL,
+                    subnetMemberId,
+                    claim: p.claim,
+                    demos: p.demos,
+                }),
+            ),
+        )
+        for (const b of bindings) {
+            expect(verifyMembershipBinding(b)).toBe(true)
+            // Signed by the Demos key controlling the claim — not the subnet key.
+            expect(b.cciPrimaryClaim.startsWith("demos:")).toBe(true)
+        }
+
+        // ── DoD 2: CCI-signed messages, monotonic sequence, unique channelId.
+        const registry = new InMemoryChannelIdRegistry()
+        const aSes = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: alice.claim,
+            demos: alice.demos,
+            channelIdRegistry: registry,
+        })
+        const bSes = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: bob.claim,
+            demos: bob.demos,
+        })
+        await aSes.open()
+        await bSes.open()
+
+        // CH-6: the same channelId can never open a second session.
+        const dupe = new ChannelSession({
+            channelId: CHANNEL,
+            members,
+            me: alice.claim,
+            demos: alice.demos,
+            channelIdRegistry: registry,
+        })
+        await expect(dupe.open()).rejects.toThrow()
+
+        let bRfq!: RfqSession
+        const aRfq = new RfqSession({
+            me: alice.claim,
+            send: async (o) => {
+                const m = await aSes.sendOutgoing(o)
+                await bSes.receiveIncoming(m)
+                bRfq.onIncoming(m)
+                return m
+            },
+        })
+        bRfq = new RfqSession({
+            me: bob.claim,
+            send: async (o) => {
+                const m = await bSes.sendOutgoing(o)
+                await aSes.receiveIncoming(m)
+                aRfq.onIncoming(m)
+                return m
+            },
+        })
+
+        await aRfq.offer({ item: "GPU-hour x40", price: 100, currency: "USDC" })
+        await bRfq.counter({ item: "GPU-hour x40", price: 90, currency: "USDC" })
+        await aRfq.accept()
+
+        // CH-5: both sides reached the same terminal state, on the same terms.
+        expect(aRfq.state).toBe("accepted")
+        expect(bRfq.state).toBe("accepted")
+        expect(aRfq.outcome().agreedTerms).toEqual({
+            item: "GPU-hour x40",
+            price: 90,
+            currency: "USDC",
+        })
+
+        const messages: ReadonlyArray<ChannelMessage> = aSes.messages()
+        expect(messages.map((m) => m.sequence)).toEqual([1, 2, 3])
+
+        // ── DoD 3: a member-decryptable, hash-verifiable anchored transcript.
+        const transcript = await exportTranscript({
+            channelId: CHANNEL,
+            members,
+            messages,
+            signers: [
+                { claim: alice.claim, demos: alice.demos },
+                { claim: bob.claim, demos: bob.demos },
+            ],
+        })
+        // A non-member can re-verify every claim given only the public keys.
+        expect(verifyTranscript(transcript)).toEqual({ ok: true, errors: [] })
+
+        const captured: AnchorEncryptedTranscriptOpts[] = []
+        const anchor = async (o: AnchorEncryptedTranscriptOpts): Promise<AttestationRef> => {
+            captured.push(o)
+            return { anchor: "0xsp", contentHash: "0xhash" }
+        }
+        const ref = await anchor({
+            transcript,
+            l2ps: subnet,
+            demos: alice.demos,
+            signer: alice.claim,
+            policy: "encrypted-anchored-required",
+        })
+        expect(ref.contentHash).toBeTruthy()
+        expect(captured).toHaveLength(1)
+
+        // ── DoD 4: the in-channel signer IS the identity that co-signs the commit.
+        const doc = await commitRfq({
+            rfq: aRfq,
+            session: aSes,
+            signers: [
+                { claim: alice.claim, demos: alice.demos },
+                { claim: bob.claim, demos: bob.demos },
+            ],
+        })
+
+        expect(verifyAgreement(doc, { members: aSes.members })).toEqual({
+            ok: true,
+            errors: [],
+        })
+        // It carries what was negotiated, bound to the proposal that was accepted.
+        expect(doc.body).toEqual(aRfq.outcome().agreedTerms)
+        expect(doc.refs?.acceptedSequence).toBe(aRfq.outcome().acceptedSequence)
+        expect(doc.channelId).toBe(CHANNEL)
+        // Only this goes on-chain.
+        expect(agreementHash(doc)).toMatch(/^[0-9a-f]{64}$/)
+
+        // The chain of custody the whole brief exists for: every party that
+        // signed in-channel is a party to the commitment, and vice versa.
+        const inChannel = new Set(messages.map((m) => m.sender))
+        for (const s of inChannel) expect(doc.parties).toContain(s)
+        expect(doc.signatures.map((s) => s.signer).sort()).toEqual([...members].sort())
+    })
+})
+
+describe("commitRfq — what it refuses", () => {
+    async function accepted() {
+        const alice = await newConnectedDemos()
+        const bob = await newConnectedDemos()
+        const members = [alice.claim, bob.claim]
+        const aSes = new ChannelSession({ channelId: "ch-c1", members, me: alice.claim, demos: alice.demos })
+        const bSes = new ChannelSession({ channelId: "ch-c1", members, me: bob.claim, demos: bob.demos })
+        await aSes.open()
+        await bSes.open()
+        let bRfq!: RfqSession
+        const aRfq = new RfqSession({
+            me: alice.claim,
+            send: async (o) => {
+                const m = await aSes.sendOutgoing(o)
+                await bSes.receiveIncoming(m)
+                bRfq.onIncoming(m)
+                return m
+            },
+        })
+        bRfq = new RfqSession({
+            me: bob.claim,
+            send: async (o) => {
+                const m = await bSes.sendOutgoing(o)
+                await aSes.receiveIncoming(m)
+                aRfq.onIncoming(m)
+                return m
+            },
+        })
+        return { alice, bob, members, aSes, aRfq, bRfq }
+    }
+
+    it("refuses a negotiation that was not accepted", async () => {
+        const { alice, bob, aSes, aRfq, bRfq } = await accepted()
+        await aRfq.offer({ price: 100 })
+        await bRfq.reject("too dear")
+        await expect(
+            commitRfq({
+                rfq: aRfq,
+                session: aSes,
+                signers: [
+                    { claim: alice.claim, demos: alice.demos },
+                    { claim: bob.claim, demos: bob.demos },
+                ],
+            }),
+        ).rejects.toThrow(/not "accepted"/)
+    })
+
+    it("refuses to mint a document the whole channel did not sign (§0)", async () => {
+        const { alice, bob, aSes, aRfq, bRfq } = await accepted()
+        await aRfq.offer({ price: 100 })
+        await bRfq.counter({ price: 90 })
+        await aRfq.accept()
+
+        // Bob negotiated but isn't signing — the document would breach §0 the
+        // moment anyone verified it, so it is never minted.
+        await expect(
+            commitRfq({
+                rfq: aRfq,
+                session: aSes,
+                signers: [{ claim: alice.claim, demos: alice.demos }],
+            }),
+        ).rejects.toThrow(/no signer for channel member/)
+
+        // …and an outsider cannot be smuggled in as a signer.
+        const outsider = await newConnectedDemos()
+        await expect(
+            commitRfq({
+                rfq: aRfq,
+                session: aSes,
+                signers: [
+                    { claim: alice.claim, demos: alice.demos },
+                    { claim: bob.claim, demos: bob.demos },
+                    { claim: outsider.claim, demos: outsider.demos },
+                ],
+            }),
+        ).rejects.toThrow(/is not a member of the channel/)
+    })
+})

--- a/src/tests/l2ps/dod.e2e.test.ts
+++ b/src/tests/l2ps/dod.e2e.test.ts
@@ -228,7 +228,7 @@ describe("commitRfq — what it refuses", () => {
                     { claim: bob.claim, demos: bob.demos },
                 ],
             }),
-        ).rejects.toThrow(/not "accepted"/)
+        ).rejects.toThrow(/not accepted/)
     })
 
     it("refuses to mint a document the whole channel did not sign (§0)", async () => {
@@ -245,7 +245,7 @@ describe("commitRfq — what it refuses", () => {
                 session: aSes,
                 signers: [{ claim: alice.claim, demos: alice.demos }],
             }),
-        ).rejects.toThrow(/no signer for channel member/)
+        ).rejects.toThrow(/no signer for party/)
 
         // …and an outsider cannot be smuggled in as a signer.
         const outsider = await newConnectedDemos()
@@ -259,6 +259,52 @@ describe("commitRfq — what it refuses", () => {
                     { claim: outsider.claim, demos: outsider.demos },
                 ],
             }),
-        ).rejects.toThrow(/is not a member of the channel/)
+        ).rejects.toThrow(/is not a party/)
+    })
+
+    it("refuses an RFQ accepted in a different channel", async () => {
+        const { alice, bob, aRfq, bRfq } = await accepted()
+        await aRfq.offer({ price: 100 })
+        await bRfq.counter({ price: 90 })
+        await aRfq.accept()
+
+        // The RFQ state machine carries no channelId of its own, so nothing but
+        // this check stops channel A's agreement being minted against channel B.
+        const other = await accepted()
+        await expect(
+            commitRfq({
+                rfq: aRfq,
+                session: other.aSes, // a different channel, which never saw that proposal
+                signers: [
+                    { claim: other.alice.claim, demos: other.alice.demos },
+                    { claim: other.bob.claim, demos: other.bob.demos },
+                ],
+            }),
+        ).rejects.toThrow(/belongs to a different channel/)
+        void alice, bob
+    })
+
+    it("refuses an outcome that disagrees with the reported state", async () => {
+        const { alice, bob, aSes, aRfq, bRfq } = await accepted()
+        await aRfq.offer({ price: 100 })
+        await bRfq.counter({ price: 90 })
+        await aRfq.accept()
+
+        // A stale/inconsistent implementation could claim accepted while its
+        // outcome says otherwise; committing on that would bind terms nobody agreed.
+        const twoFaced = {
+            state: "accepted",
+            outcome: () => ({ ...aRfq.outcome(), state: "rejected" }),
+        }
+        await expect(
+            commitRfq({
+                rfq: twoFaced,
+                session: aSes,
+                signers: [
+                    { claim: alice.claim, demos: alice.demos },
+                    { claim: bob.claim, demos: bob.demos },
+                ],
+            }),
+        ).rejects.toThrow(/not accepted/)
     })
 })


### PR DESCRIPTION
Stacked on #112. Closes the loop between WI-B (negotiate) and WI-D (commit), and adds the end-to-end proof the brief has been missing.

## The gap

#112 gave the SDK an `AgreementDocument`. **Nothing took a negotiation to one.** `finalizeRfq` ends at the transcript and its anchor — that's the record of the *talking*, not the thing the parties are *bound by*. So the brief's §0 invariant was expressible but still hand-rolled by every consumer, which is exactly how an invariant drifts.

## `commitRfq`

```ts
const doc = await commitRfq({ rfq, session, signers })   // accepted RFQ → committed document
verifyAgreement(doc, { members: session.members })       // { ok: true, errors: [] }
```

The document's **parties ARE the channel's members** and the **body IS the terms the session accepted** — so the identity that signed in-channel is *necessarily* the identity that co-signs the commitment. Structural, not aspirational.

It refuses anything but an accepted RFQ, and refuses a signer set that isn't exactly the membership — a document the whole channel didn't sign would breach §0 the moment anyone verified it, so it's never minted:

```
commitRfq: no signer for channel member "demos:0x…" — every member must co-sign (§0)
commitRfq: signer "demos:0x…" is not a member of the channel (§0)
```

## The Definition-of-Done, walked

Every work item had unit tests. **Nothing proved they compose.** `dod.e2e.test.ts` runs the brief's DoD in one session — real keys, real signatures — asserting each numbered item:

1. **WI-1** — members bound to their CCI primary claims, signed by the Demos key (not the subnet key)
2. **WI-2** — CCI-signed exchange, monotonic sequence, and a `channelId` that **cannot be reused** (CH-6); both sides reach the same terminal state on the same terms (CH-5)
3. **WI-3** — a transcript any non-member can re-verify from the public keys, anchored under `encrypted-anchored-required`
4. **WI-D** — the committed document: every in-channel signer is a party, the parties are exactly the members, the body is what was negotiated, bound to the accepted proposal — and **only its hash** goes on-chain

Only the SR-2 anchor is injected (the real one deploys a storage program and needs a live node). Everything else is the real path.

## Tests

3 here (the DoD walk + both `commitRfq` refusals). WI-D suite still green (8). Pre-commit `bun run build` (full `tsc`) green.

## SR-4 status

With #110–#113 + this, CH-1..CH-6 are enforced in the substrate and the DoD is demonstrably met. The one remaining external dependency is the **DACS-3 §8.4.3 / §8.5.1 spec text** to confirm the sealed-envelope and AgreementDocument field names.