### PR TITLE
feat(identity): resolveCciRecord — the full CCI record, not just the wallet key (DEM-773)

### DIFF
--- a/src/identity/cci/index.ts
+++ b/src/identity/cci/index.ts
@@ -1,8 +1,14 @@
 /**
- * Cross-Context Identity (CCI) — primary-claim binding for DACS-3 SR-4.
+ * Cross-Context Identity (CCI) — primary-claim binding for DACS-3 SR-4, and
+ * the full identity record behind it.
  *
- * Public surface used by L2PS membership binding (WI-1), ChannelMessage
- * envelope signing (WI-2), and encrypted-transcript anchoring (WI-3).
+ * Two layers:
+ * - the primary claim — who an account is on Demos, and the key that signs as
+ *   it. Used by L2PS membership binding (WI-1), ChannelMessage envelope signing
+ *   (WI-2), and encrypted-transcript anchoring (WI-3).
+ * - the record — every OTHER identity that account has proven control of
+ *   (other-chain wallets, Web2 accounts), expressed as claims. See
+ *   `resolveCciRecord`.
  *
  * Brief: `docs/l2ps-sr4-implementation-brief.md` in the node repo.
  */
@@ -21,3 +27,9 @@ export {
     signWithPrimaryClaim,
     verifyPrimaryClaimSignature,
 } from "./signing"
+
+export type { CciLink, CciLinkKind, CciRecord } from "./record"
+
+export { cciClaimFor, cciLinksFrom, cciSchemes } from "./record"
+
+export { resolveCciRecord } from "./resolve"

--- a/src/identity/cci/record.ts
+++ b/src/identity/cci/record.ts
@@ -1,0 +1,158 @@
+import type { AccountIdentities } from "@/types/gls/account"
+import type { ClaimReference, ClaimScheme } from "@/identity/cci/types"
+
+/**
+ * How a linked claim was established — the trust story behind it.
+ *
+ * - `xm` — another chain's wallet, linked by a signature from that wallet.
+ * - `web2` — a Web2 account, linked by a published proof.
+ * - `pqc` — a post-quantum co-signer for the same account.
+ */
+export type CciLinkKind = "xm" | "web2" | "pqc"
+
+/**
+ * One identity linked to a primary claim.
+ *
+ * `claim` is the whole point: a linked identity expressed in the same currency
+ * the rest of DACS speaks (`<scheme>:<identifier>`), so a caller can hand it
+ * straight to `parseClaimRef` or match it against a counterparty's claim
+ * instead of reaching into a chain-shaped blob.
+ */
+export interface CciLink {
+    /** The linked identity as a claim — e.g. `evm:0x…`, `twitter:someone`. */
+    claim: ClaimReference
+    kind: CciLinkKind
+    /** Sub-context within the kind: `evm` / `solana` for xm, `twitter` for web2. */
+    context: string
+    /** The raw entry the node returned, for anything this shape doesn't carry. */
+    raw: unknown
+}
+
+/**
+ * The full Cross-Context Identity record for an account: who it is on Demos,
+ * plus every other identity it has proven control of.
+ *
+ * Until now the SDK only ever exposed the primary claim — the wallet key — so
+ * consumers that needed "which Twitter/EVM identity is this agent?" had to
+ * reach past the SDK and reassemble it themselves. This is that record.
+ */
+export interface CciRecord {
+    /** The account's Demos claim — `demos:0x…`. */
+    primary: ClaimReference
+    /** The raw Demos address the record was fetched for. */
+    address: string
+    /** Every linked identity, flattened and expressed as claims. */
+    links: CciLink[]
+    /** The node's identities blob, unmodified. */
+    raw: AccountIdentities | Record<string, unknown>
+}
+
+/**
+ * Reading a chain-shaped identities blob is best-effort by nature: the node
+ * grows new identity kinds (ud, nomis, humanpassport, ethos, tlsn) faster than
+ * this type does, and a consumer asking "who is this agent" must not blow up
+ * because a kind it has never heard of appeared. Unknown shapes are skipped,
+ * and `raw` always carries the original.
+ */
+function isRecord(v: unknown): v is Record<string, unknown> {
+    return !!v && typeof v === "object" && !Array.isArray(v)
+}
+
+/** Flatten `xm.<chain>.<network>[]` into claims like `evm:0x…`. */
+function xmLinks(xm: unknown): CciLink[] {
+    if (!isRecord(xm)) return []
+    const out: CciLink[] = []
+    for (const [chain, networks] of Object.entries(xm)) {
+        if (!isRecord(networks)) continue
+        for (const entries of Object.values(networks)) {
+            if (!Array.isArray(entries)) continue
+            for (const e of entries) {
+                const address = isRecord(e) ? e.address : undefined
+                if (typeof address !== "string" || !address) continue
+                out.push({
+                    claim: `${chain}:${address}` as ClaimReference,
+                    kind: "xm",
+                    context: chain,
+                    raw: e,
+                })
+            }
+        }
+    }
+    return out
+}
+
+/** Flatten `web2.<platform>[]` into claims like `twitter:someone`. */
+function web2Links(web2: unknown): CciLink[] {
+    if (!isRecord(web2)) return []
+    const out: CciLink[] = []
+    for (const [platform, entries] of Object.entries(web2)) {
+        if (!Array.isArray(entries)) continue
+        for (const e of entries) {
+            if (!isRecord(e)) continue
+            // Prefer the human handle; fall back to the stable id.
+            const handle = e.username ?? e.userId ?? e.id
+            if (typeof handle !== "string" || !handle) continue
+            out.push({
+                claim: `${platform}:${handle}` as ClaimReference,
+                kind: "web2",
+                context: platform,
+                raw: e,
+            })
+        }
+    }
+    return out
+}
+
+/**
+ * Turn the node's identities blob into the flattened link list.
+ *
+ * Exported separately from the fetch so an indexer that already has the blob
+ * (or a test) can get claims out of it without an RPC round-trip.
+ *
+ * @param identities - The `identities` object as returned by the node.
+ * @returns Every linked identity it could express as a claim.
+ */
+export function cciLinksFrom(identities: unknown): CciLink[] {
+    if (!isRecord(identities)) return []
+    const links = [...xmLinks(identities.xm), ...web2Links(identities.web2)]
+
+    // pqc is a co-signer for the same account rather than a separate identity,
+    // so it is reported keyed by algorithm rather than as an address.
+    if (isRecord(identities.pqc)) {
+        for (const [algorithm, value] of Object.entries(identities.pqc)) {
+            const key =
+                typeof value === "string"
+                    ? value
+                    : isRecord(value) && typeof value.publicKey === "string"
+                      ? value.publicKey
+                      : undefined
+            if (!key) continue
+            links.push({
+                claim: `${algorithm}:${key}` as ClaimReference,
+                kind: "pqc",
+                context: algorithm,
+                raw: value,
+            })
+        }
+    }
+    return links
+}
+
+/** Every distinct scheme present in a record — handy for a quick capability check. */
+export function cciSchemes(record: CciRecord): ClaimScheme[] {
+    return [...new Set(record.links.map((l) => l.claim.slice(0, l.claim.indexOf(":"))))]
+}
+
+/**
+ * Find the account's claim on a given scheme, if it has proven one.
+ *
+ * @param record - The CCI record.
+ * @param scheme - e.g. `"evm"`, `"twitter"`.
+ * @returns The first matching claim, or undefined.
+ */
+export function cciClaimFor(
+    record: CciRecord,
+    scheme: string,
+): ClaimReference | undefined {
+    return record.links.find((l) => l.context === scheme)?.claim
+}

--- a/src/identity/cci/record.ts
+++ b/src/identity/cci/record.ts
@@ -58,6 +58,24 @@ function isRecord(v: unknown): v is Record<string, unknown> {
     return !!v && typeof v === "object" && !Array.isArray(v)
 }
 
+/**
+ * Normalise an address for use inside a claim.
+ *
+ * Hex (`0x…`) addresses are case-insensitive — EVM checksum casing is a display
+ * convention — so the node can hand back either spelling for the same wallet,
+ * and a raw compare would call them different identities. Lowercase those.
+ *
+ * Everything else is left verbatim on purpose: base58 chains (Solana) are
+ * case-SENSITIVE, and lowercasing one would corrupt the address into a
+ * different (or invalid) account.
+ *
+ * @param address - The address as the node stored it.
+ * @returns A stable spelling safe to compare.
+ */
+function normalizeLinkAddress(address: string): string {
+    return /^0x[0-9a-fA-F]+$/.test(address) ? address.toLowerCase() : address
+}
+
 /** Flatten `xm.<chain>.<network>[]` into claims like `evm:0x…`. */
 function xmLinks(xm: unknown): CciLink[] {
     if (!isRecord(xm)) return []
@@ -70,7 +88,7 @@ function xmLinks(xm: unknown): CciLink[] {
                 const address = isRecord(e) ? e.address : undefined
                 if (typeof address !== "string" || !address) continue
                 out.push({
-                    claim: `${chain}:${address}` as ClaimReference,
+                    claim: `${chain}:${normalizeLinkAddress(address)}` as ClaimReference,
                     kind: "xm",
                     context: chain,
                     raw: e,

--- a/src/identity/cci/resolve.ts
+++ b/src/identity/cci/resolve.ts
@@ -1,0 +1,99 @@
+import { Identities } from "@/abstraction/Identities"
+import { Demos } from "@/websdk/demosclass"
+import type { AccountIdentities } from "@/types/gls/account"
+import {
+    demosAddressFromClaim,
+    demosClaimRefForAddress,
+    isDemosClaim,
+    normalizeDemosAddress,
+} from "@/identity/cci/claim"
+import { cciLinksFrom, type CciRecord } from "@/identity/cci/record"
+import type { ClaimReference } from "@/identity/cci/types"
+
+const identities = new Identities()
+
+/**
+ * Fetch the full CCI record for an account: its Demos claim plus every identity
+ * it has proven control of.
+ *
+ * This is the seam DACS was missing. `signWithPrimaryClaim` and friends only
+ * ever knew an account as its wallet key, so a consumer that needed the agent's
+ * linked Web2/other-chain identities had to go around the SDK and reassemble
+ * the record itself. Now the whole identity comes back in one call, with the
+ * links expressed as `ClaimReference`s — the same currency the rest of DACS
+ * speaks.
+ *
+ * Identities are public data: no wallet is needed to read someone else's record,
+ * which is what lets an indexer or a verifier resolve a counterparty. Omit
+ * `subject` to read the connected wallet's own.
+ *
+ * @param demos - A connected-to-RPC Demos instance.
+ * @param subject - A `demos:0x…` claim or a raw Demos address. Defaults to the
+ * connected wallet.
+ * @returns The account's CCI record. An account with no links returns an empty
+ * `links` array — that is a valid answer, not an error.
+ * @throws If `subject` is a non-demos claim, is malformed, or is omitted with no
+ * wallet connected.
+ */
+export async function resolveCciRecord(
+    demos: Demos,
+    subject?: ClaimReference | string,
+): Promise<CciRecord> {
+    const address = await resolveAddress(demos, subject)
+
+    const response = (await identities.getIdentities(
+        demos,
+        "getIdentities",
+        address,
+    )) as { result?: number; response?: unknown; extra?: { error?: string } } | unknown
+
+    const raw = unwrap(response)
+    return {
+        primary: demosClaimRefForAddress(address),
+        address: normalizeDemosAddress(address),
+        links: cciLinksFrom(raw),
+        raw: (raw ?? {}) as AccountIdentities | Record<string, unknown>,
+    }
+}
+
+/** Accept a claim or a bare address, and fall back to the connected wallet. */
+async function resolveAddress(
+    demos: Demos,
+    subject?: ClaimReference | string,
+): Promise<string> {
+    if (!subject) {
+        if (!demos.walletConnected)
+            throw new Error(
+                "resolveCciRecord: no subject given and no wallet connected. " +
+                    "Pass a claim or address to read a specific account, or connect a wallet to read your own.",
+            )
+        return await demos.getEd25519Address()
+    }
+    if (subject.includes(":")) {
+        if (!isDemosClaim(subject as ClaimReference))
+            throw new Error(
+                `resolveCciRecord: subject must be a demos: claim or a Demos address, got "${subject}". ` +
+                    "A record is keyed by the Demos account; other schemes appear as its links.",
+            )
+        return demosAddressFromClaim(subject as ClaimReference)
+    }
+    return normalizeDemosAddress(subject)
+}
+
+/**
+ * The RPC wrapper is inconsistent across node versions — some calls hand back
+ * the identities blob directly, others wrap it in an RPCResponse. Unwrap either
+ * rather than making every caller guess which one they got.
+ */
+function unwrap(response: unknown): unknown {
+    if (!response || typeof response !== "object") return response
+    const r = response as Record<string, unknown>
+    if (!("response" in r)) return response
+    if (typeof r.result === "number" && r.result >= 400)
+        throw new Error(
+            `resolveCciRecord: node returned ${r.result}: ${
+                (r.extra as { error?: string } | undefined)?.error ?? "unknown error"
+            }`,
+        )
+    return r.response
+}

--- a/src/identity/cci/resolve.ts
+++ b/src/identity/cci/resolve.ts
@@ -88,12 +88,15 @@ async function resolveAddress(
 function unwrap(response: unknown): unknown {
     if (!response || typeof response !== "object") return response
     const r = response as Record<string, unknown>
-    if (!("response" in r)) return response
+    // Check the error BEFORE looking for `response`: an RPC error may carry no
+    // `response` key at all, and returning it verbatim would hand the caller an
+    // error object dressed up as an identities blob.
     if (typeof r.result === "number" && r.result >= 400)
         throw new Error(
             `resolveCciRecord: node returned ${r.result}: ${
                 (r.extra as { error?: string } | undefined)?.error ?? "unknown error"
             }`,
         )
+    if (!("response" in r)) return response
     return r.response
 }

--- a/src/tests/identity/cci.record.test.ts
+++ b/src/tests/identity/cci.record.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/identity/cci"
 
 const EVM = "0xAbC0000000000000000000000000000000000001"
+const EVM_CLAIM = `evm:${EVM.toLowerCase()}`
 const SOL = "So1anaAddress1111111111111111111111111111111"
 
 /** The identities blob exactly as the node's GCR models it. */
@@ -55,7 +56,7 @@ describe("cciLinksFrom — the linked identities become claims", () => {
         const links = cciLinksFrom(IDENTITIES)
         const claims = links.map((l) => l.claim).sort()
 
-        expect(claims).toEqual([`evm:${EVM}`, `solana:${SOL}`, "twitter:agent"].sort())
+        expect(claims).toEqual([EVM_CLAIM, `solana:${SOL}`, "twitter:agent"].sort())
         expect(links.find((l) => l.context === "evm")).toMatchObject({ kind: "xm" })
         expect(links.find((l) => l.context === "twitter")).toMatchObject({ kind: "web2" })
         // The original entry survives for anything the flat shape drops.
@@ -79,7 +80,7 @@ describe("cciLinksFrom — the linked identities become claims", () => {
             ud: null,
         }
         expect(cciLinksFrom(future).map((l) => l.claim).sort()).toEqual(
-            [`evm:${EVM}`, `solana:${SOL}`, "twitter:agent"].sort(),
+            [EVM_CLAIM, `solana:${SOL}`, "twitter:agent"].sort(),
         )
     })
 
@@ -98,6 +99,44 @@ describe("cciLinksFrom — the linked identities become claims", () => {
     })
 })
 
+describe("claim spelling", () => {
+    it("normalises hex addresses — the same EVM wallet is one identity", () => {
+        // The node can hand back either checksum spelling for the same wallet;
+        // a raw compare would call them two different identities.
+        const shouted = { xm: { evm: { mainnet: [{ address: EVM.toUpperCase().replace("0X", "0x") }] } } }
+        const quiet = { xm: { evm: { mainnet: [{ address: EVM.toLowerCase() }] } } }
+        expect(cciLinksFrom(shouted)[0].claim).toBe(cciLinksFrom(quiet)[0].claim)
+        expect(cciLinksFrom(shouted)[0].claim).toBe(`evm:${EVM.toLowerCase()}`)
+    })
+
+    it("leaves base58 alone — lowercasing Solana would be a different account", () => {
+        // Solana addresses are case-SENSITIVE; "normalising" one corrupts it.
+        expect(cciLinksFrom(IDENTITIES).find((l) => l.context === "solana")?.claim).toBe(
+            `solana:${SOL}`,
+        )
+    })
+})
+
+describe("TLSN-proven identities", () => {
+    it("are picked up — the node files them under web2.<platform>, not a tlsn key", () => {
+        // Review flagged these as dropped. They are not: tlsnRoutines writes to
+        // `identities.web2[context]` with context = github|discord|telegram, and
+        // web2 parsing is generic over the platform key.
+        const viaTlsn = {
+            web2: {
+                github: [
+                    { username: "octocat", userId: "583231", proof: "{}", proofHash: "0x", recvHash: "0x" },
+                ],
+                discord: [{ username: "agent#1", userId: "99" }],
+            },
+        }
+        expect(cciLinksFrom(viaTlsn).map((l) => l.claim).sort()).toEqual(
+            ["discord:agent#1", "github:octocat"].sort(),
+        )
+        expect(cciLinksFrom(viaTlsn)[0].kind).toBe("web2")
+    })
+})
+
 describe("record helpers", () => {
     const record: CciRecord = {
         primary: demosClaimRefForAddress("0x" + "a".repeat(64)),
@@ -112,7 +151,7 @@ describe("record helpers", () => {
 
     it("finds the account's claim on a given scheme", () => {
         expect(cciClaimFor(record, "twitter")).toBe("twitter:agent")
-        expect(cciClaimFor(record, "evm")).toBe(`evm:${EVM}`)
+        expect(cciClaimFor(record, "evm")).toBe(EVM_CLAIM)
         expect(cciClaimFor(record, "bitcoin")).toBeUndefined()
     })
 })

--- a/src/tests/identity/cci.record.test.ts
+++ b/src/tests/identity/cci.record.test.ts
@@ -1,0 +1,118 @@
+import type { AccountIdentities } from "@/types/gls/account"
+import {
+    cciClaimFor,
+    cciLinksFrom,
+    cciSchemes,
+    demosClaimRefForAddress,
+    type CciRecord,
+} from "@/identity/cci"
+
+const EVM = "0xAbC0000000000000000000000000000000000001"
+const SOL = "So1anaAddress1111111111111111111111111111111"
+
+/** The identities blob exactly as the node's GCR models it. */
+const IDENTITIES: AccountIdentities = {
+    xm: {
+        evm: {
+            mainnet: [
+                {
+                    address: EVM,
+                    publicKey: "0x04aa",
+                    signature: "0xsig",
+                    timestamp: 1_700_000_000,
+                    signedData: "demos-link",
+                },
+            ],
+        },
+        solana: {
+            mainnet: [
+                {
+                    address: SOL,
+                    publicKey: "sol-pub",
+                    signature: "sol-sig",
+                    timestamp: 1_700_000_001,
+                    signedData: "demos-link",
+                },
+            ],
+        },
+    },
+    pqc: {},
+    web2: {
+        twitter: [
+            {
+                proof: "https://x.com/agent/status/1",
+                userId: "42",
+                username: "agent",
+                proofHash: "0xhash",
+                timestamp: 1_700_000_002,
+            },
+        ],
+    },
+}
+
+describe("cciLinksFrom — the linked identities become claims", () => {
+    it("flattens other-chain wallets and web2 accounts into ClaimReferences", () => {
+        const links = cciLinksFrom(IDENTITIES)
+        const claims = links.map((l) => l.claim).sort()
+
+        expect(claims).toEqual([`evm:${EVM}`, `solana:${SOL}`, "twitter:agent"].sort())
+        expect(links.find((l) => l.context === "evm")).toMatchObject({ kind: "xm" })
+        expect(links.find((l) => l.context === "twitter")).toMatchObject({ kind: "web2" })
+        // The original entry survives for anything the flat shape drops.
+        expect((links.find((l) => l.context === "evm")?.raw as { signature?: string })?.signature)
+            .toBe("0xsig")
+    })
+
+    it("prefers the human handle but falls back to the stable id", () => {
+        const noHandle = { web2: { twitter: [{ userId: "42", proofHash: "0x" }] } }
+        expect(cciLinksFrom(noHandle)[0].claim).toBe("twitter:42")
+    })
+
+    it("survives identity kinds it has never heard of", () => {
+        // The node grows kinds (ud, nomis, humanpassport, ethos, tlsn) faster
+        // than this type does. Asking "who is this agent" must not blow up
+        // because an unknown one showed up.
+        const future = {
+            ...IDENTITIES,
+            nomis: { score: 800 },
+            ethos: [{ weird: true }],
+            ud: null,
+        }
+        expect(cciLinksFrom(future).map((l) => l.claim).sort()).toEqual(
+            [`evm:${EVM}`, `solana:${SOL}`, "twitter:agent"].sort(),
+        )
+    })
+
+    it("returns nothing rather than throwing on junk", () => {
+        for (const junk of [undefined, null, 42, "nope", [], { xm: "not-an-object" }]) {
+            expect(cciLinksFrom(junk)).toEqual([])
+        }
+    })
+
+    it("reads a pqc co-signer as a claim keyed by algorithm", () => {
+        const withPqc = { pqc: { falcon: { publicKey: "falcon-pub" }, mldsa: "ml-pub" } }
+        expect(cciLinksFrom(withPqc).map((l) => l.claim).sort()).toEqual(
+            ["falcon:falcon-pub", "mldsa:ml-pub"].sort(),
+        )
+        expect(cciLinksFrom(withPqc)[0].kind).toBe("pqc")
+    })
+})
+
+describe("record helpers", () => {
+    const record: CciRecord = {
+        primary: demosClaimRefForAddress("0x" + "a".repeat(64)),
+        address: "0x" + "a".repeat(64),
+        links: cciLinksFrom(IDENTITIES),
+        raw: IDENTITIES,
+    }
+
+    it("lists the schemes an account has proven", () => {
+        expect(cciSchemes(record).sort()).toEqual(["evm", "solana", "twitter"])
+    })
+
+    it("finds the account's claim on a given scheme", () => {
+        expect(cciClaimFor(record, "twitter")).toBe("twitter:agent")
+        expect(cciClaimFor(record, "evm")).toBe(`evm:${EVM}`)
+        expect(cciClaimFor(record, "bitcoin")).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Closes **DEM-773** / node#953 — the client's stated top priority.

## Why this one

> *"there is the growing issues list that has been raised whilst building out the agents that should be priority list I think as it means in the indexer we are filling in gaps manually whilst waiting for the SDK to catch up"*

**The manual gap-filling in their indexer is this ticket.** They need an agent's linked identities; the SDK never handed them over.

## It was a seam, not a missing feature

Both halves already existed and were never joined:

| | |
|---|---|
| `Identities.getIdentities()` (`src/abstraction/`) | already reads the linked Web2 / other-chain identities off the node |
| `identity/cci` — what the **entire DACS layer** consumes | exported only `ClaimReference` + primary-claim sign/verify |

So DACS could only ever see an agent as *a wallet key*. Anyone who needed "which Twitter/EVM identity is this agent?" had to reach around the SDK and reassemble the record themselves — which is exactly what the indexer is doing by hand.

## What this adds

```ts
const record = await resolveCciRecord(demos, "demos:0x…")   // or a raw address, or omit for your own
record.primary            // demos:0x…
record.links              // [{ claim: "evm:0xAbC…", kind: "xm", context: "evm", raw }, { claim: "twitter:agent", … }]
cciClaimFor(record, "twitter")   // "twitter:agent"
cciSchemes(record)               // ["evm", "solana", "twitter"]
```

Each link is a **`ClaimReference`** — the same currency the rest of DACS speaks — so a caller hands one straight to `parseClaimRef` or matches it against a counterparty's claim instead of reaching into a chain-shaped blob. `raw` keeps the node's original entry for anything the flat shape drops.

**No wallet needed to read someone else's record.** Identities are public data, and that's precisely what lets an indexer or verifier resolve a counterparty.

**`cciLinksFrom` is exported separately from the fetch**, so an indexer that already holds the blob gets claims out of it with no RPC round-trip.

## Deliberately best-effort parsing

The node grows identity kinds (`ud`, `nomis`, `humanpassport`, `ethos`, `tlsn`) faster than these types do. A consumer asking *"who is this agent"* must not blow up because a kind it has never heard of appeared — unknown shapes are skipped, junk returns no links rather than throwing, and `raw` always carries the original. There's a test pinning that.

## Scope

**DEM-731** (node-side `getDomainProof` RPC) is still open, so *domain* claims aren't verifiable node-side yet. XM/Web2 links read fine today, so this lands now rather than waiting on it.

## Tests — 7, against the real shape

Built on the actual `AccountIdentities` model (not a guess): flattening to claims, handle-vs-id fallback, **unknown future kinds**, junk input, pqc co-signers, and the record helpers. Existing `cci` suite green (23).

> ⚠️ **Toolchain note:** jest *and* tsc both hit a V8 Turboshaft JIT crash under Node 22 in this environment (`V8_Fatal` / `Trace/breakpoint trap (core dumped)`, exit 133) — it looks like a hang and it is the toolchain, not any diff. Both run green with the optimiser off, which is why the pre-commit build is skipped here:
> ```
> node --no-opt node_modules/typescript/bin/tsc --skipLibCheck --noEmit   -> 0
> node --no-opt node_modules/jest/bin/jest.js src/tests/identity/         -> 30 passed
> ```
> (`--no-opt` keeps WASM, unlike `--jitless`.)

## Next in the client's list

**DEM-772** / node#952 — x402 symbol → on-chain token id. P1: the payment guard compares `Price.asset` ("USDC") to the 402's token id, so it blocks *every* real payment — safe but unusable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving Cross-Context Identity (CCI) records for connected wallets, claim references, or account addresses.
  * Added utilities to extract linked identity claims across XM, Web2, and PQC formats.
  * Added support for listing available claim schemes and retrieving scheme-specific claims, with malformed/unknown inputs safely ignored.
* **Documentation**
  * Expanded public CCI module documentation and added additional public exports for CCI types and helpers.
* **Tests**
  * Added comprehensive unit tests covering CCI link extraction, scheme derivation, and record helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->